### PR TITLE
Populate transactionsOfInterest when rewinding

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -277,7 +277,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="chainedHeader">The blocks chain of headers.</param>
         void ProcessBlock(Block block, ChainedHeader chainedHeader = null);
 
-        void ProcessBlocks(Func<int, IEnumerable<(ChainedHeader, Block)>> blockProvider);
+        void ProcessBlocks(Func<ChainedHeader, IEnumerable<(ChainedHeader, Block)>> blockProvider);
 
         /// <summary>
         /// Processes a transaction received from the network.

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletRepository.cs
@@ -208,7 +208,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="lastBlockSynced">The last block synced to set.</param>
         /// <returns>A flag indicating success and a list of transactions removed from the wallet.</returns>
         /// <remarks>The value of lastBlockSynced must match a block that was conceivably processed by the wallet (or be null).</remarks>
-        (bool, IEnumerable<(uint256, DateTimeOffset)>) RewindWallet(string walletName, ChainedHeader lastBlockSynced);
+        (bool RewindExecuted, IEnumerable<(uint256, DateTimeOffset)> RemovedTransactions) RewindWallet(string walletName, ChainedHeader lastBlockSynced);
 
         /// <summary>
         /// Allows multiple interface calls to be grouped into a transaction.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -254,7 +254,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                 // A wallet ahead of consensus should be truncated.
                 ChainedHeader fork = this.WalletRepository.FindFork(walletName, this.ChainIndexer.Tip);
 
-                if (this.WalletRepository.RewindWallet(walletName, fork).Item1)
+                if (this.WalletRepository.RewindWallet(walletName, fork).RewindExecuted)
                     this.logger.LogDebug("Rewound wallet, {0}='{1}', {2}='{3}'", nameof(fork), fork, nameof(this.ChainIndexer.Tip), this.ChainIndexer.Tip?.HashBlock);
             }
 
@@ -1068,7 +1068,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                         // A wallet ahead of consensus should be truncated.
                         ChainedHeader fork = this.WalletRepository.FindFork(walletName, this.ChainIndexer.Tip);
 
-                        if (this.WalletRepository.RewindWallet(walletName, fork).Item1)
+                        if (this.WalletRepository.RewindWallet(walletName, fork).RewindExecuted)
                             this.logger.LogDebug("Rewound wallet, {0}='{1}', {2}='{3}'", nameof(fork), fork, nameof(this.ChainIndexer.Tip), this.ChainIndexer.Tip?.HashBlock);
                             
                         // Update the lowest common tip.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1046,7 +1046,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <inheritdoc />
-        public void ProcessBlocks(Func<int, IEnumerable<(ChainedHeader, Block)>> blockProvider)
+        public void ProcessBlocks(Func<ChainedHeader, IEnumerable<(ChainedHeader, Block)>> blockProvider)
         {
             lock (this.lockProcess)
             {
@@ -1086,7 +1086,7 @@ namespace Stratis.Bitcoin.Features.Wallet
                         walletTip = genesisHeader;
                     }
 
-                    this.WalletRepository.ProcessBlocks(blockProvider(walletTip.Height + 1));
+                    this.WalletRepository.ProcessBlocks(blockProvider(walletTip));
                 }
                 catch (Exception err)
                 {
@@ -1109,7 +1109,7 @@ namespace Stratis.Bitcoin.Features.Wallet
 
             chainedHeader = chainedHeader ?? this.ChainIndexer.GetHeader(block.GetHash());
 
-            this.ProcessBlocks((height) => (height == chainedHeader.Height) ? new[] { (chainedHeader, block) } : new (ChainedHeader, Block)[] { });
+            this.ProcessBlocks((previousBlock) => (previousBlock.HashBlock == chainedHeader.Previous.HashBlock) ? new[] { (chainedHeader, block) } : new (ChainedHeader, Block)[] { });
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -254,11 +254,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                 // A wallet ahead of consensus should be truncated.
                 ChainedHeader fork = this.WalletRepository.FindFork(walletName, this.ChainIndexer.Tip);
 
-                if (fork?.HashBlock != this.ChainIndexer.Tip?.HashBlock)
-                {
-                    this.logger.LogDebug("Rewinding wallet, {0}='{1}', {2}='{3}'", nameof(fork), fork, nameof(this.ChainIndexer.Tip), this.ChainIndexer.Tip?.HashBlock);
-                    this.WalletRepository.RewindWallet(walletName, fork);
-                }
+                if (this.WalletRepository.RewindWallet(walletName, fork).Item1)
+                    this.logger.LogDebug("Rewound wallet, {0}='{1}', {2}='{3}'", nameof(fork), fork, nameof(this.ChainIndexer.Tip), this.ChainIndexer.Tip?.HashBlock);
             }
 
             if (this.walletSettings.IsDefaultWalletEnabled())

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1068,12 +1068,9 @@ namespace Stratis.Bitcoin.Features.Wallet
                         // A wallet ahead of consensus should be truncated.
                         ChainedHeader fork = this.WalletRepository.FindFork(walletName, this.ChainIndexer.Tip);
 
-                        if (fork?.HashBlock != this.ChainIndexer.Tip?.HashBlock)
-                        {
-                            this.logger.LogDebug("Rewinding wallet, {0}='{1}', {2}='{3}'", nameof(fork), fork, nameof(this.ChainIndexer.Tip), this.ChainIndexer.Tip?.HashBlock);
-                            this.WalletRepository.RewindWallet(walletName, fork);
-                        }
-
+                        if (this.WalletRepository.RewindWallet(walletName, fork).Item1)
+                            this.logger.LogDebug("Rewound wallet, {0}='{1}', {2}='{3}'", nameof(fork), fork, nameof(this.ChainIndexer.Tip), this.ChainIndexer.Tip?.HashBlock);
+                            
                         // Update the lowest common tip.
                         walletTip = (fork == null) ? null : walletTip?.FindFork(fork);
                     }

--- a/src/Stratis.Features.SQLiteWalletRepository/Commands/ProcessBlockCommands.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Commands/ProcessBlockCommands.cs
@@ -124,8 +124,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Commands
                 ,       O.IsChange SpendIsChange
                 FROM    temp.TempPrevOut T
                 JOIN    temp.TempOutput O
-                ON      O.OutputTxTime = T.SpendTxTime
-                AND     O.OutputTxId = T.SpendTxId
+                ON      O.OutputTxId = T.SpendTxId
                 AND     O.ScriptPubKey IS NULL
                 JOIN    HDTransactionData TD
                 ON      TD.OutputTxId = T.OutputTxId

--- a/src/Stratis.Features.SQLiteWalletRepository/DBConnection.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/DBConnection.cs
@@ -384,6 +384,8 @@ namespace Stratis.Features.SQLiteWalletRepository
             {
                 if (typeof(T) == typeof(HDAddress))
                     HDAddress.MigrateTable(this);
+                else if (typeof(T) == typeof(HDPayment))
+                    HDPayment.MigrateTable(this);
             }
         }
 

--- a/src/Stratis.Features.SQLiteWalletRepository/External/IWalletTransactionLookup.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/IWalletTransactionLookup.cs
@@ -23,6 +23,6 @@ namespace Stratis.Features.SQLiteWalletRepository.External
         /// <param name="walletId">The wallet to look in.</param>
         /// <param name="accountIndex">The account to look in.</param>
         /// <param name="fromBlock">Adds outpoints where <c>SpendBlockHeight > fromBlock</c> otherwise where SpendBlockHeight is <c>null</c>.</param>
-        void AddAll(int? walletId = null, int? accountIndex = null, int? fromBlock = null);
+        void AddSpendableTransactions(int? walletId = null, int? accountIndex = null, int? fromBlock = null);
     }
 }

--- a/src/Stratis.Features.SQLiteWalletRepository/External/IWalletTransactionLookup.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/IWalletTransactionLookup.cs
@@ -22,6 +22,7 @@ namespace Stratis.Features.SQLiteWalletRepository.External
         /// </summary>
         /// <param name="walletId">The wallet to look in.</param>
         /// <param name="accountIndex">The account to look in.</param>
-        void AddAll(int? walletId = null, int? accountIndex = null);
+        /// <param name="fromBlock">Adds outpoints where <c>SpendBlockHeight > fromBlock</c> otherwise where SpendBlockHeight is <c>null</c>.</param>
+        void AddAll(int? walletId = null, int? accountIndex = null, int? fromBlock = null);
     }
 }

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -284,6 +284,10 @@ namespace Stratis.Features.SQLiteWalletRepository
             conn.BeginTransaction();
             try
             {
+                // Add the UTXOs being freed up. If rewinding to start there will be nothing to add.
+                if (lastBlockSynced != null)
+                    walletContainer.TransactionsOfInterest.AddAll(wallet.WalletId, fromBlock: lastBlockSynced.Height);
+
                 IEnumerable<(string txId, long creationTime)> res = conn.SetLastBlockSynced(wallet, lastBlockSynced).ToList();
                 conn.Commit();
 

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -1264,7 +1264,6 @@ namespace Stratis.Features.SQLiteWalletRepository
             SpendingDetails spendingDetails = transactionData.SpendingDetails;
 
             var res = HDPayment.GetAllPayments(conn,
-                spendingDetails.CreationTime.ToUnixTimeSeconds(),
                 spendingDetails.TransactionId.ToString(),
                 transactionData.Id.ToString(),
                 transactionData.Index,

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -756,7 +756,7 @@ namespace Stratis.Features.SQLiteWalletRepository
             }
             else
             {
-                walletContainer.WriteLockRelease();
+                walletContainer.WriteLockWait();
             }
 
             return new TransactionContext(walletContainer);

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDPayment.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDPayment.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using SQLite;
 
 namespace Stratis.Features.SQLiteWalletRepository.Tables
@@ -30,10 +31,46 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
             )";
         }
 
+        internal static IEnumerable<string> MigrateScript()
+        {
+            yield return $@"
+                PRAGMA foreign_keys=off;
+            ";
+
+            yield return CreateScript().First().Replace("HDPayment", "new_HDPayment");
+
+            // TODO: Copy the data.
+            yield return $@"
+                INSERT INTO new_HDPayment SELECT MAX(SpendTxTime), SpendTxId, OutputTxId, OutputIndex, ScriptPubKey, SpendIndex, MAX(SpendScriptPubKey), MAX(SpendValue), MAX(SpendIsChange) FROM HDPayment GROUP BY SpendTxId, OutputTxId, OutputIndex, ScriptPubKey, SpendIndex;
+            ";
+
+            yield return $@"
+                DROP TABLE HDPayment;
+            ";
+
+            yield return $@"
+                ALTER TABLE new_HDPayment RENAME TO HDPayment;
+            ";
+
+            foreach (var indexScript in CreateScript().Skip(1))
+                yield return indexScript;
+
+            yield return $@"
+                PRAGMA foreign_keys=on;
+            ";
+        }
+
         internal static void CreateTable(SQLiteConnection conn)
         {
             foreach (string command in CreateScript())
                 conn.Execute(command);
+        }
+
+        internal static void MigrateTable(SQLiteConnection conn)
+        {
+            if (conn.ExecuteScalar<int>("SELECT COUNT(*) AS CNTREC FROM pragma_table_info('HDPayment') WHERE name='SpendTxTime' AND pk = 1") != 0)
+                foreach (string command in MigrateScript())
+                    conn.Execute(command);
         }
 
         internal static IEnumerable<HDPayment> GetAllPayments(DBConnection conn, string spendTxId, string outputTxId, int outputIndex, string scriptPubKey)

--- a/src/Stratis.Features.SQLiteWalletRepository/Tables/HDPayment.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/Tables/HDPayment.cs
@@ -26,7 +26,7 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 SpendScriptPubKey   TEXT,
                 SpendValue          INTEGER NOT NULL,
                 SpendIsChange       INTEGER NOT NULL,
-                PRIMARY KEY(SpendTxTime, SpendTxId, OutputTxId, OutputIndex, ScriptPubKey, SpendIndex)
+                PRIMARY KEY(SpendTxId, OutputTxId, OutputIndex, ScriptPubKey, SpendIndex)
             )";
         }
 
@@ -36,18 +36,16 @@ namespace Stratis.Features.SQLiteWalletRepository.Tables
                 conn.Execute(command);
         }
 
-        internal static IEnumerable<HDPayment> GetAllPayments(DBConnection conn, long spendTxTime, string spendTxId, string outputTxId, int outputIndex, string scriptPubKey)
+        internal static IEnumerable<HDPayment> GetAllPayments(DBConnection conn, string spendTxId, string outputTxId, int outputIndex, string scriptPubKey)
         {
             return conn.Query<HDPayment>($@"
                 SELECT  *
                 FROM    HDPayment
-                WHERE   SpendTxTime = ?
-                AND     SpendTxId = ?
+                WHERE   SpendTxId = ?
                 AND     OutputTxId = ?
                 AND     OutputIndex = ?
                 AND     ScriptPubKey = ?
                 ORDER   BY SpendIndex",
-                spendTxTime,
                 spendTxId,
                 outputTxId,
                 outputIndex,

--- a/src/Stratis.Features.SQLiteWalletRepository/TransactionContext.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/TransactionContext.cs
@@ -29,7 +29,7 @@ namespace Stratis.Features.SQLiteWalletRepository
 
             this.CleanupUnusedWalletFile();
 
-            this.walletContainer.LockUpdateWallet.Release();
+            this.walletContainer.WriteLockRelease();
         }
 
         internal void CleanupUnusedWalletFile()
@@ -57,7 +57,7 @@ namespace Stratis.Features.SQLiteWalletRepository
 
             this.CleanupUnusedWalletFile();
 
-            this.walletContainer.LockUpdateWallet.Release();
+            this.walletContainer.WriteLockRelease();
         }
 
         public void Dispose()
@@ -67,7 +67,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 this.walletContainer.Conn.Rollback();
             }
 
-            this.walletContainer.LockUpdateWallet.Release();
+            this.walletContainer.WriteLockRelease();
         }
     }
 }

--- a/src/Stratis.Features.SQLiteWalletRepository/WalletTransactionLookup.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/WalletTransactionLookup.cs
@@ -40,7 +40,7 @@ namespace Stratis.Features.SQLiteWalletRepository
         }
 
         /// <inheritdoc />
-        public void AddAll(int? walletId = null, int? accountIndex = null, int? fromBlock = null)
+        public void AddSpendableTransactions(int? walletId = null, int? accountIndex = null, int? fromBlock = null)
         {
             Guard.Assert((walletId ?? this.walletId) == (this.walletId ?? walletId));
 

--- a/src/Stratis.Features.SQLiteWalletRepository/WalletTransactionLookup.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/WalletTransactionLookup.cs
@@ -40,7 +40,7 @@ namespace Stratis.Features.SQLiteWalletRepository
         }
 
         /// <inheritdoc />
-        public void AddAll(int? walletId = null, int? accountIndex = null)
+        public void AddAll(int? walletId = null, int? accountIndex = null, int? fromBlock = null)
         {
             Guard.Assert((walletId ?? this.walletId) == (this.walletId ?? walletId));
 
@@ -51,9 +51,10 @@ namespace Stratis.Features.SQLiteWalletRepository
 
             List<HDTransactionData> spendableTransactions = this.conn.Query<HDTransactionData>($@"
                 SELECT  *
-                FROM    HDTransactionData
+                FROM    HDTransactionData{((fromBlock == null) ? $@"
                 WHERE   SpendBlockHash IS NULL
-                AND     SpendBlockHeight IS NULL {
+                AND     SpendBlockHeight IS NULL" : $@"
+                WHERE   SpendBlockHeight > {fromBlock} ")}{
                 // Restrict to wallet if provided.
                 ((walletId != null) ? $@"
                 AND      WalletId = {strWalletId}" : "")}{


### PR DESCRIPTION
The node start up on Block N and then rewinds to N-M. This will require updating `TransactionsOfInterest` for any UTXO's that were spent in the last M blocks starting with Block N.
So further parameterization of `AddAll` is required to include the range.
A call can then be added in the `Rewind` method.
Also updating batched blocks processing to ensure blocks are linked by previous.