### PR TITLE
Remove PoAHeaderSignatureRule for CirrusD

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -27,11 +27,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
         private VotingManager votingManager;
 
-        private IFederationManager federationManager;
-
         private IChainState chainState;
-
-        private PoAConsensusFactory consensusFactory;
 
         private Network network;
 
@@ -45,10 +41,8 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             this.slotsManager = engine.SlotsManager;
             this.validator = engine.PoaHeaderValidator;
             this.votingManager = engine.VotingManager;
-            this.federationManager = engine.FederationManager;
             this.chainState = engine.ChainState;
             this.network = this.Parent.Network;
-            this.consensusFactory = (PoAConsensusFactory)this.network.Consensus.ConsensusFactory;
 
             this.maxReorg = this.network.Consensus.MaxReorgLength;
             this.votingEnabled = ((PoAConsensusOptions)this.network.Consensus.Options).VotingEnabled;

--- a/src/Stratis.Features.Collateral/CollateralFeature.cs
+++ b/src/Stratis.Features.Collateral/CollateralFeature.cs
@@ -46,6 +46,7 @@ namespace Stratis.Features.Collateral
             {
                 // Remove the PoAHeaderSignatureRule if this is not a miner as CirrusD has no concept of the federation and
                 // any modifications of it.
+                // This rule is only required to ensure that the mining nodes don't mine on top of bad blocks. A consensus error will prevent that from happening."
                 // TODO: The code should be refactored at some point so that we dont do this hack.
                 var indexOf = fullNodeBuilder.Network.Consensus.ConsensusRules.FullValidationRules.IndexOf(typeof(PoAHeaderSignatureRule));
                 fullNodeBuilder.Network.Consensus.ConsensusRules.FullValidationRules.RemoveAt(indexOf);

--- a/src/Stratis.Features.Collateral/CollateralFeature.cs
+++ b/src/Stratis.Features.Collateral/CollateralFeature.cs
@@ -4,6 +4,7 @@ using Stratis.Bitcoin.Builder;
 using Stratis.Bitcoin.Builder.Feature;
 using Stratis.Bitcoin.Features.Miner;
 using Stratis.Bitcoin.Features.PoA;
+using Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules;
 using Stratis.Bitcoin.Features.SmartContracts;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Features.Collateral.CounterChain;
@@ -41,6 +42,15 @@ namespace Stratis.Features.Collateral
         // Both Cirrus Peg and Cirrus Miner calls this.
         public static IFullNodeBuilder CheckForPoAMembersCollateral(this IFullNodeBuilder fullNodeBuilder, bool isMiner)
         {
+            if (!isMiner)
+            {
+                // Remove the PoAHeaderSignatureRule if this is not a miner as CirrusD has no concept of the federation and
+                // any modifications of it.
+                // TODO: The code should be refactored at some point so that we dont do this hack.
+                var indexOf = fullNodeBuilder.Network.Consensus.ConsensusRules.FullValidationRules.IndexOf(typeof(PoAHeaderSignatureRule));
+                fullNodeBuilder.Network.Consensus.ConsensusRules.FullValidationRules.RemoveAt(indexOf);
+            }
+
             // These rules always execute between all Cirrus nodes.
             fullNodeBuilder.Network.Consensus.ConsensusRules.FullValidationRules.Insert(0, typeof(CheckCollateralCommitmentHeightRule));
 


### PR DESCRIPTION
Cirrus should has no concept of the federation or any modifications of it. This is a bit of hack until we can refactor the code so that CirrusD can also be federation aware.