### PR TITLE
Load federation from genesis and polls

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -39,6 +39,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         protected readonly DBreezeSerializer dBreezeSerializer;
         protected readonly ChainState chainState;
         protected readonly IAsyncProvider asyncProvider;
+        protected readonly Mock<IFullNode> fullNode;
 
         public PoATestsBase(TestPoANetwork network = null)
         {
@@ -91,7 +92,13 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             var keyValueRepo = new KeyValueRepository(dir, new DBreezeSerializer(network.Consensus.ConsensusFactory));
 
             var settings = new NodeSettings(network, args: new string[] { $"-datadir={dir}" });
-            var federationManager = new FederationManager(settings, network, loggerFactory, keyValueRepo, signals);
+            var fullNode = new Mock<IFullNode>();
+            var federationManager = new FederationManager(settings, network, loggerFactory, keyValueRepo, signals, fullNode.Object);
+            var votingManager = new VotingManager(federationManager, loggerFactory, new Mock<ISlotsManager>().Object,
+                new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, settings.DataFolder, null, signals, 
+                new Mock<IFinalizedBlockInfoRepository>().Object, network);
+            votingManager.Initialize();
+            fullNode.Setup(x => x.NodeService<VotingManager>(It.IsAny<bool>())).Returns(votingManager);
             federationManager.Initialize();
 
             return federationManager;

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -95,9 +95,16 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             var settings = new NodeSettings(network, args: new string[] { $"-datadir={dir}" });
             var fullNode = new Mock<IFullNode>();
             var federationManager = new FederationManager(settings, network, loggerFactory, keyValueRepo, signals, fullNode.Object);
-            var votingManager = new VotingManager(federationManager, loggerFactory, new Mock<ISlotsManager>().Object,
-                new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, settings.DataFolder, dbreezeSerializer, signals, 
-                new Mock<IFinalizedBlockInfoRepository>().Object, network);
+            var asyncProvider = new AsyncProvider(loggerFactory, signals, new Mock<INodeLifetime>().Object);
+            var finalizedBlockRepo = new FinalizedBlockInfoRepository(new KeyValueRepository(settings.DataFolder, dbreezeSerializer), loggerFactory, asyncProvider);
+            finalizedBlockRepo.LoadFinalizedBlockInfoAsync(network).GetAwaiter().GetResult();
+
+            var chainIndexerMock = new Mock<ChainIndexer>();
+            var header = new BlockHeader();
+            chainIndexerMock.Setup(x => x.Tip).Returns(new ChainedHeader(header, header.GetHash(), 0));
+            var slotsManager = new SlotsManager(network, federationManager, chainIndexerMock.Object, loggerFactory);
+            var votingManager = new VotingManager(federationManager, loggerFactory, slotsManager,
+                new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, settings.DataFolder, dbreezeSerializer, signals, finalizedBlockRepo, network);
             votingManager.Initialize();
             fullNode.Setup(x => x.NodeService<VotingManager>(It.IsAny<bool>())).Returns(votingManager);
             federationManager.Initialize();

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -89,13 +89,14 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         public static IFederationManager CreateFederationManager(object caller, Network network, LoggerFactory loggerFactory, ISignals signals)
         {
             string dir = TestBase.CreateTestDir(caller);
-            var keyValueRepo = new KeyValueRepository(dir, new DBreezeSerializer(network.Consensus.ConsensusFactory));
+            var dbreezeSerializer = new DBreezeSerializer(network.Consensus.ConsensusFactory);
+            var keyValueRepo = new KeyValueRepository(dir, dbreezeSerializer);
 
             var settings = new NodeSettings(network, args: new string[] { $"-datadir={dir}" });
             var fullNode = new Mock<IFullNode>();
             var federationManager = new FederationManager(settings, network, loggerFactory, keyValueRepo, signals, fullNode.Object);
             var votingManager = new VotingManager(federationManager, loggerFactory, new Mock<ISlotsManager>().Object,
-                new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, settings.DataFolder, null, signals, 
+                new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, settings.DataFolder, dbreezeSerializer, signals, 
                 new Mock<IFinalizedBlockInfoRepository>().Object, network);
             votingManager.Initialize();
             fullNode.Setup(x => x.NodeService<VotingManager>(It.IsAny<bool>())).Returns(votingManager);

--- a/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
@@ -66,9 +66,6 @@ namespace Stratis.Bitcoin.Features.PoA
 
         private readonly ISignals signals;
 
-        /// <summary>Key for accessing list of public keys that represent federation members from <see cref="IKeyValueRepository"/>.</summary>
-        protected const string federationMembersDbKey = "fedmemberskeys";
-
         /// <summary>Collection of all active federation members as determined by the genesis members and all executed polls.</summary>
         /// <remarks>All access should be protected by <see cref="locker"/>.</remarks>
         protected List<IFederationMember> federationMembers;
@@ -99,10 +96,7 @@ namespace Stratis.Bitcoin.Features.PoA
             if (this.federationMembers == null)
             {
                 this.logger.LogDebug("Federation members are not stored in the db. Loading genesis federation members.");
-
                 this.federationMembers = genesisFederation;
-
-                this.SaveFederation(this.federationMembers);
             }
 
             // Display federation.
@@ -154,8 +148,6 @@ namespace Stratis.Bitcoin.Features.PoA
                             .Any(m => m.PubKey == federationMember.PubKey && ((CollateralFederationMember)m).IsMultisigMember);
                     }
                 }
-
-                this.SaveFederation(this.federationMembers);
             }
         }
 
@@ -192,7 +184,7 @@ namespace Stratis.Bitcoin.Features.PoA
             this.signals.Publish(new FedMemberAdded(federationMember));
         }
 
-        /// <remarks>Should be protected by <see cref="locker"/>.</remarks>
+        /// <summary>Should be protected by <see cref="locker"/>.</summary>
         protected virtual void AddFederationMemberLocked(IFederationMember federationMember)
         {
             if (this.federationMembers.Contains(federationMember))
@@ -203,7 +195,6 @@ namespace Stratis.Bitcoin.Features.PoA
 
             this.federationMembers.Add(federationMember);
 
-            this.SaveFederation(this.federationMembers);
             this.SetIsFederationMember();
 
             this.logger.LogInformation("Federation member '{0}' was added!", federationMember);
@@ -215,7 +206,6 @@ namespace Stratis.Bitcoin.Features.PoA
             {
                 this.federationMembers.Remove(federationMember);
 
-                this.SaveFederation(this.federationMembers);
                 this.SetIsFederationMember();
 
                 this.logger.LogInformation("Federation member '{0}' was removed!", federationMember);
@@ -223,8 +213,6 @@ namespace Stratis.Bitcoin.Features.PoA
 
             this.signals.Publish(new FedMemberKicked(federationMember));
         }
-
-        protected abstract void SaveFederation(List<IFederationMember> federation);
 
         /// <summary>Loads saved collection of federation members from the database.</summary>
         protected abstract void LoadFederation();
@@ -254,12 +242,7 @@ namespace Stratis.Bitcoin.Features.PoA
         protected override void LoadFederation()
         {
             VotingManager votingManager = this.fullNode.NodeService<VotingManager>();
-
             this.federationMembers = votingManager.GetFederationFromExecutedPolls();
-        }
-
-        protected override void SaveFederation(List<IFederationMember> federation)
-        {
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
@@ -106,6 +106,7 @@ namespace Stratis.Bitcoin.Features.PoA
                     this.votingManager.Initialize();
                 }
             }
+
             this.federationManager.Initialize();
             this.whitelistedHashesRepository.Initialize();
 

--- a/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
@@ -89,9 +89,6 @@ namespace Stratis.Bitcoin.Features.PoA
 
             this.ReplaceBlockStoreBehavior(connectionParameters);
 
-            this.federationManager.Initialize();
-            this.whitelistedHashesRepository.Initialize();
-
             var options = (PoAConsensusOptions)this.network.Consensus.Options;
 
             if (options.VotingEnabled)
@@ -109,6 +106,8 @@ namespace Stratis.Bitcoin.Features.PoA
                     this.votingManager.Initialize();
                 }
             }
+            this.federationManager.Initialize();
+            this.whitelistedHashesRepository.Initialize();
 
             this.miner.InitializeMining();
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/DefaultVotingController.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/DefaultVotingController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -69,7 +70,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 var federationMemberModels = new List<FederationMemberModel>();
 
                 // Get their last active times.
-                Dictionary<PubKey, uint> activeTimes = this.idleFederationMembersKicker.GetFederationMembersByLastActiveTime();
+                ConcurrentDictionary<PubKey, uint> activeTimes = this.idleFederationMembersKicker.GetFederationMembersByLastActiveTime();
                 foreach (IFederationMember federationMember in federationMembers)
                 {
                     federationMemberModels.Add(new FederationMemberModel()

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -14,7 +15,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 {
     public interface IIdleFederationMembersKicker : IDisposable
     {
-        Dictionary<PubKey, uint> GetFederationMembersByLastActiveTime();
+        ConcurrentDictionary<PubKey, uint> GetFederationMembersByLastActiveTime();
         bool ShouldMemberBeKicked(PubKey pubKey, uint blockTime, out uint inactiveForSeconds);
         void Execute(ChainedHeader consensusTip);
         void Initialize();
@@ -51,7 +52,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         private SubscriptionToken blockConnectedToken, fedMemberAddedToken, fedMemberKickedToken;
 
         /// <summary>Active time is updated when member is added or produced a new block.</remarks>
-        private Dictionary<PubKey, uint> fedPubKeysByLastActiveTime;
+        private ConcurrentDictionary<PubKey, uint> fedPubKeysByLastActiveTime;
 
         private const string fedMembersByLastActiveTimeKey = "fedMembersByLastActiveTime";
 
@@ -83,31 +84,31 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
             if (loaded != null)
             {
-                this.fedPubKeysByLastActiveTime = new Dictionary<PubKey, uint>();
+                this.fedPubKeysByLastActiveTime = new ConcurrentDictionary<PubKey, uint>();
 
                 foreach (KeyValuePair<string, uint> loadedMember in loaded)
                 {
-                    this.fedPubKeysByLastActiveTime.Add(new PubKey(loadedMember.Key), loadedMember.Value);
+                    this.fedPubKeysByLastActiveTime[new PubKey(loadedMember.Key)] = loadedMember.Value;
                 }
             }
             else
             {
                 this.logger.LogDebug("No saved data found. Initializing federation data with current timestamp.");
 
-                this.fedPubKeysByLastActiveTime = new Dictionary<PubKey, uint>();
+                this.fedPubKeysByLastActiveTime = new ConcurrentDictionary<PubKey, uint>();
 
                 // If this is a clean sync initialize each member's last active time with the genesis timestamp.
                 // Each member's last active time will be updated on each block connected event during syncing
                 // or on block mined.
-                foreach (IFederationMember federationMember in this.federationManager.GetFederationMembers())
-                    this.fedPubKeysByLastActiveTime.Add(federationMember.PubKey, this.network.GenesisTime);
+                foreach (IFederationMember federationMember in ((PoAConsensusOptions)this.network.Consensus.Options).GenesisFederationMembers)
+                    this.fedPubKeysByLastActiveTime[federationMember.PubKey] = this.network.GenesisTime;
 
                 this.SaveMembersByLastActiveTime();
             }
         }
 
         /// <inheritdoc />
-        public Dictionary<PubKey, uint> GetFederationMembersByLastActiveTime()
+        public ConcurrentDictionary<PubKey, uint> GetFederationMembersByLastActiveTime()
         {
             return this.fedPubKeysByLastActiveTime;
         }
@@ -123,7 +124,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
         private void OnFedMemberKicked(FedMemberKicked fedMemberKickedData)
         {
-            this.fedPubKeysByLastActiveTime.Remove(fedMemberKickedData.KickedMember.PubKey);
+            this.fedPubKeysByLastActiveTime.Remove(fedMemberKickedData.KickedMember.PubKey, out _);
 
             this.SaveMembersByLastActiveTime();
         }
@@ -132,7 +133,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         {
             if (!this.fedPubKeysByLastActiveTime.ContainsKey(fedMemberAddedData.AddedMember.PubKey))
             {
-                this.fedPubKeysByLastActiveTime.Add(fedMemberAddedData.AddedMember.PubKey, this.consensusManager.Tip.Header.Time);
+                this.fedPubKeysByLastActiveTime[fedMemberAddedData.AddedMember.PubKey] = this.consensusManager.Tip.Header.Time;
 
                 this.SaveMembersByLastActiveTime();
             }

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -43,8 +43,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
         private readonly ILogger logger;
 
-        private readonly IDateTimeProvider timeProvider;
-
         private readonly uint federationMemberMaxIdleTimeSeconds;
 
         private readonly PoAConsensusFactory consensusFactory;
@@ -57,7 +55,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         private const string fedMembersByLastActiveTimeKey = "fedMembersByLastActiveTime";
 
         public IdleFederationMembersKicker(ISignals signals, Network network, IKeyValueRepository keyValueRepository, IConsensusManager consensusManager,
-            IFederationManager federationManager, ISlotsManager slotsManager, VotingManager votingManager, ILoggerFactory loggerFactory, IDateTimeProvider timeProvider)
+            IFederationManager federationManager, ISlotsManager slotsManager, VotingManager votingManager, ILoggerFactory loggerFactory)
         {
             this.signals = signals;
             this.network = network;
@@ -66,7 +64,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             this.federationManager = federationManager;
             this.slotsManager = slotsManager;
             this.votingManager = votingManager;
-            this.timeProvider = timeProvider;
 
             this.consensusFactory = this.network.Consensus.ConsensusFactory as PoAConsensusFactory;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);

--- a/src/Stratis.Features.Collateral/CollateralFederationManager.cs
+++ b/src/Stratis.Features.Collateral/CollateralFederationManager.cs
@@ -77,46 +77,15 @@ namespace Stratis.Features.Collateral
 
         protected override void LoadFederation()
         {
-            List<CollateralFederationMemberModel> fedMemberModels = this.keyValueRepo.LoadValueJson<List<CollateralFederationMemberModel>>(federationMembersDbKey);
+            VotingManager votingManager = this.fullNode.NodeService<VotingManager>();
 
-            if (fedMemberModels == null)
-            {
-                this.logger.LogTrace("(-)[NOT_FOUND]:null");
-                this.federationMembers = null;
-                return;
-            }
-
-            var federation = new List<IFederationMember>(fedMemberModels.Count);
-
-            foreach (CollateralFederationMemberModel fedMemberModel in fedMemberModels)
-            {
-                var pubKey = new PubKey(fedMemberModel.PubKeyHex);
-                federation.Add(new CollateralFederationMember(pubKey, false, new Money(fedMemberModel.CollateralAmountSatoshis),
-                    fedMemberModel.CollateralMainchainAddress));
-            }
-
-            this.federationMembers = federation;
+            this.federationMembers = votingManager.GetFederationFromExecutedPolls();
 
             this.UpdateMultisigMiners(this.multisigMinersApplicabilityHeight != null);
         }
 
         protected override void SaveFederation(List<IFederationMember> federation)
         {
-            IEnumerable<CollateralFederationMember> collateralFederation = federation.Cast<CollateralFederationMember>();
-
-            var modelsCollection = new List<CollateralFederationMemberModel>(federation.Count);
-
-            foreach (CollateralFederationMember federationMember in collateralFederation)
-            {
-                modelsCollection.Add(new CollateralFederationMemberModel()
-                {
-                    PubKeyHex = federationMember.PubKey.ToHex(),
-                    CollateralMainchainAddress = federationMember.CollateralMainchainAddress,
-                    CollateralAmountSatoshis = federationMember.CollateralAmount.Satoshi
-                });
-            }
-
-            this.keyValueRepo.SaveValueJson(federationMembersDbKey, modelsCollection);
         }
 
         public async Task<PubKey> JoinFederationAsync(JoinFederationRequestModel request, CancellationToken cancellationToken)

--- a/src/Stratis.Features.Collateral/CollateralFederationManager.cs
+++ b/src/Stratis.Features.Collateral/CollateralFederationManager.cs
@@ -84,10 +84,6 @@ namespace Stratis.Features.Collateral
             this.UpdateMultisigMiners(this.multisigMinersApplicabilityHeight != null);
         }
 
-        protected override void SaveFederation(List<IFederationMember> federation)
-        {
-        }
-
         public async Task<PubKey> JoinFederationAsync(JoinFederationRequestModel request, CancellationToken cancellationToken)
         {
             // Get the address pub key hash.

--- a/src/Stratis.Features.FederatedPeg.Tests/Utils/FedPegTestsHelper.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Utils/FedPegTestsHelper.cs
@@ -8,17 +8,16 @@ namespace Stratis.Features.FederatedPeg.Tests.Utils
 {
     public static class FedPegTestsHelper
     {
-        public static FederatedPegSettings CreateSettings(Network network, Network counterChainNetwork, out NodeSettings nodeSettings)
+        public static FederatedPegSettings CreateSettings(Network network, Network counterChainNetwork, string dataFolder, out NodeSettings nodeSettings)
         {
             FederationId federationId = network.Federations.GetOnlyFederation().Id;
             string redeemScript = PayToFederationTemplate.Instance.GenerateScriptPubKey(federationId).ToString();
             string federationIps = "127.0.0.1:36201,127.0.0.1:36202,127.0.0.1:36203";
             string multisigPubKey = network.Federations.GetFederation(federationId).GetFederationDetails().transactionSigningKeys.TakeLast(1).First().ToHex();
-            string[] args = new[] { "-sidechain", "-regtest", $"-federationips={federationIps}", $"-redeemscript={redeemScript}", $"-publickey={multisigPubKey}", "-mincoinmaturity=1", "-mindepositconfirmations=1" };
+            string[] args = new[] { "-sidechain", "-regtest", $"-datadir={dataFolder}", $"-federationips={federationIps}", $"-redeemscript={redeemScript}", $"-publickey={multisigPubKey}", "-mincoinmaturity=1", "-mindepositconfirmations=1" };
             nodeSettings = new NodeSettings(network, ProtocolVersion.ALT_PROTOCOL_VERSION, args: args);
 
             var settings = new FederatedPegSettings(nodeSettings, new CounterChainNetworkWrapper(counterChainNetwork));
-
             return settings;
         }
     }


### PR DESCRIPTION
The `federationMembers` property of the `FederationManager` and `CollateralFederationManager` classes is expected to contain the genesis members as updated via all executed polls.

This PR guarantees that that is in fact the case.

Previously the property was subject to being loaded from the DB. Now it is derived from the genesis and polls - to exactly match what it is supposed to be.. See `LoadFederation`. Also see how the changes integrate seamlessly with what `GetModifiedFederation` does/assumes.

I remember someone complaining about JSON deserialization related to federation members. This PR should address that issue as well - due to the DB no longer being used.