### PR TITLE
Fix GetDestinations for TX_SEGWIT

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/AddressIdentifier.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/AddressIdentifier.cs
@@ -10,12 +10,11 @@
 
         public int? AddressIndex { get; set; }
 
+        /// <summary>The ScriptPubKey of a TxDestination (PKH). TxOut ScriptPubKey values are mapped to one or more of these destinations via ScriptDestinationReader.</summary>
+        /// <remarks>Don't use this to store scripts derived from templates other than P2PKH.</remarks>
         public string ScriptPubKey { get; set; }
 
-        /// <summary>P2WPKH scriptPubKey</summary>
-        public string Bech32ScriptPubKey { get; set; }
-
-        // TODO: Document how this is distinct from ScriptPubKey. Is it the P2PK scriptPubKey as opposed to ScriptPubKey storing the P2PKH scriptPubKey?
+        /// <summary>Always a P2PK script.</summary>
         public string PubKeyScript;
 
         public override bool Equals(object obj)

--- a/src/Stratis.Features.SQLiteWalletRepository/Commands/ProcessBlockCommands.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Commands/ProcessBlockCommands.cs
@@ -90,7 +90,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Commands
                 ,      NULL SpendTxTotalOut
                 FROM   temp.TempOutput T
                 JOIN   HDAddress A
-                ON     (A.ScriptPubKey = T.ScriptPubKey) OR (A.Bech32ScriptPubKey = T.ScriptPubKey)
+                ON     A.ScriptPubKey = T.ScriptPubKey
                 AND    A.WalletId IN (
                        SELECT WalletId
                        FROM   HDWallet

--- a/src/Stratis.Features.SQLiteWalletRepository/DBConnection.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/DBConnection.cs
@@ -376,6 +376,11 @@ namespace Stratis.Features.SQLiteWalletRepository
                     throw new Exception($"Table creation failed for database at { this.Repository.DBPath }: {err.Message}");
                 }
             }
+            else
+            {
+                if (typeof(T) == typeof(HDAddress))
+                    HDAddress.MigrateTable(this);
+            }
         }
 
         internal HDWallet GetWalletByName(string walletName)

--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -51,8 +51,9 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                         yield return PayToScriptHashTemplate.Instance.ExtractScriptPubKeyParameters(redeemScript).ScriptPubKey;
                         break;
                     case TxOutType.TX_SEGWIT:
-                        // TODO: Do we need to make the distinction between P2WPKH and P2WSH?
-                        yield return PayToWitTemplate.Instance.ExtractScriptPubKeyParameters(this.network, redeemScript).ScriptPubKey;
+                        TxDestination txDestination = PayToWitTemplate.Instance.ExtractScriptPubKeyParameters(this.network, redeemScript);
+                        if (txDestination != null)
+                            yield return new KeyId(txDestination.ToBytes()).ScriptPubKey;
                         break;
                     default:
                         if (this.scriptAddressReader is ScriptDestinationReader scriptDestinationReader)
@@ -148,9 +149,6 @@ namespace Stratis.Features.SQLiteWalletRepository.External
 
                                         // Add the new address to our addresses of interest.
                                         addressesOfInterest.AddTentative(Script.FromHex(newAddress.ScriptPubKey), newAddress);
-
-                                        // And the P2WPKH.
-                                        addressesOfInterest.AddTentative(Script.FromHex(newAddress.Bech32ScriptPubKey), newAddress);
                                     }
                                 }
                             }

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -537,7 +537,6 @@ namespace Stratis.Features.SQLiteWalletRepository
                 AddressIndex = addressIndex,
                 PubKey = pubKeyScript?.ToHex(),
                 ScriptPubKey = scriptPubKey?.ToHex(),
-                Bech32ScriptPubKey = bech32ScriptPubKey?.ToHex(),
                 Address = scriptPubKey?.GetDestinationAddress(this.Network).ToString() ?? "",
                 Bech32Address = bech32ScriptPubKey?.GetDestinationAddress(this.Network).ToString() ?? ""
             };
@@ -624,7 +623,8 @@ namespace Stratis.Features.SQLiteWalletRepository
 
         private HDAddress CreateAddress(AddressIdentifier addressId)
         {
-            Script witScriptPubKey = Script.FromHex(addressId.Bech32ScriptPubKey);
+            var pubKey = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(Script.FromHex(addressId.PubKeyScript));
+            Script witScriptPubKey = PayToWitPubKeyHashTemplate.Instance.GenerateScriptPubKey(pubKey);
 
             return new HDAddress()
             {
@@ -635,7 +635,6 @@ namespace Stratis.Features.SQLiteWalletRepository
                 PubKey = addressId.PubKeyScript,
                 ScriptPubKey = addressId.ScriptPubKey,
                 Address = Script.FromHex(addressId.ScriptPubKey).GetDestinationAddress(this.Network).ToString(),
-                Bech32ScriptPubKey = addressId.Bech32ScriptPubKey,
                 Bech32Address = witScriptPubKey.GetDestinationAddress(this.Network).ToString()
             };
         }
@@ -1219,8 +1218,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                     PubKey = pubKey.ScriptPubKey.ToHex(),
                     ScriptPubKey = scriptPubKey.ToHex(),
                     Address = scriptPubKey.GetDestinationAddress(this.Network).ToString(),
-                    Bech32Address = witScriptPubKey.GetDestinationAddress(this.Network).ToString(),
-                    Bech32ScriptPubKey = witScriptPubKey.ToHex()
+                    Bech32Address = witScriptPubKey.GetDestinationAddress(this.Network).ToString()
                 }, this.Network);
 
                 hdAddress.AddressCollection = (hdAddress.AddressType == 0) ? hdAccount.ExternalAddresses : hdAccount.InternalAddresses;

--- a/src/Stratis.Features.SQLiteWalletRepository/TopUpTracker.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/TopUpTracker.cs
@@ -80,7 +80,6 @@ namespace Stratis.Features.SQLiteWalletRepository
                 AddressType = this.AddressType,
                 AddressIndex = addressIndex,
                 ScriptPubKey = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(pubKey).ToHex(),
-                Bech32ScriptPubKey = PayToWitPubKeyHashTemplate.Instance.GenerateScriptPubKey(pubKey).ToHex(),
                 PubKeyScript = pubKey.ScriptPubKey.ToHex()
             };
         }

--- a/src/Stratis.Features.SQLiteWalletRepository/WalletAddressLookup.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/WalletAddressLookup.cs
@@ -84,9 +84,6 @@ namespace Stratis.Features.SQLiteWalletRepository
             foreach (HDAddress address in addresses)
             {
                 this.Add(Script.FromHex(address.ScriptPubKey));
-
-                // We need to add the P2WPKH scriptPubKey as an address of interest too
-                this.Add(Script.FromHex(address.Bech32ScriptPubKey));
             }
         }
 
@@ -107,7 +104,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                         ,       AddressIndex
                         ,       ScriptPubKey
                         FROM    HDAddress
-                        WHERE   (ScriptPubKey = {strHex} OR Bech32ScriptPubKey = {strHex}) {
+                        WHERE   ScriptPubKey = {strHex} {
                     // Restrict to wallet if provided.
                     // "BETWEEN" boosts performance from half a seconds to 2ms.
                     ((this.walletId != null) ? $@"


### PR DESCRIPTION
Fixes `TransactionsToListsBase.GetDestinations`:
```
case TxOutType.TX_SEGWIT:
    // TODO: Do we need to make the distinction between P2WPKH and P2WSH?
    yield return PayToWitTemplate.Instance.ExtractScriptPubKeyParameters(this.network, redeemScript).ScriptPubKey;
    break;
```
The derivation is **incorrect** (does not provide the intended value). It should be derived as follows:
```
case TxOutType.TX_SEGWIT:
    TxDestination txDestination = PayToWitTemplate.Instance.ExtractScriptPubKeyParameters(this.network, redeemScript);
    if (txDestination != null)
        yield return new KeyId(txDestination.ToBytes()).ScriptPubKey;
    break;
```

This effectively strips the segregated witness version byte from the destination thus allowing successful extraction of the key id (pkh) and associated `ScriptPubKey` value. 

In summary we observe that:

`txDestination.ScriptPubKey != new KeyId(txDestination.ToBytes).ScriptPubKey`

 and that, by design, we need the latter value instead:

```
public class AddressIdentifier {
...
        /// <summary>The ScriptPubKey of a KeyId (PKH). TxOut's ScriptPubKey value is mapped to 
        /// one or more of these destinations via ScriptDestinationReader.</summary>
        public string ScriptPubKey { get; set; }
...
```

Once this is fixed the database fields `Bech32ScriptPubKey`and `ScriptPubKey` always contain identical values and hence the new `Bech32ScriptPubKey` field becomes redundant. It is consequently removed. The `Bech32Address` is retained as it provides a user-friendly experience, along with `Address` when viewing the wallet database (although _not_ playing a role in the SQL logic). Updating the ReadyData is out-of-scope for this PR but it does remove the redundant field from wallets if present (`HDAddress.MigrateTable`).