### PR TITLE
Cirrus genesis is unchangeable history

### DIFF
--- a/src/Stratis.Bitcoin.Networks/StraxRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StraxRegTest.cs
@@ -83,7 +83,7 @@ namespace Stratis.Bitcoin.Networks
             var cirrusFederationMnemonics = new[] {
                 "ensure feel swift crucial bridge charge cloud tell hobby twenty people mandate",
                 "quiz sunset vote alley draw turkey hill scrap lumber game differ fiction",
-                "fat chalk grant major hair possible adjust talent magnet lobster retreat siren"
+                "exchange rent bronze pole post hurry oppose drama eternal voice client state"
                }.Select(m => new Mnemonic(m, Wordlist.English)).ToList();
 
             // Will replace the last multisig member.

--- a/src/Stratis.Bitcoin.Networks/StraxRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StraxRegTest.cs
@@ -82,10 +82,18 @@ namespace Stratis.Bitcoin.Networks
             // Cirrus federation.
             var cirrusFederationMnemonics = new[] {
                 "ensure feel swift crucial bridge charge cloud tell hobby twenty people mandate",
-                "blame similar caution exit urge combine oak fat maximum link eyebrow elbow"
+                "quiz sunset vote alley draw turkey hill scrap lumber game differ fiction",
+                "fat chalk grant major hair possible adjust talent magnet lobster retreat siren"
                }.Select(m => new Mnemonic(m, Wordlist.English)).ToList();
 
-            var cirrusFederationKeys = cirrusFederationMnemonics.Select(m => m.DeriveExtKey().PrivateKey).ToList();
+            // Will replace the last multisig member.
+            var newFederationMemberMnemonics = new string[]
+            {
+                "fat chalk grant major hair possible adjust talent magnet lobster retreat siren"
+            }.Select(m => new Mnemonic(m, Wordlist.English)).ToList();
+
+            // Mimic the code found in CirrusRegTest.
+            var cirrusFederationKeys = cirrusFederationMnemonics.Take(2).Concat(newFederationMemberMnemonics).Select(m => m.DeriveExtKey().PrivateKey).ToList();
 
             List<PubKey> cirrusFederationPubKeys = cirrusFederationKeys.Select(k => k.PubKey).ToList();
 

--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -117,7 +117,8 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.federationKeys = new[]
             {
                 "ensure feel swift crucial bridge charge cloud tell hobby twenty people mandate",
-                "blame similar caution exit urge combine oak fat maximum link eyebrow elbow",
+                "quiz sunset vote alley draw turkey hill scrap lumber game differ fiction",
+                "exchange rent bronze pole post hurry oppose drama eternal voice client state"
             }.Select(m => HdOperations.GetExtendedKey(m)).ToArray();
 
             SetExtendedKey(0);

--- a/src/Stratis.Features.FederatedPeg.Tests/VerifyMultisigAddresses.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/VerifyMultisigAddresses.cs
@@ -19,24 +19,24 @@ namespace Stratis.Features.FederatedPeg.Tests
             string[] expectedFederationIds = new[] {
                 "0272ef88df1ac2bc9b14b05ced742c2a9c2f76e48ccb92258136750d0ae2af3859",
                 "022c7d264dd56381d51526365f8e439a68fb8b5cd0272e073ee4047999e0bb034f",
-                "009b9de39718cf6042d336e1fff3676fd9a651376399efb5472b0b1733769341e1"
+                "0347f6ba6232037a68ce2b8ac988c07c071eee1e7edd0e6bb9b3dbda22772ad96a"
             };
             string[] expectedMultisigScripts = new[]
             {
                 "0272ef88df1ac2bc9b14b05ced742c2a9c2f76e48ccb92258136750d0ae2af3859 OP_FEDERATION OP_CHECKMULTISIG",
                 "022c7d264dd56381d51526365f8e439a68fb8b5cd0272e073ee4047999e0bb034f OP_FEDERATION OP_CHECKMULTISIG",
-                "009b9de39718cf6042d336e1fff3676fd9a651376399efb5472b0b1733769341e1 OP_FEDERATION OP_CHECKMULTISIG"
+                "0347f6ba6232037a68ce2b8ac988c07c071eee1e7edd0e6bb9b3dbda22772ad96a OP_FEDERATION OP_CHECKMULTISIG"
             };
             string[] expectedPaymentScripts = new[]
             {
                 "OP_HASH160 36f8bb703df2de2b4ddc0448dd28aac5d24a0e6d OP_EQUAL",
                 "OP_HASH160 44026086e900f9f3bdd34ed2e9436ceef05c09b3 OP_EQUAL",
-                "OP_HASH160 a379dfdfd8a6cb4b7fe522fa9d5a695cece3901a OP_EQUAL"
+                "OP_HASH160 9244ef1a1a829e2e94a652e071cb22d600ed4c40 OP_EQUAL"
             };
             string[] expectedAddresses = new[] {
                 "yRL7Jn1Ytgc6g2k5Sidh6K4vf7cKTj6n45",
                 "tD8CqzmXqjcTdX5G2y9WNMzbR5qUqiMFda",
-                "tMpzC3oa7ktseYpvRAihp4F9RJAYSB7WWB"
+                "tLG1HR71iEDKbKkvB8sH3Gy6HLF8o4Pnim"
             };
             string[] federationIds = networks.Select(n => Encoders.Hex.EncodeData(n.Federations.GetOnlyFederation().Id.ToBytes())).ToArray();
             Script[] multisigScripts = federationIds.Select((id, n) => networks[n].Federations.GetOnlyFederation().MultisigScript).ToArray();

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -72,7 +72,8 @@ namespace Stratis.Sidechains.Networks
 
             this.FederationMnemonics = new[] {
                 "ensure feel swift crucial bridge charge cloud tell hobby twenty people mandate",
-                "blame similar caution exit urge combine oak fat maximum link eyebrow elbow"
+                "quiz sunset vote alley draw turkey hill scrap lumber game differ fiction",
+                "exchange rent bronze pole post hurry oppose drama eternal voice client state"
             }.Select(m => new Mnemonic(m, Wordlist.English)).ToList();
 
             this.FederationKeys = this.FederationMnemonics.Select(m => m.DeriveExtKey().PrivateKey).ToList();
@@ -99,7 +100,8 @@ namespace Stratis.Sidechains.Networks
             this.Federations = new Federations();
 
             // Default transaction-signing keys!
-            this.Federations.RegisterFederation(new Federation(federationPubKeys.ToArray()));
+            // Use the new keys as the old keys should never be used by the new opcode.
+            this.Federations.RegisterFederation(new Federation(newFederationPubKeys.ToArray()));
 
             var consensusOptions = new PoAConsensusOptions(
                 maxBlockBaseSize: 1_000_000,


### PR DESCRIPTION
The `CirrusRegTest` class was recently updated to change the genesis members. This should not be allowed as the Cirrus genesis members are unchangeable history.

This PR reverts the `CirrusRegTest` members to what they were known to be in the SBFN code base which overlaps the Cirrus legacy.