### PR TITLE
Ensure normal balances can't be affected by ColdStaking scripts

### DIFF
--- a/src/Stratis.Bitcoin.Features.ColdStaking.Tests/ColdStakingManagerTest.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking.Tests/ColdStakingManagerTest.cs
@@ -173,7 +173,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Tests
             Money balance = walletManager.GetSpendableTransactionsInAccount(new WalletAccountReference(coldWallet.Name, coldWalletAccount.Name), 0).Sum(x => x.Transaction.Amount);
             var coldStakeAddress = coldWallet.GetAccounts(Wallet.Wallet.AllAccounts).ElementAt(0).ExternalAddresses.ElementAt(0);
             Transaction withdrawalTransaction = this.CreateColdStakingWithdrawalTransaction(coldWallet, "password", coldStakeAddress,
-                withdrawalPubKey, ColdStakingScriptTemplate.Instance.GenerateScriptPubKey(destinationColdPubKey.Hash, destinationHotPubKey.Hash),
+                withdrawalPubKey, ColdStakingScriptTemplate.Instance.GenerateScriptPubKey(destinationHotPubKey.Hash, destinationColdPubKey.Hash),
                 new Money(750), new Money(263));
 
             // Process the transaction.

--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingScriptTemplate.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingScriptTemplate.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using NBitcoin;
+using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Utilities;
 using static NBitcoin.OpcodeType;
 
@@ -186,8 +187,8 @@ namespace Stratis.Bitcoin.Features.ColdStaking
 
             Guard.Assert(!needMoreCheck);
 
-            hotPubKeyHash = new KeyId(scriptPubKey.ToBytes(true).SafeSubarray(6, 20));
-            coldPubKeyHash = new KeyId(scriptPubKey.ToBytes(true).SafeSubarray(28, 20));
+            hotPubKeyHash = new AccountRestrictedKeyId(scriptPubKey.ToBytes(true).SafeSubarray(6, 20), ColdStakingManager.HotWalletAccountIndex);
+            coldPubKeyHash = new AccountRestrictedKeyId(scriptPubKey.ToBytes(true).SafeSubarray(28, 20), ColdStakingManager.ColdWalletAccountIndex);
 
             return true;
         }

--- a/src/Stratis.Bitcoin.Features.Wallet/AccountRestrictedKeyId.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/AccountRestrictedKeyId.cs
@@ -2,7 +2,12 @@
 
 namespace Stratis.Bitcoin.Features.Wallet
 {
-    public class AccountRestrictedKeyId : KeyId
+    public interface IAccountRestrictedKeyId
+    {
+        int AccountId { get; }
+    }
+
+    public class AccountRestrictedKeyId : KeyId, IAccountRestrictedKeyId
     {
         public int AccountId { get; private set; }
 

--- a/src/Stratis.Bitcoin.Features.Wallet/AccountRestrictedKeyId.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/AccountRestrictedKeyId.cs
@@ -1,0 +1,17 @@
+﻿using NBitcoin;
+
+namespace Stratis.Bitcoin.Features.Wallet
+{
+    public class AccountRestrictedKeyId : KeyId
+    {
+        public int AccountId { get; private set; }
+
+        public AccountRestrictedKeyId(byte[] keyBytes, int accountId) : base(keyBytes)
+        {
+            this.AccountId = accountId;
+        }
+        public AccountRestrictedKeyId(KeyId keyId, int accountId) : this(keyId.ToBytes(), accountId)
+        {
+        }
+    }
+}

--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -143,8 +143,18 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                             // This feature, by design, is agnostic of the type of template being processed.
                             // This type of check is good to have for cold staking though but is catered for in broader terms.
                             // I.e. don't allow any funny business with keys being used with accounts they were not intended for.
-                            if (destination is IAccountRestrictedKeyId accountRestrictedKey && accountRestrictedKey.AccountId != address.AccountIndex)
-                                continue;
+                            if (destination is IAccountRestrictedKeyId accountRestrictedKey)
+                            {
+                                if (accountRestrictedKey.AccountId != address.AccountIndex)
+                                    continue;
+                            }
+                            else
+                            {
+                                // This tests the converse. 
+                                // Don't allow special-purpose accounts (e.g. coldstaking) to be used like normal accounts.
+                                if (address.AccountIndex >= Wallet.SpecialPurposeAccountIndexesStart)
+                                    continue;
+                            }
 
                             // Check if top-up is required.
                             // Get the top-up tracker that applies to this account and address type.

--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -138,30 +138,26 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                         bool containsAddress = addressesOfInterest.Contains(pubKeyScript, out AddressIdentifier address);
 
                         // Paying to one of our addresses?
-                        if (containsAddress)
+                        if (containsAddress && address != null)
                         {
+                            // This feature, by design, is agnostic of the type of template being processed.
+                            // This type of check is good to have for cold staking though but is catered for in broader terms.
+                            // I.e. don't allow any funny business with keys being used with accounts they were not intended for.
+                            if (destination is AccountRestrictedKeyId accountRestrictedKey && accountRestrictedKey.AccountId != address.AccountIndex)
+                                continue;
+
                             // Check if top-up is required.
-                            if (address != null)
+                            // Get the top-up tracker that applies to this account and address type.
+                            ITopUpTracker tracker = this.GetTopUpTracker(address);
+                            if (!tracker.IsWatchOnlyAccount)
                             {
-
-                                // This feature, by design, is agnostic of the type of template being processed.
-                                // This type of check is good to have for cold staking though but is catered for in broader terms.
-                                // I.e. don't allow any funny business with keys being used with accounts they were not intended for.
-                                if (destination is AccountRestrictedKeyId accountRestrictedKey && accountRestrictedKey.AccountId != address.AccountIndex)
-                                    continue;
-
-                                // Get the top-up tracker that applies to this account and address type.
-                                ITopUpTracker tracker = this.GetTopUpTracker(address);
-                                if (!tracker.IsWatchOnlyAccount)
+                                // If an address inside the address buffer is being used then top-up the buffer.
+                                while (address.AddressIndex >= tracker.NextAddressIndex)
                                 {
-                                    // If an address inside the address buffer is being used then top-up the buffer.
-                                    while (address.AddressIndex >= tracker.NextAddressIndex)
-                                    {
-                                        AddressIdentifier newAddress = tracker.CreateAddress();
+                                    AddressIdentifier newAddress = tracker.CreateAddress();
 
-                                        // Add the new address to our addresses of interest.
-                                        addressesOfInterest.AddTentative(Script.FromHex(newAddress.ScriptPubKey), newAddress);
-                                    }
+                                    // Add the new address to our addresses of interest.
+                                    addressesOfInterest.AddTentative(Script.FromHex(newAddress.ScriptPubKey), newAddress);
                                 }
                             }
 

--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -143,7 +143,7 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                             // This feature, by design, is agnostic of the type of template being processed.
                             // This type of check is good to have for cold staking though but is catered for in broader terms.
                             // I.e. don't allow any funny business with keys being used with accounts they were not intended for.
-                            if (destination is AccountRestrictedKeyId accountRestrictedKey && accountRestrictedKey.AccountId != address.AccountIndex)
+                            if (destination is IAccountRestrictedKeyId accountRestrictedKey && accountRestrictedKey.AccountId != address.AccountIndex)
                                 continue;
 
                             // Check if top-up is required.

--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -34,7 +34,7 @@ namespace Stratis.Features.SQLiteWalletRepository.External
             this.dateTimeProvider = dateTimeProvider;
         }
 
-        internal IEnumerable<Script> GetDestinations(Script redeemScript)
+        internal IEnumerable<KeyId> GetDestinations(Script redeemScript)
         {
             ScriptTemplate scriptTemplate = this.network.StandardScriptsRegistry.GetTemplateFromScriptPubKey(redeemScript);
 
@@ -44,25 +44,25 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                 switch (scriptTemplate.Type)
                 {
                     case TxOutType.TX_PUBKEYHASH:
-                        yield return redeemScript;
+                        yield return PayToPubkeyHashTemplate.Instance.ExtractScriptPubKeyParameters(redeemScript);
                         break;
                     case TxOutType.TX_PUBKEY:
-                        yield return PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(redeemScript).Hash.ScriptPubKey;
+                        yield return PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(redeemScript).Hash;
                         break;
                     case TxOutType.TX_SCRIPTHASH:
-                        yield return PayToScriptHashTemplate.Instance.ExtractScriptPubKeyParameters(redeemScript).ScriptPubKey;
+                        yield return (KeyId)(TxDestination)PayToScriptHashTemplate.Instance.ExtractScriptPubKeyParameters(redeemScript);
                         break;
                     case TxOutType.TX_SEGWIT:
                         TxDestination txDestination = PayToWitTemplate.Instance.ExtractScriptPubKeyParameters(this.network, redeemScript);
                         if (txDestination != null)
-                            yield return new KeyId(txDestination.ToBytes()).ScriptPubKey;
+                            yield return new KeyId(txDestination.ToBytes());
                         break;
                     default:
                         if (this.scriptAddressReader is ScriptDestinationReader scriptDestinationReader)
                         {
                             foreach (TxDestination destination in scriptDestinationReader.GetDestinationFromScriptPubKey(this.network, redeemScript))
                             {
-                                yield return destination.ScriptPubKey;
+                                yield return (KeyId)destination;
                             }
                         }
                         else
@@ -70,7 +70,7 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                             string address = this.scriptAddressReader.GetAddressFromScriptPubKey(this.network, redeemScript);
                             TxDestination destination = ScriptDestinationReader.GetDestinationForAddress(address, this.network);
                             if (destination != null)
-                                yield return destination.ScriptPubKey;
+                                yield return (KeyId)destination;
                         }
 
                         break;
@@ -124,7 +124,7 @@ namespace Stratis.Features.SQLiteWalletRepository.External
 
                     var destinations = this.GetDestinations(txOut.ScriptPubKey);
 
-                    bool isChange = destinations.Any(d => addressesOfInterest.Contains(d, out AddressIdentifier address2) && address2.AddressType == 1);
+                    bool isChange = destinations.Any(d => addressesOfInterest.Contains(d.ScriptPubKey, out AddressIdentifier address2) && address2.AddressType == 1);
 
                     if (addSpendTx)
                     {
@@ -132,16 +132,24 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                         this.RecordReceipt(block, null, txOut, tx.IsCoinBase | tx.IsCoinStake, blockTime ?? currentTime, txId, i, isChange);
                     }
 
-                    foreach (Script pubKeyScript in destinations)
+                    foreach (KeyId keyId in destinations)
                     {
+                        Script pubKeyScript = keyId.ScriptPubKey;
                         bool containsAddress = addressesOfInterest.Contains(pubKeyScript, out AddressIdentifier address);
 
                         // Paying to one of our addresses?
                         if (containsAddress)
                         {
                             // Check if top-up is required.
-                            if (containsAddress && address != null)
+                            if (address != null)
                             {
+
+                                // This feature, by design, is agnostic of the type of template being processed.
+                                // This type of check is good to have for cold staking though but is catered for in broader terms.
+                                // I.e. don't allow any funny business with keys being used with accounts they were not intended for.
+                                if (keyId is AccountRestrictedKeyId accountRestrictedKey && accountRestrictedKey.AccountId != address.AccountIndex)
+                                    continue;
+
                                 // Get the top-up tracker that applies to this account and address type.
                                 ITopUpTracker tracker = this.GetTopUpTracker(address);
                                 if (!tracker.IsWatchOnlyAccount)
@@ -157,17 +165,12 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                                 }
                             }
 
-                            // TODO: This is a bit of a conundrum - by recording a coldstaking output as having a value, we cause all the effects that the filtration at the higher
-                            // layers is intended to prevent. So it would be a lot simpler if we could just set the output value to 0 here if it is a coldstaking script. But that
-                            // will most likely have unintended consequences on areas of the code that do expect the outputs to have a value, such as staking.
-
                             // Record outputs received by our wallets.
-                            this.RecordReceipt(block, pubKeyScript, txOut, tx.IsCoinBase | tx.IsCoinStake, blockTime ?? currentTime, txId, i, containsAddress && address.AddressType == 1);
+                            this.RecordReceipt(block, pubKeyScript, txOut, tx.IsCoinBase | tx.IsCoinStake, blockTime ?? currentTime, txId, i, address.AddressType == 1);
 
                             additions = true;
 
-                            if (containsAddress)
-                                transactionsOfInterest.AddTentative(new OutPoint(txId, i), address);
+                            transactionsOfInterest.AddTentative(new OutPoint(txId, i), address);
                         }
                     }
                 }
@@ -208,7 +211,7 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                         new HashHeightPair(transactionData.BlockHash ?? 0, (int)transactionData.BlockHeight);
 
                     Script scriptPubKey = transactionData.ScriptPubKey;
-                    foreach (Script pubKeyScript in this.GetDestinations(scriptPubKey))
+                    foreach (Script pubKeyScript in this.GetDestinations(scriptPubKey).Select(d => d.ScriptPubKey))
                     {
                         bool containsAddress = addressesOfInterest.Contains(pubKeyScript, out AddressIdentifier targetAddress);
 


### PR DESCRIPTION
**The `KeyId`'s derived from the cold staking script are tagged with their expected accounts:** 

```
        public bool ExtractScriptPubKeyParameters(Script scriptPubKey, out KeyId hotPubKeyHash, out KeyId coldPubKeyHash)
        {
            if (!this.FastCheckScriptPubKey(scriptPubKey, out bool needMoreCheck))
            {
                hotPubKeyHash = null;
                coldPubKeyHash = null;

                return false;
            }

            Guard.Assert(!needMoreCheck);

            hotPubKeyHash = new AccountRestrictedKeyId(scriptPubKey.ToBytes(true).SafeSubarray(6, 20), ColdStakingManager.HotWalletAccountIndex);
            coldPubKeyHash = new AccountRestrictedKeyId(scriptPubKey.ToBytes(true).SafeSubarray(28, 20), ColdStakingManager.ColdWalletAccountIndex);

            return true;
        }
```

This way the `KeyId`s will not be matched with other/normal accounts and can't maliciously/inadvertently affect those balances. Although these checks are performed to a certain degree during the construction of the cold staking script (at least on one of the pub key hashes) we still need this fix to ensure an attacker could not manually create a script that includes normal address pub key hashes.

```
                    foreach (TxDestination destination in destinations)
                    {
                        var pubKeyScript = destination.ScriptPubKey;
                        bool containsAddress = addressesOfInterest.Contains(pubKeyScript, out AddressIdentifier address);

                        // Paying to one of our addresses?
                        if (containsAddress && address != null)
                        {
                            // This feature, by design, is agnostic of the type of template being processed.
                            // This type of check is good to have for cold staking though but is catered for in broader terms.
                            // I.e. don't allow any funny business with keys being used with accounts they were not intended for.
                            if (destination is IAccountRestrictedKeyId accountRestrictedKey)
                            {
                                if (accountRestrictedKey.AccountId != address.AccountIndex)
                                    continue;
                            }
                            else
                            {
                                // This tests the converse. 
                                // Don't allow special-purpose accounts (e.g. coldstaking) to be used like normal accounts.
                                if (address.AccountIndex >= Wallet.SpecialPurposeAccountIndexesStart)
                                    continue;
                            }
...
```

This change helped identify a problem in the `ProcessTransactionWithValidColdStakingSetupLoadsTransactionsIntoWall` test case. 

A fix for the test case is included.