### PR TITLE
Don't search blocks prior to CollateralCommitmentActivationHeight

### DIFF
--- a/src/Stratis.Features.Collateral/CollateralFederationManager.cs
+++ b/src/Stratis.Features.Collateral/CollateralFederationManager.cs
@@ -234,7 +234,7 @@ namespace Stratis.Features.Collateral
             this.multisigMinersApplicabilityHeight = null;
             var commitmentHeightEncoder = new CollateralHeightCommitmentEncoder(this.logger);
 
-            ChainedHeader[] headers = consensusManager.Tip.EnumerateToGenesis().TakeWhile(h => h != this.lastBlockChecked).Reverse().ToArray();
+            ChainedHeader[] headers = consensusManager.Tip.EnumerateToGenesis().TakeWhile(h => h != this.lastBlockChecked && h.Height >= this.network.CollateralCommitmentActivationHeight).Reverse().ToArray();
 
             ChainedHeader first = BinarySearch.BinaryFindFirst<ChainedHeader>(headers, (chainedHeader) =>
             {


### PR DESCRIPTION
This is an important optimization. The binary search will not be optimal if we search the blocks before the collateral commitment heights became active. In fact, the sheer number of `null` values that will be encountered by `BinaryFindFirst`, will make the search almost O(n). This PR addresses that issue by not searching blocks prior to `CollateralCommitmentActivationHeight`.