### PR TITLE
Fix Withdrawal Extractor

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTestBase.cs
@@ -166,7 +166,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.federatedPegSettings.MultiSigRedeemScript.Returns(this.redeemScript);
             this.federatedPegSettings.MultiSigAddress.Returns(this.redeemScript.Hash.GetAddress(this.network));
             this.federatedPegSettings.PublicKey.Returns(this.extendedKey.PrivateKey.PubKey.ToHex());
-            this.withdrawalExtractor = new WithdrawalExtractor(this.loggerFactory, this.federatedPegSettings, this.opReturnDataReader, this.network);
+            this.withdrawalExtractor = new WithdrawalExtractor(this.federatedPegSettings, this.opReturnDataReader, this.network);
         }
 
         protected (Transaction, ChainedHeader) AddFundingTransaction(Money[] amounts)

--- a/src/Stratis.Features.FederatedPeg.Tests/WithdrawalExtractorTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/WithdrawalExtractorTests.cs
@@ -49,7 +49,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.transactionBuilder = new TestMultisigTransactionBuilder(this.addressHelper);
 
             this.withdrawalExtractor = new WithdrawalExtractor(
-                this.loggerFactory, this.settings, this.opReturnDataReader, this.network);
+                this.settings, this.opReturnDataReader, this.network);
         }
 
         // TODO: Will depend on decision made on backlog issue https://github.com/stratisproject/FederatedSidechains/issues/124

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalExtractor.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalExtractor.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Features.FederatedPeg.Interfaces;
 using TracerAttributes;
@@ -39,17 +38,13 @@ namespace Stratis.Features.FederatedPeg.TargetChain
 
         private readonly Network network;
 
-        private readonly ILogger logger;
-
         private readonly BitcoinAddress multisigAddress;
 
         public WithdrawalExtractor(
-            ILoggerFactory loggerFactory,
             IFederatedPegSettings federatedPegSettings,
             IOpReturnDataReader opReturnDataReader,
             Network network)
         {
-            this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.multisigAddress = federatedPegSettings.MultiSigAddress;
             this.opReturnDataReader = opReturnDataReader;
             this.network = network;
@@ -66,7 +61,6 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             foreach (Transaction transaction in block.Transactions)
             {
                 IWithdrawal withdrawal = this.ExtractWithdrawalFromTransaction(transaction, block.GetHash(), blockHeight);
-
                 if (withdrawal != null)
                     withdrawals.Add(withdrawal);
             }
@@ -80,25 +74,46 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             if (transaction.IsCoinBase)
                 return null;
 
-            // Withdrawal has a specific structure.
-            if (transaction.Outputs.Count != ExpectedNumberOfOutputsNoChange && transaction.Outputs.Count != ExpectedNumberOfOutputsChange)
-                return null;
-
             if (!this.IsOnlyFromMultisig(transaction))
                 return null;
 
             if (!this.opReturnDataReader.TryGetTransactionId(transaction, out string depositId))
                 return null;
 
-            TxOut targetAddressOutput = transaction.Outputs.SingleOrDefault(this.IsTargetAddressCandidate);
-            if (targetAddressOutput == null)
+            // This is not a withdrawal transaction.
+            if (transaction.Outputs.Count < ExpectedNumberOfOutputsNoChange)
                 return null;
+
+            Money withdrawalAmount = null;
+            string targetAddress = null;
+
+            // Cross Chain transfers either has 2 or 3 outputs.
+            if (transaction.Outputs.Count == ExpectedNumberOfOutputsNoChange || transaction.Outputs.Count == ExpectedNumberOfOutputsChange)
+            {
+                TxOut targetAddressOutput = transaction.Outputs.SingleOrDefault(this.IsTargetAddressCandidate);
+                if (targetAddressOutput == null)
+                    return null;
+
+                withdrawalAmount = targetAddressOutput.Value;
+                targetAddress = targetAddressOutput.ScriptPubKey.GetDestinationAddress(this.network).ToString();
+            }
+
+            // Reward distribution trnsactions will have more than 3 outputs.
+            if (transaction.Outputs.Count > ExpectedNumberOfOutputsChange)
+            {
+                IEnumerable<TxOut> txOuts = transaction.Outputs.Where(output => output.ScriptPubKey != this.multisigAddress.ScriptPubKey && !output.ScriptPubKey.IsUnspendable);
+                if (!txOuts.Any())
+                    return null;
+
+                withdrawalAmount = txOuts.Sum(t => t.Value);
+                targetAddress = this.network.CirrusRewardDummyAddress;
+            }
 
             var withdrawal = new Withdrawal(
                 uint256.Parse(depositId),
                 transaction.GetHash(),
-                targetAddressOutput.Value,
-                targetAddressOutput.ScriptPubKey.GetDestinationAddress(this.network).ToString(),
+                withdrawalAmount,
+                targetAddress,
                 blockHeight,
                 blockHash);
 

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalExtractor.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalExtractor.cs
@@ -13,8 +13,6 @@ namespace Stratis.Features.FederatedPeg.TargetChain
     /// </summary>
     public interface IWithdrawalExtractor
     {
-        IWithdrawal ExtractDistributionWithdrawal(Transaction transaction, uint256 blockHash, int blockHeight);
-
         IReadOnlyList<IWithdrawal> ExtractWithdrawalsFromBlock(Block block, int blockHeight);
 
         IWithdrawal ExtractWithdrawalFromTransaction(Transaction transaction, uint256 blockHash, int blockHeight);
@@ -87,7 +85,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             Money withdrawalAmount = null;
             string targetAddress = null;
 
-            // Cross Chain transfers either has 2 or 3 outputs.
+            // Cross chain transfers either has 2 or 3 outputs.
             if (transaction.Outputs.Count == ExpectedNumberOfOutputsNoChange || transaction.Outputs.Count == ExpectedNumberOfOutputsChange)
             {
                 TxOut targetAddressOutput = transaction.Outputs.SingleOrDefault(this.IsTargetAddressCandidate);
@@ -97,10 +95,9 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 withdrawalAmount = targetAddressOutput.Value;
                 targetAddress = targetAddressOutput.ScriptPubKey.GetDestinationAddress(this.network).ToString();
             }
-
-            // Reward distribution trnsactions will have more than 3 outputs.
-            if (transaction.Outputs.Count > ExpectedNumberOfOutputsChange)
+            else
             {
+                // Reward distribution trnsactions will have more than 3 outputs.
                 IEnumerable<TxOut> txOuts = transaction.Outputs.Where(output => output.ScriptPubKey != this.multisigAddress.ScriptPubKey && !output.ScriptPubKey.IsUnspendable);
                 if (!txOuts.Any())
                     return null;
@@ -116,39 +113,6 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 targetAddress,
                 blockHeight,
                 blockHash);
-
-            return withdrawal;
-        }
-
-        public IWithdrawal ExtractDistributionWithdrawal(Transaction transaction, uint256 blockHash, int blockHeight)
-        {
-            // Coinbase can't contain withdrawals.
-            if (transaction.IsCoinBase)
-                return null;
-
-            // Distribution withdrawal transactions has more outputs.
-            if (transaction.Outputs.Count <= ExpectedNumberOfOutputsChange)
-                return null;
-
-            if (!this.IsOnlyFromMultisig(transaction))
-                return null;
-
-            if (!this.opReturnDataReader.TryGetTransactionId(transaction, out string depositId))
-                return null;
-
-            Withdrawal withdrawal = null;
-            IEnumerable<TxOut> txOuts = transaction.Outputs.Where(output => output.ScriptPubKey != this.multisigAddress.ScriptPubKey && !output.ScriptPubKey.IsUnspendable);
-            if (txOuts.Any())
-            {
-                var targetOutputValue = txOuts.Sum(t => t.Value);
-                withdrawal = new Withdrawal(
-                    uint256.Parse(depositId),
-                    transaction.GetHash(),
-                    targetOutputValue,
-                    this.network.CirrusRewardDummyAddress,
-                    blockHeight,
-                    blockHash);
-            }
 
             return withdrawal;
         }

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalHistoryProvider.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalHistoryProvider.cs
@@ -32,7 +32,6 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         /// <param name="mempoolManager">Mempool which provides information about transactions in the mempool.</param>
         /// <param name="loggerFactory">Logger factory.</param>
         /// <param name="counterChainNetworkWrapper">Counter chain network.</param>
-        /// 
         public WithdrawalHistoryProvider(
             Network network,
             IFederatedPegSettings federatedPegSettings,

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -470,12 +470,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 }
 
                 // Extract the withdrawal from the transaction (if any).
-                IWithdrawal withdrawal = null;
-                if (isDistribution)
-                    withdrawal = this.withdrawalExtractor.ExtractDistributionWithdrawal(transaction, blockHash, blockHeight ?? 0);
-                else
-                    withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(transaction, blockHash, blockHeight ?? 0);
-
+                IWithdrawal withdrawal = this.withdrawalExtractor.ExtractWithdrawalFromTransaction(transaction, blockHash, blockHeight ?? 0);
                 if (withdrawal != null)
                 {
                     // Exit if already present and included in a block.


### PR DESCRIPTION
This fixes the CCTS not processing distribution withdrawal transactions properly cause of the number of outputs check.

This is still a bit hacky as ideally we would want a way to identify a distribution withdrawal transaction a bit more explicitly but yeah this is good enough for now.