### PR TITLE
Prevent regtest IBD assumption when "time gaps" are really expected

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/BaseRPCControllerTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/BaseRPCControllerTest.cs
@@ -1,4 +1,5 @@
-﻿using Stratis.Bitcoin.Builder;
+﻿using NBitcoin;
+using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.Consensus;
@@ -23,9 +24,9 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         /// </summary>
         /// <param name="dir">Data directory that the node should use.</param>
         /// <returns>Interface to the newly built node.</returns>
-        public IFullNode BuildServicedNode(string dir)
+        public IFullNode BuildServicedNode(string dir, Network network = null)
         {
-            var nodeSettings = new NodeSettings(this.Network, args: new string[] { $"-datadir={dir}" });
+            var nodeSettings = new NodeSettings(network ?? this.Network, args: new string[] { $"-datadir={dir}" });
             var fullNodeBuilder = new FullNodeBuilder(nodeSettings);
             IFullNode fullNode = fullNodeBuilder
                 .UseBlockStore()

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/ConsensusActionTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/ConsensusActionTests.cs
@@ -4,6 +4,7 @@ using Stratis.Bitcoin.Features.Consensus;
 using Stratis.Bitcoin.Interfaces;
 using Xunit;
 using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Tests.Common;
 
 namespace Stratis.Bitcoin.IntegrationTests.RPC
 {
@@ -40,7 +41,7 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
         {
             string dir = CreateTestDir(this);
 
-            IFullNode fullNode = this.BuildServicedNode(dir);
+            IFullNode fullNode = this.BuildServicedNode(dir, KnownNetworks.StraxMain);
             var isIBDProvider = fullNode.NodeService<IInitialBlockDownloadState>(true);
             var chainState = fullNode.NodeService<IChainState>(true);
             chainState.ConsensusTip = new ChainedHeader(fullNode.Network.GetGenesis().Header, fullNode.Network.GenesisHash, 0);

--- a/src/Stratis.Bitcoin/Base/InitialBlockDownloadState.cs
+++ b/src/Stratis.Bitcoin/Base/InitialBlockDownloadState.cs
@@ -60,7 +60,17 @@ namespace Stratis.Bitcoin.Base
                 return true;
 
             if (this.chainState.ConsensusTip.Header.BlockTime < (this.dateTimeProvider.GetUtcNow().AddSeconds(-this.consensusSettings.MaxTipAge)))
-                return true;
+            {
+                if (!this.network.IsRegTest())
+                    return true;
+
+                // RegTest networks may experience long periods of no mining.
+                // If this happens we don't want to be in IBD because we can't
+                // mine new blocks in IBD and our nodes will be frozen at the
+                // current height. Also note that in RegTest its typical for one
+                // machine to control all (local) nodes and hence we are in control
+                // of any side-effects that may arise from returning false here.
+            }
 
             if (this.chainState.ConsensusTip.ChainWork < this.minimumChainWork)
                 return true;


### PR DESCRIPTION
If there is a time delay between mining the last POW block at block 12,500 and starting staking then **staking** will never occur.
The code below shows that returning IBD=true when not really in IBD will indeed prevent staking from occurring:

```
      public async Task GenerateBlocksAsync(WalletSecret walletSecret, CancellationToken cancellationToken)
        {
            Guard.NotNull(walletSecret, nameof(walletSecret));

            BlockTemplate blockTemplate = null;

            while (!cancellationToken.IsCancellationRequested)
            {
                // Prevent staking if the system time is not in sync with that of other members on the network.
                if (this.timeSyncBehaviorState.IsSystemTimeOutOfSync)
                {
                    this.logger.LogError("Staking cannot start, your system time does not match that of other nodes on the network." + Environment.NewLine
                                         + "Please adjust your system time and restart the node.");
                    await Task.Delay(TimeSpan.FromMilliseconds(this.systemTimeOutOfSyncSleep), cancellationToken).ConfigureAwait(false);
                    continue;
                }

                // Don't stake if the wallet is not up-to-date with the current chain.
                if (this.consensusManager.Tip.HashBlock != this.walletManager.WalletTipHash)
                {
                    this.logger.LogDebug("Waiting for wallet to catch up before mining can be started.");

                    await Task.Delay(TimeSpan.FromMilliseconds(this.minerSleep), cancellationToken).ConfigureAwait(false);
                    continue;
                }

                // Prevent staking if in initial block download.
                if (this.initialBlockDownloadState.IsInitialBlockDownload())
                {
                    this.logger.LogDebug("Waiting for synchronization before mining can be started.");

                    await Task.Delay(TimeSpan.FromMilliseconds(this.minerSleep), cancellationToken).ConfigureAwait(false);
                    continue;
                }
```

This PR fixes the IBD determination.