### PR TITLE
Fix OP_RETURN value in transaction building

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -94,6 +94,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             throw new WalletException($"Could not build the transaction. Details: {errorsMessage}");
         }
 
+        // TODO: This only seems to be used in a test, consider removing it?
         /// <inheritdoc />
         public void FundTransaction(TransactionBuildContext context, Transaction transaction)
         {
@@ -307,7 +308,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             // Get total spendable balance in the account.
             long balance = context.UnspentOutputs.Sum(t => t.Transaction.Amount);
-            long totalToSend = context.Recipients.Sum(s => s.Amount);
+            long totalToSend = context.Recipients.Sum(s => s.Amount) + (context.OpReturnAmount ?? Money.Zero);
             if (balance < totalToSend)
                 throw new WalletException("Not enough funds.");
 


### PR DESCRIPTION
https://dev.azure.com/Stratisplatformuk/STRAX/_boards/board/t/STRAX%20Team/Stories/?workitem=5144

Interesting bug which was never noticed before, presumably because OP_RETURN outputs typically have very small values.

Needs to go into SBFN too.