### PR TITLE
Show hex of transaction failing NonMandatoryScriptVerifyFlagFailed

### DIFF
--- a/src/Stratis.Bitcoin.Features.MemoryPool/Rules/CheckAllInputsMempoolRule.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/Rules/CheckAllInputsMempoolRule.cs
@@ -117,7 +117,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Rules
                             this.logger.LogTrace("(-)[FAIL_NON_MANDATORY_SCRIPT_VERIFY]");
                             // TODO: Check what this actually means in Core's logic. If it is on testnet/regtest and RequireStandard is false, is the transaction still rejected?
                             context.State.Fail(MempoolErrors.NonMandatoryScriptVerifyFlagFailed, 
-                                $"{ctx.Error.ToString()} : Transaction = { tx.ToHex() } : ScriptVerifyFlags = { scriptVerify }").Throw();
+                                $"{ctx.Error.ToString()} : Transaction = { tx.ToHex() } : scriptVerify = { scriptVerify } : ctx.scriptVerify = { ctx.ScriptVerify }").Throw();
                         }
                     }
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool/Rules/CheckAllInputsMempoolRule.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/Rules/CheckAllInputsMempoolRule.cs
@@ -115,9 +115,11 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Rules
                         if (ctx.VerifyScript(input.ScriptSig, txout.ScriptPubKey, checker))
                         {
                             this.logger.LogTrace("(-)[FAIL_NON_MANDATORY_SCRIPT_VERIFY]");
+                            this.logger.LogDebug("Failed non-mandatory script verify: Transaction = {0}, scriptVerify = {1}, ctx.scriptVerify = {2}",
+                                tx.ToHex(), scriptVerify, ctx.ScriptVerify);
+
                             // TODO: Check what this actually means in Core's logic. If it is on testnet/regtest and RequireStandard is false, is the transaction still rejected?
-                            context.State.Fail(MempoolErrors.NonMandatoryScriptVerifyFlagFailed, 
-                                $"{ctx.Error.ToString()} : Transaction = { tx.ToHex() } : scriptVerify = { scriptVerify } : ctx.scriptVerify = { ctx.ScriptVerify }").Throw();
+                            context.State.Fail(MempoolErrors.NonMandatoryScriptVerifyFlagFailed, ctx.Error.ToString()).Throw();
                         }
                     }
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool/Rules/CheckAllInputsMempoolRule.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/Rules/CheckAllInputsMempoolRule.cs
@@ -116,7 +116,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Rules
                         {
                             this.logger.LogTrace("(-)[FAIL_NON_MANDATORY_SCRIPT_VERIFY]");
                             // TODO: Check what this actually means in Core's logic. If it is on testnet/regtest and RequireStandard is false, is the transaction still rejected?
-                            context.State.Fail(MempoolErrors.NonMandatoryScriptVerifyFlagFailed, ctx.Error.ToString()).Throw();
+                            context.State.Fail(MempoolErrors.NonMandatoryScriptVerifyFlagFailed, 
+                                $"{ctx.Error.ToString()} : Transaction = { tx.ToHex() }").Throw();
                         }
                     }
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool/Rules/CheckAllInputsMempoolRule.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/Rules/CheckAllInputsMempoolRule.cs
@@ -117,7 +117,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Rules
                             this.logger.LogTrace("(-)[FAIL_NON_MANDATORY_SCRIPT_VERIFY]");
                             // TODO: Check what this actually means in Core's logic. If it is on testnet/regtest and RequireStandard is false, is the transaction still rejected?
                             context.State.Fail(MempoolErrors.NonMandatoryScriptVerifyFlagFailed, 
-                                $"{ctx.Error.ToString()} : Transaction = { tx.ToHex() }").Throw();
+                                $"{ctx.Error.ToString()} : Transaction = { tx.ToHex() } : ScriptVerifyFlags = { scriptVerify }").Throw();
                         }
                     }
 


### PR DESCRIPTION
Show hex of transaction failing with `NonMandatoryScriptVerifyFlagFailed`. Includes the `ScriptVerify` flag.