### PR TITLE
Update vote extraction

### DIFF
--- a/src/SwapExtractionTool/BlockExplorerClient.cs
+++ b/src/SwapExtractionTool/BlockExplorerClient.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Flurl;
+using Flurl.Http;
+using Newtonsoft.Json;
+
+namespace SwapExtractionTool
+{
+    public class BlockExplorerClient : IDisposable
+    {
+        private readonly string baseUrl;
+
+        private HttpClient httpClient;
+
+        public BlockExplorerClient(string baseUrl)
+        {
+            this.baseUrl = baseUrl;
+            this.httpClient = new HttpClient();
+        }
+
+        public TransactionModel GetTransaction(string txId)
+        {
+            TransactionModel result = $"{this.baseUrl}"
+                .AppendPathSegment($"transactions/")
+                .AppendPathSegment($"{txId}")
+                .GetJsonAsync<TransactionModel>().GetAwaiter().GetResult();
+
+            return result;
+        }
+
+        public void Dispose()
+        {
+            this.httpClient?.Dispose();
+        }
+    }
+
+    // Auto-generated models
+
+    public class Amount
+    {
+        public long satoshi { get; set; }
+    }
+
+    public class Fee
+    {
+        public int satoshi { get; set; }
+    }
+
+    public class Amount2
+    {
+        public long satoshi { get; set; }
+    }
+
+    public class In
+    {
+        public string hash { get; set; }
+        public Amount2 amount { get; set; }
+        public int n { get; set; }
+    }
+
+    public class Amount3
+    {
+        public long satoshi { get; set; }
+    }
+
+    public class Out
+    {
+        public string hash { get; set; }
+        public Amount3 amount { get; set; }
+        public int n { get; set; }
+    }
+
+    public class TransactionModel
+    {
+        public string hash { get; set; }
+        public bool isCoinbase { get; set; }
+        public bool isCoinstake { get; set; }
+        public bool isSmartContract { get; set; }
+        public Amount amount { get; set; }
+        public Fee fee { get; set; }
+        public int height { get; set; }
+        public DateTime firstSeen { get; set; }
+        public int time { get; set; }
+        public bool spent { get; set; }
+
+        [JsonProperty(PropertyName = "in")]
+        public List<In> _in { get; set; }
+
+        [JsonProperty(PropertyName = "out")]
+        public List<Out> _out { get; set; }
+        
+        public int confirmations { get; set; }
+    }
+}

--- a/src/SwapExtractionTool/Program.cs
+++ b/src/SwapExtractionTool/Program.cs
@@ -12,6 +12,7 @@ namespace SwapExtractionTool
             int stratisNetworkApiPort;
             int startBlock = 0;
             Network straxNetwork;
+            string blockExplorerBaseUrl;
 
             if (args.Contains("-testnet"))
             {
@@ -19,6 +20,7 @@ namespace SwapExtractionTool
 
                 stratisNetworkApiPort = 38221;
                 straxNetwork = new StraxTest();
+                blockExplorerBaseUrl = "https://stratistestindexer1.azurewebsites.net/api/v1/";
             }
             else
             {
@@ -26,6 +28,7 @@ namespace SwapExtractionTool
 
                 stratisNetworkApiPort = 37221;
                 straxNetwork = new StraxMain();
+                blockExplorerBaseUrl = "https://stratismainindexer1.azurewebsites.net/api/v1/";
             }
 
             var arg = args.FirstOrDefault(a => a.StartsWith("-startfrom"));
@@ -40,7 +43,8 @@ namespace SwapExtractionTool
 
             if (args.Contains("-swapvote") || args.Contains("-collateralvote"))
             {
-                var service = new VoteExtractionService(stratisNetworkApiPort, straxNetwork);
+                var blockExplorerClient = new BlockExplorerClient(blockExplorerBaseUrl);
+                var service = new VoteExtractionService(stratisNetworkApiPort, straxNetwork, blockExplorerClient);
 
                 if (args.Contains("-collateralvote"))
                     await service.RunAsync(VoteType.CollateralVote, startBlock);

--- a/src/SwapExtractionTool/VoteExtractionService.cs
+++ b/src/SwapExtractionTool/VoteExtractionService.cs
@@ -5,7 +5,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Flurl;
 using Flurl.Http;
-using Microsoft.AspNetCore.Server.IIS.Core;
 using NBitcoin;
 using Stratis.Bitcoin.Controllers.Models;
 using Stratis.Bitcoin.Features.BlockStore.Controllers;


### PR DESCRIPTION
Instead of trying to maintain all the necessary indexes locally, this leverages the block explorer for looking up the inputs of burn transactions. If it recognises that an address with an existing vote funded the burn transaction, it amends the vote weight for that address accordingly. If multiple vote addresses are in the inputs of a burn, only 1 will be assigned the total value of the burn and the rest are reset to their final detected balance per the address indexer.