### PR TITLE
Don't check legacy (Stratis) collateral

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -600,7 +600,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
         /// <inheritdoc />
         public VerboseAddressBalancesResult GetAddressIndexerState(string[] addresses)
         {
-            var result = new VerboseAddressBalancesResult(this.consensusManager.Tip.Height);
+            var result = new VerboseAddressBalancesResult(this.consensusManager.Tip.Height, this.chainIndexer.GetHeader(0).Header.Time);
+
+            if (this.chainIndexer.Tip.Height >= 1)
+                result.GenesisBlockTime = this.chainIndexer.GetHeader(1).Header.Time - (uint)this.network.Consensus.PowTargetTimespan.Seconds;
 
             if (addresses.Length == 0)
                 return result;

--- a/src/Stratis.Bitcoin/Controllers/Models/AddressBalancesResult.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/AddressBalancesResult.cs
@@ -62,14 +62,17 @@ namespace Stratis.Bitcoin.Controllers.Models
             this.BalancesData = new List<AddressIndexerData>();
         }
 
-        public VerboseAddressBalancesResult(int consensusTipHeight) : this()
+        public VerboseAddressBalancesResult(int consensusTipHeight, uint genesisBlockTime) : this()
         {
             this.ConsensusTipHeight = consensusTipHeight;
+            this.GenesisBlockTime = genesisBlockTime;
         }
 
         public List<AddressIndexerData> BalancesData { get; set; }
 
         public int ConsensusTipHeight { get; set; }
+
+        public uint GenesisBlockTime { get; set; }
 
         [JsonProperty("reason")]
         public string Reason { get; private set; }

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -48,6 +48,11 @@ namespace Stratis.Features.Collateral
                 return Task.CompletedTask;
             }
 
+            // If the time on this block is earlier than the STRAX genesis block then ignore this rule.
+            uint counterChainGenesisBlockTime = this.collateralChecker.GetCounterChainGenesisBlockTime();
+            if (context.ValidationContext.ChainedHeaderToValidate.Header.Time < counterChainGenesisBlockTime)
+                return Task.CompletedTask;                
+
             var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.Logger);
             int? commitmentHeight = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());
             if (commitmentHeight == null)

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -30,6 +30,8 @@ namespace Stratis.Features.Collateral
         bool CheckCollateral(IFederationMember federationMember, int heightToCheckAt);
 
         int GetCounterChainConsensusHeight();
+
+        uint GetCounterChainGenesisBlockTime();
     }
 
     public class CollateralChecker : ICollateralChecker
@@ -64,6 +66,8 @@ namespace Stratis.Features.Collateral
         /// <summary>Consensus tip height of a counter chain.</summary>
         /// <remarks>All access should be protected by <see cref="locker"/>.</remarks>
         private int counterChainConsensusTipHeight;
+
+        private uint counterChainGenesisBlockTime;
 
         private Task updateCollateralContinuouslyTask;
 
@@ -119,6 +123,14 @@ namespace Stratis.Features.Collateral
             lock (this.locker)
             {
                 return this.counterChainConsensusTipHeight;
+            }
+        }
+
+        public uint GetCounterChainGenesisBlockTime()
+        {
+            lock (this.locker)
+            {
+                return this.counterChainGenesisBlockTime;
             }
         }
 
@@ -198,6 +210,7 @@ namespace Stratis.Features.Collateral
                 }
 
                 this.counterChainConsensusTipHeight = verboseAddressBalanceResult.ConsensusTipHeight;
+                this.counterChainGenesisBlockTime = verboseAddressBalanceResult.GenesisBlockTime;
             }
 
             this.collateralUpdated = true;

--- a/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
+++ b/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
@@ -79,7 +79,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
         {
             var mockClient = new Mock<IBlockStoreClient>();
             mockClient.Setup(x => x.GetVerboseAddressesBalancesDataAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Bitcoin.Controllers.Models.VerboseAddressBalancesResult(100000));
+                .ReturnsAsync(new Bitcoin.Controllers.Models.VerboseAddressBalancesResult(100000, 0));
 
             node.Start(() =>
             {

--- a/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
@@ -41,7 +41,9 @@ namespace Stratis.Features.FederatedPeg.Tests
                 .Returns(new CollateralFederationMember(new Key().PubKey, false, new Money(1), "addr1"));
 
             this.ruleContext = new RuleContext(new ValidationContext(), DateTimeOffset.Now);
-            this.ruleContext.ValidationContext.BlockToValidate = new Block(new BlockHeader() { Time = 5234 });
+            var header = new BlockHeader() { Time = 5234 };
+            this.ruleContext.ValidationContext.BlockToValidate = new Block(header);
+            this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(header, header.GetHash(), 0);
 
             Block block = this.ruleContext.ValidationContext.BlockToValidate;
             block.AddTransaction(new Transaction());

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -80,7 +80,7 @@ namespace Stratis.Features.FederatedPeg.Tests
         {
             var blockStoreClientMock = new Mock<IBlockStoreClient>();
 
-            var collateralData = new VerboseAddressBalancesResult(this.collateralCheckHeight + 1000)
+            var collateralData = new VerboseAddressBalancesResult(this.collateralCheckHeight + 1000, 0)
             {
                 BalancesData = new List<AddressIndexerData>()
                 {


### PR DESCRIPTION
See https://stratisplatformuk.visualstudio.com/STRAX/_workitems/edit/5201.

This PR is based on two assumptions:
1. We won't be starting the Cirrus chain afresh. 
2. We will stop the old federation before starting up Strax.

The PR leverages the fact that any Strax-related Cirrus blocks will then have a timestamp after the Strax genesis block and all Stratis-related Cirrus blocks will then have a timestamp before the Strax genesis block.

**This PR ensures that the old blocks produced with Stratis collateral won't participate in `CheckCollateralFullValidationRule`**:

```
            // If the time on this block is earlier than the STRAX genesis block then ignore this rule.
            uint counterChainGenesisBlockTime = this.collateralChecker.GetCounterChainGenesisBlockTime();
            if (context.ValidationContext.ChainedHeaderToValidate.Header.Time < counterChainGenesisBlockTime)
                return Task.CompletedTask;   
```
