### PR TITLE
Qualify collateral commitment heights to identify the network

### DIFF
--- a/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
@@ -26,7 +26,7 @@ namespace Stratis.Features.Collateral
 
             var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.Logger);
 
-            int? commitmentHeight = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());
+            (int? commitmentHeight, _) = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());
             if (commitmentHeight == null)
             {
                 // Every PoA miner on a sidechain network is forced to include commitment data to the blocks mined.

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -49,7 +49,7 @@ namespace Stratis.Features.Collateral
             }
 
             var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.Logger);
-            int? commitmentHeight = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());
+            (int? commitmentHeight, _) = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());
             if (commitmentHeight == null)
             {
                 // We return here as it is CheckCollateralCommitmentHeightRule's responsibility to perform this check.

--- a/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
+++ b/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
@@ -155,7 +155,7 @@ namespace Stratis.Features.Collateral
             }
 
             if (commitmentData != null)
-                return (BitConverter.ToInt32(commitmentData), BitConverter.ToUInt32(magic));
+                return (BitConverter.ToInt32(commitmentData), ((magic == null) ? (uint?)null : BitConverter.ToUInt32(magic)));
 
             return (null, null);
         }

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralHeightCommitmentEncoderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralHeightCommitmentEncoderTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Features.Collateral;
 using Xunit;
 
@@ -29,13 +30,14 @@ namespace Stratis.Features.FederatedPeg.Tests
 
                 byte[] encodedWithPrefix = this.encoder.EncodeCommitmentHeight(randomValue);
 
-                var votingOutputScript = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(encodedWithPrefix));
+                var votingOutputScript = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(encodedWithPrefix), Op.GetPushOp(KnownNetworks.StraxMain.MagicBytes));
                 var tx = new Transaction();
                 tx.AddOutput(Money.Zero, votingOutputScript);
 
-                int? decodedValue = this.encoder.DecodeCommitmentHeight(tx);
+                (int? decodedValue, uint? magic) = this.encoder.DecodeCommitmentHeight(tx);
 
                 Assert.Equal(randomValue, decodedValue);
+                Assert.Equal(KnownNetworks.StraxMain.Magic, magic);
             }
         }
     }

--- a/src/Stratis.Features.FederatedPeg/Distribution/RewardDistributionManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Distribution/RewardDistributionManager.cs
@@ -58,7 +58,7 @@ namespace Stratis.Features.FederatedPeg.Distribution
 
             for (int i = 0; i < iterations; i++)
             {
-                int? heightOfMainChainCommitment = encoder.DecodeCommitmentHeight(currentHeader.Block.Transactions[0]);
+                (int? heightOfMainChainCommitment, _) = encoder.DecodeCommitmentHeight(currentHeader.Block.Transactions[0]);
 
                 if (heightOfMainChainCommitment == null)
                     continue;


### PR DESCRIPTION
**This fix is best introduced before the release**. It avoids a situation where we have two types of collateral commitment heights recorded in the Cirrus blocks with no explicit way to identify the network that they belong to.

The PR adds a 3rd opcode to the OP_RETURN (currently only containing the collateral commitment height) that identifies the counter-chain network by recording the associated magic bytes. We also remain backward compatible with blocks containing only 2 opcodes in the OP_RETURN (implies a STRAT network).

https://github.com/stratisproject/StratisFullNode/pull/92#discussion_r505287665