### PR TITLE
AddressIndexer can be a lot faster..

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -27,14 +27,12 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
     public class TestAddressIndexer : AddressIndexer
     {
         private readonly IConsensusManager consensusManager;
-        private readonly ChainIndexer chainIndexer;
 
         public TestAddressIndexer(StoreSettings storeSettings, DataFolder dataFolder, ILoggerFactory loggerFactory, Network network, INodeStats nodeStats,
             IConsensusManager consensusManager, IAsyncProvider asyncProvider, ChainIndexer chainIndexer, IDateTimeProvider dateTimeProvider) 
             : base(storeSettings, dataFolder, loggerFactory, network, nodeStats, consensusManager, asyncProvider, chainIndexer, dateTimeProvider, null)
         {
             this.consensusManager = consensusManager;
-            this.chainIndexer = chainIndexer;
         }
 
         public override IBatchedBlockProvider CreateBatchedBlockProvider(IBlockStore blockStore)

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -156,7 +156,13 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
             this.compactionTriggerDistance = maxReorgLength * 2 + SyncBuffer + 1000;
 
-            this.batchedBlockProvider = new BatchedBlockProvider(chainIndexer, blockStoreQueue);
+            this.batchedBlockProvider = this.CreateBatchedBlockProvider(blockStoreQueue);
+        }
+
+        /// <summary>Provides a place for tests to hook in.</summary>
+        public virtual IBatchedBlockProvider CreateBatchedBlockProvider(IBlockStore blockStore)
+        {
+            return new BatchedBlockProvider(this.chainIndexer, blockStore);
         }
 
         /// <summary>Returns maxReorg of <see cref="FallBackMaxReorg"/> in case maxReorg is <c>0</c>.</summary>

--- a/src/Stratis.Bitcoin/Utilities/BatchedBlockProvider.cs
+++ b/src/Stratis.Bitcoin/Utilities/BatchedBlockProvider.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using NBitcoin;
+using Stratis.Bitcoin.Interfaces;
+
+namespace Stratis.Bitcoin.Utilities
+{
+    public interface IBatchedBlockProvider
+    {
+        IEnumerable<(ChainedHeader, Block)> BatchBlocksFrom(int startHeight, CancellationTokenSource cancellationToken);
+    }
+
+    public class BatchedBlockProvider : IBatchedBlockProvider
+    {
+        private readonly ChainIndexer chainIndexer;
+        private readonly IBlockStore blockStore;
+
+        public BatchedBlockProvider(ChainIndexer chainIndexer, IBlockStore blockStore)
+        {
+            this.chainIndexer = chainIndexer;
+            this.blockStore = blockStore;
+        }
+
+        public IEnumerable<(ChainedHeader, Block)> BatchBlocksFrom(int startHeight, CancellationTokenSource cancellationToken)
+        {
+            for (int height = startHeight; !cancellationToken.IsCancellationRequested; )
+            {
+                var hashes = new List<uint256>();
+                for (int i = 0; i < 100; i++)
+                {
+                    ChainedHeader header = this.chainIndexer.GetHeader(height + i);
+                    if (header == null)
+                        break;
+
+                    hashes.Add(header.HashBlock);
+                }
+
+                if (hashes.Count == 0)
+                    yield break;
+
+                List<Block> blocks = this.blockStore.GetBlocks(hashes);
+
+                for (int i = 0; i < blocks.Count && !cancellationToken.IsCancellationRequested; height++, i++)
+                {
+                    ChainedHeader header = this.chainIndexer.GetHeader(height);
+                    yield return ((header, blocks[i]));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR updates the AddressIndexer to utilize batched block reads: 

`List<Block> blocks = this.blockStore.GetBlocks(hashes);`.

More extensive changes could be made in the future that may include in-memory indexes that can be resurrected from disk:
1) ScriptPubKey:BlockHeight:RemainingAmount (SortedList)(Memory)(Remove if RemainingAmount = 0)
2) OutTxId:OutIndex => ScriptPubKey:BlockHeight:OutputAmount (Dictionary)(Memory)(Remove if spent)
3) BlockHeight:ScriptPubKey:OutTxId:OutIndex => OutputAmount:SpendHeight (Disk + Cache)(Remove if spent and past MaxReorg)

The on-disk storage strategy would include adding the new data (in batches) at the end of the table (after in-memory caching).