### PR TITLE
Allow only an OP_RETURN transaction output to be built

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -344,7 +344,6 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// recipient will receive in STRAT (or a sidechain coin). If the transaction was realized,
         /// both the values would be used to create the UTXOs for the transaction recipients.
         /// </summary> 
-        [Required(ErrorMessage = "A list of recipients is required.")]
         [MinLength(1)]
         public List<RecipientModel> Recipients { get; set; }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
@@ -638,6 +638,14 @@ namespace Stratis.Bitcoin.Features.Wallet.Services
         {
             return await Task.Run(() =>
             {
+                if (request.Recipients == null)
+                {
+                    request.Recipients = new List<RecipientModel>();
+
+                    if (request.OpReturnAmount == null || request.OpReturnAmount == Money.Zero)
+                        throw new FeatureException(HttpStatusCode.BadRequest, "No recipients.", "Either one or both of recipients and opReturnAmount must be specified.");
+                }
+
                 var recipients = request.Recipients.Select(recipientModel => new Recipient
                 {
                     ScriptPubKey = BitcoinAddress.Create(recipientModel.DestinationAddress, this.network).ScriptPubKey,

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletTransactionHandler.cs
@@ -389,7 +389,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 throw new WalletException("No amount specified.");
 
             if (context.Recipients.Any(a => a.SubtractFeeFromAmount))
-                throw new NotImplementedException("Substracting the fee from the recipient is not supported yet.");
+                throw new NotImplementedException("Subtracting the fee from the recipient is not supported yet.");
 
             foreach (Recipient recipient in context.Recipients)
                 context.TransactionBuilder.Send(recipient.ScriptPubKey, recipient.Amount);


### PR DESCRIPTION
The wallet API currently requires at least one recipient to be defined. This relaxes that requirement as long as the OP_RETURN amount is set