### PR TITLE
Don't allow POW mining outside of POW era

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/PowMining.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PowMining.cs
@@ -238,7 +238,6 @@ namespace Stratis.Bitcoin.Features.Miner
         /// </summary>
         private bool MineBlock(MineBlockContext context)
         {
-            //context.BlockTemplate.Block.Header.Nonce = InnerLoopCount;
             if (this.network.Consensus.LastPOWBlock != 0 && context.ChainTip.Height > this.network.Consensus.LastPOWBlock)
             {
                 context.BlockTemplate.Block.Header.Nonce = InnerLoopCount;

--- a/src/Stratis.Bitcoin.Features.Miner/PowMining.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/PowMining.cs
@@ -239,7 +239,7 @@ namespace Stratis.Bitcoin.Features.Miner
         private bool MineBlock(MineBlockContext context)
         {
             context.BlockTemplate.Block.Header.Nonce = InnerLoopCount;
-            if (context.ChainTip.Height > this.network.Consensus.LastPOWBlock)
+            if (this.network.Consensus.LastPOWBlock != 0 && context.ChainTip.Height > this.network.Consensus.LastPOWBlock)
                 return false;
 
             context.ExtraNonce = this.IncrementExtraNonce(context.BlockTemplate.Block, context.ChainTip, context.ExtraNonce);


### PR DESCRIPTION
Avoids the following error:

![image](https://user-images.githubusercontent.com/29645989/94237154-bf970200-ff51-11ea-9050-7fb2a649808c.png)

![image](https://user-images.githubusercontent.com/29645989/94239644-75b01b00-ff55-11ea-9f0a-b3aafac34ada.png)

In addition mining is changed slightly to utilize all processors.