### PR TITLE
Use the whitelist and not bind list to check whitelisting during IBD

### DIFF
--- a/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
+++ b/src/Stratis.Bitcoin/P2P/Peer/NetworkPeerServer.cs
@@ -236,7 +236,7 @@ namespace Stratis.Bitcoin.P2P.Peer
 
             var clientLocalEndPoint = tcpClient.Client.LocalEndPoint as IPEndPoint;
 
-            bool endpointCanBeWhiteListed = this.connectionManagerSettings.Bind.Where(x => x.Whitelisted).Any(x => x.Endpoint.MapToIpv6().Contains(clientLocalEndPoint));
+            bool endpointCanBeWhiteListed = this.connectionManagerSettings.Whitelist.Any(x => x.MatchIpOnly(clientRemoteEndPoint));
 
             if (endpointCanBeWhiteListed)
             {


### PR DESCRIPTION
- Previously the filtering was done using the bind list, which is incorrect. This changes the check to go against the -whitelist and matches the IPs, not ports.