### PR TITLE
Improvements to vote weight determination

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -50,8 +50,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             this.asyncProviderMock = new Mock<IAsyncProvider>();
 
+            var utxoIndexerMock = new Mock<IUtxoIndexer>();
+
             this.addressIndexer = new AddressIndexer(storeSettings, dataFolder, new ExtendedLoggerFactory(), this.network, stats.Object,
-                this.consensusManagerMock.Object, this.asyncProviderMock.Object, indexer, new DateTimeProvider());
+                this.consensusManagerMock.Object, this.asyncProviderMock.Object, indexer, new DateTimeProvider(), utxoIndexerMock.Object);
 
             this.genesisHeader = new ChainedHeader(this.network.GetGenesis().Header, this.network.GetGenesis().Header.GetHash(), 0);
         }

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -15,6 +15,7 @@ using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Configuration.Logging;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Controllers.Models;
+using Stratis.Bitcoin.Features.BlockStore.Models;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Utilities;
@@ -39,6 +40,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
         /// <summary>Returns verbose balances data.</summary>
         /// <param name="addresses">The set of addresses that will be queried.</param>
         VerboseAddressBalancesResult GetAddressIndexerState(string[] addresses);
+
+        LastBalanceDecreaseTransactionModel GetLastBalanceDecreaseTransaction(string address);
     }
 
     public class AddressIndexer : IAddressIndexer
@@ -106,6 +109,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
 
         private readonly IDateTimeProvider dateTimeProvider;
 
+        private readonly IUtxoIndexer utxoIndexer;
+
         private Task indexingTask;
 
         private DateTime lastFlushTime;
@@ -132,7 +137,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
         public const int SyncBuffer = 50;
 
         public AddressIndexer(StoreSettings storeSettings, DataFolder dataFolder, ILoggerFactory loggerFactory, Network network, INodeStats nodeStats,
-            IConsensusManager consensusManager, IAsyncProvider asyncProvider, ChainIndexer chainIndexer, IDateTimeProvider dateTimeProvider)
+            IConsensusManager consensusManager, IAsyncProvider asyncProvider, ChainIndexer chainIndexer, IDateTimeProvider dateTimeProvider, IUtxoIndexer utxoIndexer)
         {
             this.storeSettings = storeSettings;
             this.network = network;
@@ -141,6 +146,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
             this.consensusManager = consensusManager;
             this.asyncProvider = asyncProvider;
             this.dateTimeProvider = dateTimeProvider;
+            this.utxoIndexer = utxoIndexer;
             this.loggerFactory = loggerFactory;
             this.scriptAddressReader = new ScriptAddressReader();
 
@@ -627,6 +633,71 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
             }
 
             return result;
+        }
+
+        public LastBalanceDecreaseTransactionModel GetLastBalanceDecreaseTransaction(string address)
+        {
+            if (address == null)
+                return null;
+
+            (bool isQueryable, string reason) = this.IsQueryable();
+
+            if (!isQueryable)
+                return null;
+
+            int lastBalanceHeight;
+
+            lock (this.lockObject)
+            {
+                AddressIndexerData indexData = this.addressIndexRepository.GetOrCreateAddress(address);
+
+                AddressBalanceChange lastBalanceUpdate = indexData.BalanceChanges.Where(a => !a.Deposited).OrderByDescending(b => b.BalanceChangedHeight).FirstOrDefault();
+
+                if (lastBalanceUpdate == null)
+                    return null;
+
+                lastBalanceHeight = lastBalanceUpdate.BalanceChangedHeight;
+            }
+
+            // Height 0 is used as a placeholder height for compacted address balance records, so ignore them if they are the only record.
+            if (lastBalanceHeight == 0)
+                return null;
+            
+            ChainedHeader header = this.chainIndexer.GetHeader(lastBalanceHeight);
+
+            if (header == null)
+                return null;
+
+            Block block = this.consensusManager.GetBlockData(header.HashBlock).Block;
+
+            if (block == null)
+                return null;
+
+            // Get the UTXO snapshot as of one block lower than the last balance change, so that we are definitely able to look up the inputs of each transaction in the next block.
+            ReconstructedCoinviewContext utxos = this.utxoIndexer.GetCoinviewAtHeight(lastBalanceHeight - 1);
+
+            Transaction foundTransaction = null;
+
+            foreach (Transaction transaction in block.Transactions)
+            {
+                if (transaction.IsCoinBase)
+                    continue;
+
+                foreach (TxIn txIn in transaction.Inputs)
+                {
+                    Transaction prevTx = utxos.Transactions[txIn.PrevOut.Hash];
+
+                    foreach (TxOut txOut in prevTx.Outputs)
+                    {
+                        if (this.scriptAddressReader.GetAddressFromScriptPubKey(this.network, txOut.ScriptPubKey) == address)
+                        {
+                            foundTransaction = transaction;
+                        }
+                    }
+                }
+            }
+
+            return foundTransaction == null ? null : new LastBalanceDecreaseTransactionModel() { BlockHeight = lastBalanceHeight, TransactionHex = foundTransaction.ToHex() };
         }
 
         private (bool isQueryable, string reason) IsQueryable()

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -697,7 +697,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
                 }
             }
 
-            return foundTransaction == null ? null : new LastBalanceDecreaseTransactionModel() { BlockHeight = lastBalanceHeight, TransactionHex = foundTransaction.ToHex() };
+            return foundTransaction == null ? null : new LastBalanceDecreaseTransactionModel() { BlockHeight = lastBalanceHeight, Transaction = new TransactionVerboseModel(foundTransaction, this.network) };
         }
 
         private (bool isQueryable, string reason) IsQueryable()

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
@@ -23,6 +23,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         public const string GetBlock = "block";
         public const string GetBlockCount = "getblockcount";
         public const string GetUtxoSet = "getutxoset";
+        public const string GetLastBalanceDecreaseTransaction = "getlastbalanceupdatetransaction";
     }
 
     /// <summary>Controller providing operations on a blockstore.</summary>
@@ -266,6 +267,25 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
                 }
 
                 return this.Json(outputs);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        [Route(BlockStoreRouteEndPoint.GetLastBalanceDecreaseTransaction)]
+        [HttpGet]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        public IActionResult GetLastBalanceUpdateTransaction(string address)
+        {
+            try
+            {
+                LastBalanceDecreaseTransactionModel result = this.addressIndexer.GetLastBalanceDecreaseTransaction(address);
+
+                return this.Json(result);
             }
             catch (Exception e)
             {

--- a/src/Stratis.Bitcoin.Features.BlockStore/Models/LastBalanceDecreaseTransactionModel.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Models/LastBalanceDecreaseTransactionModel.cs
@@ -1,0 +1,11 @@
+﻿namespace Stratis.Bitcoin.Features.BlockStore.Models
+{
+    public class LastBalanceDecreaseTransactionModel
+    {
+        public string TransactionHex { get; set; }
+
+        public int BlockHeight { get; set; }
+
+        //public long DecreasedBy { get; set; }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.BlockStore/Models/LastBalanceDecreaseTransactionModel.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Models/LastBalanceDecreaseTransactionModel.cs
@@ -1,11 +1,11 @@
-﻿namespace Stratis.Bitcoin.Features.BlockStore.Models
+﻿using Stratis.Bitcoin.Controllers.Models;
+
+namespace Stratis.Bitcoin.Features.BlockStore.Models
 {
     public class LastBalanceDecreaseTransactionModel
     {
-        public string TransactionHex { get; set; }
+        public TransactionVerboseModel Transaction { get; set; }
 
         public int BlockHeight { get; set; }
-
-        //public long DecreasedBy { get; set; }
     }
 }


### PR DESCRIPTION
This leverages the ability to look up the last balance decrease transaction when computing vote weight. If the decrease was due to a burn transaction the burn amount (if greater) will be used instead of the original vote weight.