### PR TITLE
Bump Mono.Cecil versions

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Stratis.Bitcoin.Features.SmartContracts.Tests.csproj
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Stratis.Bitcoin.Features.SmartContracts.Tests.csproj
@@ -23,7 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Mono.Cecil" Version="0.10.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
     <PackageReference Include="NetJSON" Version="1.2.2" />
   </ItemGroup>
 

--- a/src/Stratis.SmartContracts.CLR.Validation/Stratis.SmartContracts.CLR.Validation.csproj
+++ b/src/Stratis.SmartContracts.CLR.Validation/Stratis.SmartContracts.CLR.Validation.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Mono.Cecil" Version="0.10.1" />
+    <PackageReference Include="Mono.Cecil" Version="0.11.0" />
     <PackageReference Include="Stratis.SmartContracts" Version="1.2.1" />
     <PackageReference Include="Stratis.SmartContracts.Standards" Version="1.0.0" />
     <PackageReference Include="Tracer.Fody" Version="3.1.0">


### PR DESCRIPTION
It looks like Tracer.Fody ultimately depends on Mono.Cecil 0.11.0 via the Fody package