### PR TITLE
Revert non-essential SQLiteWalletRepository updates

### DIFF
--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepositoryExt.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepositoryExt.cs
@@ -39,7 +39,7 @@ namespace Stratis.Features.SQLiteWalletRepository
             return res;
         }
 
-        internal static HdAddress ToHdAddress(this SQLiteWalletRepository repo, HDAddress address, Network network)
+        internal static HdAddress ToHdAddress(this SQLiteWalletRepository repo, HDAddress address)
         {
             Script pubKeyScript = (address.PubKey == null) ? null : new Script(Encoders.Hex.DecodeData(address.PubKey)); // P2PK
             Script scriptPubKey = new Script(Encoders.Hex.DecodeData(address.ScriptPubKey));
@@ -77,7 +77,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                                   && (bytes[48] == (byte)0x68) // OP_ENDIF
                                   && (bytes[49] == (byte)0x88) // OP_EQUALVERIFY
                                   && (bytes[50] == (byte)0xac)); // OP_CHECKSIG
-            
+
             // TODO: Need to make a central determination of whether a UTXO is Segwit or not (i.e. it pays to a P2WPKH scriptPubKey)
 
             var res = new TransactionData()

--- a/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
@@ -52,7 +52,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 RedeemScript = txOut.ScriptPubKey.ToHex(),
 
                 // By using the script that is associated with the targetAddress we hope to extract the same (even Bech32).
-                Address = txOut.ScriptPubKey.GetDestinationAddress(this.conn.Repository.Network).ToString() ?? "",
+                Address = txOut.ScriptPubKey.GetDestinationAddress(this.conn.Repository.Network)?.ToString() ?? "",
                 OutputBlockHeight = block?.Height,
                 OutputBlockHash = block?.Hash.ToString(),
                 OutputTxIsCoinBase = isCoinBase ? 1 : 0,

--- a/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/TransactionsToLists.cs
@@ -51,7 +51,8 @@ namespace Stratis.Features.SQLiteWalletRepository
                 // The ScriptPubKey from the txOut.
                 RedeemScript = txOut.ScriptPubKey.ToHex(),
 
-                Address = pubKeyScript?.GetDestinationAddress(this.conn.Repository.Network).ToString() ?? "",
+                // By using the script that is associated with the targetAddress we hope to extract the same (even Bech32).
+                Address = txOut.ScriptPubKey.GetDestinationAddress(this.conn.Repository.Network).ToString() ?? "",
                 OutputBlockHeight = block?.Height,
                 OutputBlockHash = block?.Hash.ToString(),
                 OutputTxIsCoinBase = isCoinBase ? 1 : 0,


### PR DESCRIPTION
This PR reverts a few non-essential changes to the SQLiteWalletRepository.

If this increases the stability of the wallet balances we can keep this PR. Otherwise we will close this.