### PR TITLE
Fix RewardClaimer

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Distribution/RewardClaimer.cs
+++ b/src/Stratis.Features.FederatedPeg/Distribution/RewardClaimer.cs
@@ -64,7 +64,7 @@ namespace Stratis.Features.FederatedPeg.Distribution
 
             Block maturedBlock = chainedHeader.Block;
             if (maturedBlock == null)
-                maturedBlock = this.consensusManager.GetBlockData(maturedBlock.GetHash()).Block;
+                maturedBlock = this.consensusManager.GetBlockData(chainedHeader.HashBlock).Block;
 
             // If we still don't have the block data, just return.
             if (maturedBlock == null)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29645989/96336218-d6042980-10c9-11eb-8e4a-e4fbaa4b5b62.png)

If `maturedBlock` is null the `GetHash`  call will fail.