### PR TITLE
Adjust CheckCollateralFullValidationRule for switchover

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -600,10 +600,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
         /// <inheritdoc />
         public VerboseAddressBalancesResult GetAddressIndexerState(string[] addresses)
         {
-            var result = new VerboseAddressBalancesResult(this.consensusManager.Tip.Height, this.chainIndexer.GetHeader(0).Header.Time);
-
-            if (this.chainIndexer.Tip.Height >= 1)
-                result.GenesisBlockTime = this.chainIndexer.GetHeader(1).Header.Time - (uint)this.network.Consensus.PowTargetTimespan.Seconds;
+            var result = new VerboseAddressBalancesResult(this.consensusManager.Tip.Height);
 
             if (addresses.Length == 0)
                 return result;

--- a/src/Stratis.Bitcoin.Features.PoA/SlotsManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/SlotsManager.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Features.PoA
         /// <summary>Determines whether timestamp is valid according to the network rules.</summary>
         bool IsValidTimestamp(uint headerUnixTimestamp);
 
-        uint GetRoundLengthSeconds(int federationMembersCount);
+        uint GetRoundLengthSeconds(int? federationMembersCount = null);
     }
 
     public class SlotsManager : ISlotsManager
@@ -104,8 +104,10 @@ namespace Stratis.Bitcoin.Features.PoA
             return (headerUnixTimestamp % this.consensusOptions.TargetSpacingSeconds) == 0;
         }
 
-        public uint GetRoundLengthSeconds(int federationMembersCount)
+        public uint GetRoundLengthSeconds(int? federationMembersCount = null)
         {
+            federationMembersCount = federationMembersCount ?? this.federationManager.GetFederationMembers().Count;
+
             uint roundLength = (uint)(federationMembersCount * this.consensusOptions.TargetSpacingSeconds);
 
             return roundLength;

--- a/src/Stratis.Bitcoin/Controllers/Models/AddressBalancesResult.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/AddressBalancesResult.cs
@@ -62,17 +62,14 @@ namespace Stratis.Bitcoin.Controllers.Models
             this.BalancesData = new List<AddressIndexerData>();
         }
 
-        public VerboseAddressBalancesResult(int consensusTipHeight, uint genesisBlockTime) : this()
+        public VerboseAddressBalancesResult(int consensusTipHeight) : this()
         {
             this.ConsensusTipHeight = consensusTipHeight;
-            this.GenesisBlockTime = genesisBlockTime;
         }
 
         public List<AddressIndexerData> BalancesData { get; set; }
 
         public int ConsensusTipHeight { get; set; }
-
-        public uint GenesisBlockTime { get; set; }
 
         [JsonProperty("reason")]
         public string Reason { get; private set; }

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -55,7 +55,7 @@ namespace Stratis.Features.Collateral
             }
 
             var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.Logger);
-            (int? commitmentHeight, uint? magic) = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());
+            (int? commitmentHeight, uint? commitmentNetworkMagic) = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());
             if (commitmentHeight == null)
             {
                 // We return here as it is CheckCollateralCommitmentHeightRule's responsibility to perform this check.
@@ -63,7 +63,7 @@ namespace Stratis.Features.Collateral
                 return Task.CompletedTask;
             }
 
-            this.Logger.LogDebug("Commitment is: {0}. Magic is: {1}", commitmentHeight, magic);
+            this.Logger.LogDebug("Commitment is: {0}. Magic is: {1}", commitmentHeight, commitmentNetworkMagic);
 
             // TODO: The code contained in the following "if" can be removed after most nodes have switched their mainchain to Strax.
 
@@ -74,7 +74,7 @@ namespace Stratis.Features.Collateral
 
             // 1. If the block miner is on STRAX then skip this code and go check the collateral.
             Network counterChainNetwork = this.fullNode.NodeService<CounterChainNetworkWrapper>().CounterChainNetwork;
-            if (this.network.Name.StartsWith("Cirrus") && magic != counterChainNetwork.Magic)
+            if (this.network.Name.StartsWith("Cirrus") && commitmentNetworkMagic != counterChainNetwork.Magic)
             {
                 // 2. The block miner is on STRAT.
                 IConsensusManager consensusManager = this.fullNode.NodeService<IConsensusManager>();

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -65,8 +65,6 @@ namespace Stratis.Features.Collateral
 
             this.Logger.LogDebug("Commitment is: {0}. Magic is: {1}", commitmentHeight, commitmentNetworkMagic);
 
-            // TODO: The code contained in the following "if" can be removed after most nodes have switched their mainchain to Strax.
-
             // Strategy:
             // 1. I'm a Cirrus miner on STRAX. If the block's miner is also on STRAX then check the collateral. Pass or Fail as appropriate.
             // 2. The block miner is on STRAT. If most nodes were on STRAT(prev round) then they will check the rule. Pass the rule.

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -78,13 +78,13 @@ namespace Stratis.Features.Collateral
                 IConsensusManager consensusManager = this.fullNode.NodeService<IConsensusManager>();
                 int memberCount = 1;
                 int membersOnDifferentCounterChain = 1;
-                uint targetSpacing = this.slotsManager.GetRoundLengthSeconds();
+                uint minimumRoundLength = this.slotsManager.GetRoundLengthSeconds() - ((PoAConsensusOptions)this.network.Consensus.Options).TargetSpacingSeconds / 2;
 
                 // Check the block being validated and any prior blocks in the same round.
                 foreach (ChainedHeader chainedHeader in context.ValidationContext.ChainedHeaderToValidate.EnumerateToGenesis().Skip(1))
                 {
                     Block block = chainedHeader?.Block ?? consensusManager.GetBlockData(chainedHeader.HashBlock).Block;
-                    if (block == null || (block.Header.Time + targetSpacing) < context.ValidationContext.BlockToValidate.Header.Time)
+                    if (block == null || (block.Header.Time + minimumRoundLength) < context.ValidationContext.BlockToValidate.Header.Time)
                         break;
 
                     (int? commitmentHeight2, uint? magic2) = commitmentHeightEncoder.DecodeCommitmentHeight(block.Transactions.First());

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -76,18 +76,17 @@ namespace Stratis.Features.Collateral
             {
                 // 2. The block miner is on STRAT.
                 IConsensusManager consensusManager = this.fullNode.NodeService<IConsensusManager>();
-                int memberCount = 0;
-                int membersOnDifferentCounterChain = 0;
+                int memberCount = 1;
+                int membersOnDifferentCounterChain = 1;
                 uint targetSpacing = this.slotsManager.GetRoundLengthSeconds();
-                ChainedHeader chainedHeader = context.ValidationContext.ChainedHeaderToValidate;
 
                 // Check the block being validated and any prior blocks in the same round.
-                // We already know at this point that block will not be null so this loop executes 
-                // at least once and memberCount will be at least 1.
-                for (Block block = context.ValidationContext.BlockToValidate; 
-                    block != null && (block.Header.Time + targetSpacing) >= context.ValidationContext.BlockToValidate.Header.Time;
-                    chainedHeader = chainedHeader.Previous, block = chainedHeader?.Block ?? consensusManager.GetBlockData(chainedHeader.HashBlock).Block)
+                foreach (ChainedHeader chainedHeader in context.ValidationContext.ChainedHeaderToValidate.EnumerateToGenesis().Skip(1))
                 {
+                    Block block = chainedHeader?.Block ?? consensusManager.GetBlockData(chainedHeader.HashBlock).Block;
+                    if (block == null || (block.Header.Time + targetSpacing) < context.ValidationContext.BlockToValidate.Header.Time)
+                        break;
+
                     (int? commitmentHeight2, uint? magic2) = commitmentHeightEncoder.DecodeCommitmentHeight(block.Transactions.First());
                     if (commitmentHeight2 == null)
                         continue;

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -65,8 +65,6 @@ namespace Stratis.Features.Collateral
 
             this.Logger.LogDebug("Commitment is: {0}. Magic is: {1}", commitmentHeight, magic);
 
-            int counterChainHeight = this.collateralChecker.GetCounterChainConsensusHeight();
-
             // TODO: The code contained in the following "if" can be removed after most nodes have switched their mainchain to Strax.
 
             // Strategy:
@@ -114,6 +112,7 @@ namespace Stratis.Features.Collateral
             }
 
             // TODO: Both this and CollateralPoAMiner are using this chain's MaxReorg instead of the Counter chain's MaxReorg. Beware: fixing requires fork.
+            int counterChainHeight = this.collateralChecker.GetCounterChainConsensusHeight();
             int maxReorgLength = AddressIndexer.GetMaxReorgOrFallbackMaxReorg(this.network);
 
             // Check if commitment height is less than `mainchain consensus tip height - MaxReorg`.

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -10,6 +10,7 @@ using Stratis.Bitcoin.Features.BlockStore.AddressIndexing;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
+using Stratis.Features.Collateral.CounterChain;
 
 namespace Stratis.Features.Collateral
 {
@@ -74,7 +75,8 @@ namespace Stratis.Features.Collateral
             // 3. The miner is on STRAT and most nodes were on STRAX(prev round).Fail the rule.
 
             // 1. If the block miner is on STRAX then skip this code and go check the collateral.
-            if (this.network.Name.StartsWith("Cirrus") && magic != this.network.Magic)
+            Network counterChainNetwork = this.fullNode.NodeService<CounterChainNetworkWrapper>().CounterChainNetwork;
+            if (this.network.Name.StartsWith("Cirrus") && magic != counterChainNetwork.Magic)
             {
                 // 2. The block miner is on STRAT.
                 IConsensusManager consensusManager = this.fullNode.NodeService<IConsensusManager>();
@@ -93,7 +95,7 @@ namespace Stratis.Features.Collateral
                     if (commitmentHeight2 == null)
                         continue;
 
-                    if (magic2 != this.network.Magic)
+                    if (magic2 != counterChainNetwork.Magic)
                         membersOnStratis++;
 
                     memberCount++;

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -80,7 +80,7 @@ namespace Stratis.Features.Collateral
                 int membersOnDifferentCounterChain = 1;
                 uint minimumRoundLength = this.slotsManager.GetRoundLengthSeconds() - ((PoAConsensusOptions)this.network.Consensus.Options).TargetSpacingSeconds / 2;
 
-                // Check the block being validated and any prior blocks in the same round.
+                // Check and any prior blocks in the same round.
                 foreach (ChainedHeader chainedHeader in context.ValidationContext.ChainedHeaderToValidate.EnumerateToGenesis().Skip(1))
                 {
                     Block block = chainedHeader?.Block ?? consensusManager.GetBlockData(chainedHeader.HashBlock).Block;

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -48,11 +48,6 @@ namespace Stratis.Features.Collateral
                 return Task.CompletedTask;
             }
 
-            // If the time on this block is earlier than the STRAX genesis block then ignore this rule.
-            uint counterChainGenesisBlockTime = this.collateralChecker.GetCounterChainGenesisBlockTime();
-            if (context.ValidationContext.ChainedHeaderToValidate.Header.Time < counterChainGenesisBlockTime)
-                return Task.CompletedTask;                
-
             var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.Logger);
             (int? commitmentHeight, _) = commitmentHeightEncoder.DecodeCommitmentHeight(context.ValidationContext.BlockToValidate.Transactions.First());
             if (commitmentHeight == null)

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -30,8 +30,6 @@ namespace Stratis.Features.Collateral
         bool CheckCollateral(IFederationMember federationMember, int heightToCheckAt);
 
         int GetCounterChainConsensusHeight();
-
-        uint GetCounterChainGenesisBlockTime();
     }
 
     public class CollateralChecker : ICollateralChecker
@@ -66,8 +64,6 @@ namespace Stratis.Features.Collateral
         /// <summary>Consensus tip height of a counter chain.</summary>
         /// <remarks>All access should be protected by <see cref="locker"/>.</remarks>
         private int counterChainConsensusTipHeight;
-
-        private uint counterChainGenesisBlockTime;
 
         private Task updateCollateralContinuouslyTask;
 
@@ -123,14 +119,6 @@ namespace Stratis.Features.Collateral
             lock (this.locker)
             {
                 return this.counterChainConsensusTipHeight;
-            }
-        }
-
-        public uint GetCounterChainGenesisBlockTime()
-        {
-            lock (this.locker)
-            {
-                return this.counterChainGenesisBlockTime;
             }
         }
 
@@ -210,7 +198,6 @@ namespace Stratis.Features.Collateral
                 }
 
                 this.counterChainConsensusTipHeight = verboseAddressBalanceResult.ConsensusTipHeight;
-                this.counterChainGenesisBlockTime = verboseAddressBalanceResult.GenesisBlockTime;
             }
 
             this.collateralUpdated = true;

--- a/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
+++ b/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
@@ -79,7 +79,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
         {
             var mockClient = new Mock<IBlockStoreClient>();
             mockClient.Setup(x => x.GetVerboseAddressesBalancesDataAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new Bitcoin.Controllers.Models.VerboseAddressBalancesResult(100000, 0));
+                .ReturnsAsync(new Bitcoin.Controllers.Models.VerboseAddressBalancesResult(100000));
 
             node.Start(() =>
             {

--- a/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
@@ -4,14 +4,17 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;
+using Stratis.Bitcoin;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Features.PoA.Voting;
 using Stratis.Bitcoin.Interfaces;
+using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Features.Collateral;
+using Stratis.Features.Collateral.CounterChain;
 using Xunit;
 
 namespace Stratis.Features.FederatedPeg.Tests
@@ -19,13 +22,9 @@ namespace Stratis.Features.FederatedPeg.Tests
     public class CheckCollateralFullValidationRuleTests
     {
         private readonly CheckCollateralFullValidationRule rule;
-
         private readonly Mock<IInitialBlockDownloadState> ibdMock;
-
         private readonly Mock<ICollateralChecker> collateralCheckerMock;
-
         private readonly Mock<ISlotsManager> slotsManagerMock;
-
         private readonly RuleContext ruleContext;
 
         public CheckCollateralFullValidationRuleTests()
@@ -33,7 +32,6 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.ibdMock = new Mock<IInitialBlockDownloadState>();
             this.collateralCheckerMock = new Mock<ICollateralChecker>();
             this.slotsManagerMock = new Mock<ISlotsManager>();
-
 
             this.ibdMock.Setup(x => x.IsInitialBlockDownload()).Returns(false);
             this.slotsManagerMock
@@ -73,7 +71,12 @@ namespace Stratis.Features.FederatedPeg.Tests
             var commitmentHeightData = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(encodedHeight));
             block.Transactions[0].AddOutput(Money.Zero, commitmentHeightData);
 
-            this.rule = new CheckCollateralFullValidationRule(this.ibdMock.Object, this.collateralCheckerMock.Object, this.slotsManagerMock.Object, null, new Mock<IDateTimeProvider>().Object, new PoANetwork())
+            var fullnode = new Mock<IFullNode>();
+            fullnode.Setup(x => x.NodeService<CounterChainNetworkWrapper>(false)).Returns(new CounterChainNetworkWrapper(new StraxMain()));
+            var consensusManager = new Mock<IConsensusManager>();
+            fullnode.Setup(x => x.NodeService<IConsensusManager>(false)).Returns(consensusManager.Object);
+
+            this.rule = new CheckCollateralFullValidationRule(this.ibdMock.Object, this.collateralCheckerMock.Object, this.slotsManagerMock.Object, fullnode.Object, new Mock<IDateTimeProvider>().Object, new PoANetwork())
             {
                 Logger = logger
             };

--- a/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
@@ -73,7 +73,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             var commitmentHeightData = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(encodedHeight));
             block.Transactions[0].AddOutput(Money.Zero, commitmentHeightData);
 
-            this.rule = new CheckCollateralFullValidationRule(this.ibdMock.Object, this.collateralCheckerMock.Object, this.slotsManagerMock.Object, new Mock<IDateTimeProvider>().Object, new PoANetwork())
+            this.rule = new CheckCollateralFullValidationRule(this.ibdMock.Object, this.collateralCheckerMock.Object, this.slotsManagerMock.Object, null, new Mock<IDateTimeProvider>().Object, new PoANetwork())
             {
                 Logger = logger
             };

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -80,7 +80,7 @@ namespace Stratis.Features.FederatedPeg.Tests
         {
             var blockStoreClientMock = new Mock<IBlockStoreClient>();
 
-            var collateralData = new VerboseAddressBalancesResult(this.collateralCheckHeight + 1000, 0)
+            var collateralData = new VerboseAddressBalancesResult(this.collateralCheckHeight + 1000)
             {
                 BalancesData = new List<AddressIndexerData>()
                 {


### PR DESCRIPTION
Without this PR the `CheckCollateralFullValidationRule` will fail when trying to sync the Cirrus chain from scratch. This is due to the legacy Stratis-related collateral commitment heights embedded in the Cirrus chain. The rule is updated to selectively pass/fail the rule as follows:

I'm on STRAX.
1. If the block miner is on STRAX then check the collateral. Pass or Fail as appropriate.
2. The block miner is on STRAT. If most nodes were on STRAT (prev round) then they will check the rule. Pass the rule.
3. The miner is on STRAT and most nodes were on STRAX (prev round). Fail the rule.