### PR TITLE
Fix Script Registry

### DIFF
--- a/src/NBitcoin/IStandardScriptsRegistry.cs
+++ b/src/NBitcoin/IStandardScriptsRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NBitcoin.BitcoinCore;
 
 namespace NBitcoin
@@ -15,8 +16,12 @@ namespace NBitcoin
 
         bool IsStandardScriptPubKey(Network network, Script scriptPubKey);
 
+        bool IsStandardScriptSig(Network network, Script scriptSig, Script scriptPubKey = null);
+
         bool AreInputsStandard(Network network, Transaction tx, CoinsView coinsView);
 
         List<ScriptTemplate> GetScriptTemplates { get; }
+
+        ScriptTemplate this[Type key] { get; }
     }
 }

--- a/src/NBitcoin/StandardScriptsRegistry.cs
+++ b/src/NBitcoin/StandardScriptsRegistry.cs
@@ -1,5 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using NBitcoin.BitcoinCore;
+using NBitcoin.Policy;
 
 namespace NBitcoin
 {
@@ -14,37 +17,77 @@ namespace NBitcoin
         /// <param name="scriptTemplate">The standard script template to register.</param>
         public virtual void RegisterStandardScriptTemplate(ScriptTemplate scriptTemplate)
         {
-            StandardScripts.RegisterStandardScriptTemplate(scriptTemplate);
+            if (!this.GetScriptTemplates.Any(template => (template.Type == scriptTemplate.Type)))
+                this.GetScriptTemplates.Add(scriptTemplate);
+        }
+
+        public ScriptTemplate this[Type key]
+        {
+            get => this.GetScriptTemplates.FirstOrDefault(template => template.GetType() == key);
         }
 
         public virtual bool IsStandardTransaction(Transaction tx, Network network)
         {
-            return StandardScripts.IsStandardTransaction(tx, network);
+            return new StandardTransactionPolicy(network).Check(tx, null).Length == 0;
         }
 
         public virtual bool AreOutputsStandard(Network network, Transaction tx)
         {
-            return StandardScripts.AreOutputsStandard(network, tx);
+            return tx.Outputs.All(vout => this.IsStandardScriptPubKey(network, vout.ScriptPubKey));
         }
 
         public virtual ScriptTemplate GetTemplateFromScriptPubKey(Script script)
         {
-            return StandardScripts.GetTemplateFromScriptPubKey(script);
+            return this.GetScriptTemplates.FirstOrDefault(t => t.CheckScriptPubKey(script));
         }
 
         public virtual bool IsStandardScriptPubKey(Network network, Script scriptPubKey)
         {
-            return StandardScripts.IsStandardScriptPubKey(network, scriptPubKey);
+            return this.GetScriptTemplates.Any(template => template.CheckScriptPubKey(scriptPubKey));
         }
 
+        public virtual bool IsStandardScriptSig(Network network, Script scriptSig, Script scriptPubKey = null)
+        {
+            if (scriptPubKey == null)
+                return this.GetScriptTemplates.Any(template => template.CheckScriptSig(network, scriptSig, null));
+
+            ScriptTemplate template = this.GetTemplateFromScriptPubKey(scriptPubKey);
+            if (template == null)
+                return false;
+
+            return template.CheckScriptSig(network, scriptSig, scriptPubKey);
+        }
+
+        // Check transaction inputs, and make sure any
+        // pay-to-script-hash transactions are evaluating IsStandard scripts
+        //
+        // Why bother? To avoid denial-of-service attacks; an attacker
+        // can submit a standard HASH... OP_EQUAL transaction,
+        // which will get accepted into blocks. The redemption
+        // script can be anything; an attacker could use a very
+        // expensive-to-check-upon-redemption script like:
+        //   DUP CHECKSIG DROP ... repeated 100 times... OP_1
         public virtual bool AreInputsStandard(Network network, Transaction tx, CoinsView coinsView)
         {
-            return StandardScripts.AreInputsStandard(network, tx, coinsView);
+            if (tx.IsCoinBase)
+                return true; // Coinbases don't use vin normally
+
+            foreach (TxIn input in tx.Inputs)
+            {
+                TxOut prev = coinsView.GetOutputFor(input);
+                if (prev == null)
+                    return false;
+
+                if (!this.IsStandardScriptSig(network, input.ScriptSig, prev.ScriptPubKey))
+                    return false;
+            }
+
+            return true;
         }
 
         public virtual List<ScriptTemplate> GetScriptTemplates
         {
-            get { return null; }
+            get { throw new NotImplementedException(); }
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.PoA/Policies/PoAStandardScriptsRegistry.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Policies/PoAStandardScriptsRegistry.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 using NBitcoin;
-using NBitcoin.BitcoinCore;
 
 namespace Stratis.Bitcoin.Features.PoA.Policies
 {
@@ -12,50 +10,17 @@ namespace Stratis.Bitcoin.Features.PoA.Policies
     {
         public const int MaxOpReturnRelay = 153;
 
-        private readonly List<ScriptTemplate> standardTemplates = new List<ScriptTemplate>
+        private static readonly List<ScriptTemplate> scriptTemplates = new List<ScriptTemplate>
         {
-            PayToPubkeyHashTemplate.Instance,
-            PayToPubkeyTemplate.Instance,
-            PayToScriptHashTemplate.Instance,
-            PayToMultiSigTemplate.Instance,
-            PayToFederationTemplate.Instance,
-            new TxNullDataTemplate(MaxOpReturnRelay),
-            PayToWitTemplate.Instance
+            { new PayToPubkeyHashTemplate() },
+            { new PayToPubkeyTemplate() },
+            { new PayToScriptHashTemplate() },
+            { new PayToMultiSigTemplate() },
+            { new PayToFederationTemplate() },
+            { new TxNullDataTemplate(MaxOpReturnRelay) },
+            { new PayToWitTemplate() }
         };
 
-        public override List<ScriptTemplate> GetScriptTemplates => this.standardTemplates;
-
-        public override void RegisterStandardScriptTemplate(ScriptTemplate scriptTemplate)
-        {
-            if (!this.standardTemplates.Any(template => (template.Type == scriptTemplate.Type)))
-            {
-                this.standardTemplates.Add(scriptTemplate);
-            }
-        }
-
-        public override bool IsStandardTransaction(Transaction tx, Network network)
-        {
-            return base.IsStandardTransaction(tx, network);
-        }
-
-        public override bool AreOutputsStandard(Network network, Transaction tx)
-        {
-            return base.AreOutputsStandard(network, tx);
-        }
-
-        public override ScriptTemplate GetTemplateFromScriptPubKey(Script script)
-        {
-            return this.standardTemplates.FirstOrDefault(t => t.CheckScriptPubKey(script));
-        }
-
-        public override bool IsStandardScriptPubKey(Network network, Script scriptPubKey)
-        {
-            return base.IsStandardScriptPubKey(network, scriptPubKey);
-        }
-
-        public override bool AreInputsStandard(Network network, Transaction tx, CoinsView coinsView)
-        {
-            return base.AreInputsStandard(network, tx, coinsView);
-        }
+        public override List<ScriptTemplate> GetScriptTemplates => scriptTemplates;
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/AllowedScriptTypeRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/AllowedScriptTypeRule.cs
@@ -61,6 +61,25 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             if (network.StandardScriptsRegistry.IsStandardScriptPubKey(network, output.ScriptPubKey))
                 return;
 
+            if (PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
+                return;
+
+            // For cross-chain transfers	
+            if (PayToScriptHashTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
+                return;
+
+            // For cross-chain transfers	
+            if (PayToMultiSigTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
+                return;
+
+            // For cross-chain transfers	
+            if (PayToFederationTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
+                return;
+
+            // For cross-chain transfers	
+            if (network.StandardScriptsRegistry[typeof(TxNullDataTemplate)].CheckScriptPubKey(output.ScriptPubKey))
+                return;
+
             new ConsensusError("disallowed-output-script", "Only the following script types are allowed on smart contracts network: P2PKH, P2SH, P2MultiSig, OP_RETURN and smart contracts").Throw();
         }
 
@@ -69,7 +88,22 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             if (input.ScriptSig.IsSmartContractSpend())
                 return;
 
-            if (network.StandardScriptsRegistry.IsStandardScriptSig(network, input.ScriptSig))
+            if (PayToPubkeyHashTemplate.Instance.CheckScriptSig(network, input.ScriptSig))
+                return;
+
+            // Currently necessary to spend premine. Could be stricter.	
+            if (PayToPubkeyTemplate.Instance.CheckScriptSig(network, input.ScriptSig, null))
+                return;
+
+            if (PayToScriptHashTemplate.Instance.CheckScriptSig(network, input.ScriptSig, null))
+                return;
+
+            // For cross-chain transfers	
+            if (PayToMultiSigTemplate.Instance.CheckScriptSig(network, input.ScriptSig, null))
+                return;
+
+            // For cross-chain transfers	
+            if (PayToFederationTemplate.Instance.CheckScriptSig(network, input.ScriptSig, null))
                 return;
 
             new ConsensusError("disallowed-input-script", "Only the following script types are allowed on smart contracts network: P2PKH, P2SH, P2MultiSig, OP_RETURN and smart contracts").Throw();

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/AllowedScriptTypeRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/AllowedScriptTypeRule.cs
@@ -40,7 +40,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             {
                 foreach (TxOut output in transaction.Outputs)
                 {
-                    CheckOutput(output);
+                    CheckOutput(network, output);
                 }
 
                 foreach (TxIn input in transaction.Inputs)
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             }
         }
 
-        private static void CheckOutput(TxOut output)
+        private static void CheckOutput(Network network, TxOut output)
         {
             if (output.ScriptPubKey.IsSmartContractExec())
                 return;
@@ -58,23 +58,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             if (output.ScriptPubKey.IsSmartContractInternalCall())
                 return;
 
-            if (PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
-                return;
-
-            // For cross-chain transfers
-            if (PayToScriptHashTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
-                return;
-
-            // For cross-chain transfers
-            if (PayToMultiSigTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
-                return;
-
-            // For cross-chain transfers
-            if (PayToFederationTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
-                return;
-
-            // For cross-chain transfers
-            if (TxNullDataTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
+            if (network.StandardScriptsRegistry.IsStandardScriptPubKey(network, output.ScriptPubKey))
                 return;
 
             new ConsensusError("disallowed-output-script", "Only the following script types are allowed on smart contracts network: P2PKH, P2SH, P2MultiSig, OP_RETURN and smart contracts").Throw();
@@ -85,23 +69,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             if (input.ScriptSig.IsSmartContractSpend())
                 return;
 
-            if (PayToPubkeyHashTemplate.Instance.CheckScriptSig(network, input.ScriptSig))
+            if (network.StandardScriptsRegistry.IsStandardScriptSig(network, input.ScriptSig))
                 return;
-
-            // Currently necessary to spend premine. Could be stricter.
-            if (PayToPubkeyTemplate.Instance.CheckScriptSig(network, input.ScriptSig, null))
-                return;
-
-            if (PayToScriptHashTemplate.Instance.CheckScriptSig(network, input.ScriptSig, null))
-                return;
-
-            // For cross-chain transfers
-            if (PayToMultiSigTemplate.Instance.CheckScriptSig(network, input.ScriptSig, null))
-                return;
-
-            // For cross-chain transfers
-            if (PayToFederationTemplate.Instance.CheckScriptSig(network, input.ScriptSig, null))
-            return;
 
             new ConsensusError("disallowed-input-script", "Only the following script types are allowed on smart contracts network: P2PKH, P2SH, P2MultiSig, OP_RETURN and smart contracts").Throw();
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/AllowedScriptTypeRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/AllowedScriptTypeRule.cs
@@ -58,9 +58,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             if (output.ScriptPubKey.IsSmartContractInternalCall())
                 return;
 
-            if (network.StandardScriptsRegistry.IsStandardScriptPubKey(network, output.ScriptPubKey))
-                return;
-
             if (PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(output.ScriptPubKey))
                 return;
 

--- a/src/Stratis.Bitcoin.Networks/Policies/StraxStandardScriptsRegistry.cs
+++ b/src/Stratis.Bitcoin.Networks/Policies/StraxStandardScriptsRegistry.cs
@@ -12,30 +12,17 @@ namespace Stratis.Bitcoin.Networks.Policies
         public const int MaxOpReturnRelay = 83;
 
         // Need a network-specific version of the template list
-        private readonly List<ScriptTemplate> standardTemplates = new List<ScriptTemplate>
+        private static readonly List<ScriptTemplate> standardTemplates = new List<ScriptTemplate>
         {
-            PayToPubkeyHashTemplate.Instance,
-            PayToPubkeyTemplate.Instance,
-            PayToScriptHashTemplate.Instance,
-            PayToMultiSigTemplate.Instance,
-            PayToFederationTemplate.Instance,
+            new PayToPubkeyHashTemplate(),
+            new PayToPubkeyTemplate(),
+            new PayToScriptHashTemplate(),
+            new PayToMultiSigTemplate(),
+            new PayToFederationTemplate(),
             new TxNullDataTemplate(MaxOpReturnRelay),
-            PayToWitTemplate.Instance
+            new PayToWitTemplate()
         };
 
-        public override List<ScriptTemplate> GetScriptTemplates => this.standardTemplates;
-
-        public override void RegisterStandardScriptTemplate(ScriptTemplate scriptTemplate)
-        {
-            if (!this.standardTemplates.Any(template => (template.Type == scriptTemplate.Type)))
-            {
-                this.standardTemplates.Add(scriptTemplate);
-            }
-        }
-        
-        public override ScriptTemplate GetTemplateFromScriptPubKey(Script script)
-        {
-            return this.standardTemplates.FirstOrDefault(t => t.CheckScriptPubKey(script));
-        }
+        public override List<ScriptTemplate> GetScriptTemplates => standardTemplates;        
     }
 }


### PR DESCRIPTION
We are still referencing static variables such as:

`PayToPubkeyHashTemplate.Instance`

This PR represents the first step away from that approach.

Also, following this PR we should be able to write:

`network.StandardScriptsRegistry[typeof(PayToPubkeyHashTemplate)].CheckScriptPubKey(scriptPubKey)`

instead of:

`PayToPubkeyHashTemplate.Instance.CheckScriptPubKey(scriptPubKey)`

We may decide to take this one step further with:

`network.PayToPubkeyHashTemplate.CheckScriptPubKey(scriptPubKey)`