### PR TITLE
Fix console mining slots

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -429,7 +429,7 @@ namespace Stratis.Bitcoin.Features.PoA
 
                 PubKey pubKey = modifiedFederation[headerSlot].PubKey;
 
-                string pubKeyRepresentation = (pubKey == this.federationManager.CurrentFederationKey?.PubKey) ? "****" : pubKey.ToString().Substring(0, pubKeyTakeCharacters);
+                string pubKeyRepresentation = (pubKey == this.federationManager.CurrentFederationKey?.PubKey) ? "████" : pubKey.ToString().Substring(0, pubKeyTakeCharacters);
 
                 // Mined in this slot?
                 if (timeHeader == currentHeader.Header.Time)

--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -400,11 +400,15 @@ namespace Stratis.Bitcoin.Features.PoA
         [NoTrace]
         private void AddComponentStats(StringBuilder log)
         {
-            if (this.ibdState.IsInitialBlockDownload())
-                return;
-
             log.AppendLine();
             log.AppendLine("======PoA Miner======");
+
+            if (this.ibdState.IsInitialBlockDownload())
+            {
+                log.AppendLine($"Mining information is not available during IBD.");
+                log.AppendLine();
+                return;
+            }
 
             ChainedHeader tip = this.consensusManager.Tip;
             ChainedHeader currentHeader = tip;

--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -409,7 +409,7 @@ namespace Stratis.Bitcoin.Features.PoA
             ChainedHeader tip = this.consensusManager.Tip;
             ChainedHeader currentHeader = tip;
 
-            int pubKeyTakeCharacters = 4;
+            int pubKeyTakeCharacters = 5;
             int hitCount = 0;
 
             List<IFederationMember> modifiedFederation = this.votingManager?.GetModifiedFederation(currentHeader) ?? this.federationManager.GetFederationMembers();
@@ -421,6 +421,8 @@ namespace Stratis.Bitcoin.Features.PoA
 
             uint timeHeader = (uint)this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
             timeHeader -= timeHeader % this.network.ConsensusOptions.TargetSpacingSeconds;
+            if (timeHeader < currentHeader.Header.Time)
+                timeHeader += this.network.ConsensusOptions.TargetSpacingSeconds;
 
             // Iterate mining slots.
             for (int i = 0; i < maxDepth; i++)
@@ -429,7 +431,7 @@ namespace Stratis.Bitcoin.Features.PoA
 
                 PubKey pubKey = modifiedFederation[headerSlot].PubKey;
 
-                string pubKeyRepresentation = (pubKey == this.federationManager.CurrentFederationKey?.PubKey) ? "████" : pubKey.ToString().Substring(0, pubKeyTakeCharacters);
+                string pubKeyRepresentation = (pubKey == this.federationManager.CurrentFederationKey?.PubKey) ? "█████" : pubKey.ToString().Substring(0, pubKeyTakeCharacters);
 
                 // Mined in this slot?
                 if (timeHeader == currentHeader.Header.Time)

--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -417,7 +417,7 @@ namespace Stratis.Bitcoin.Features.PoA
             int maxDepth = modifiedFederation.Count;
 
             log.AppendLine($"Mining information for the last { maxDepth } blocks.");
-            log.AppendLine("'<' and '>' surrounds a miner didn't produce a block at the timestamp he was supposed to.");
+            log.AppendLine("Note that '<' and '>' surrounds a slot where a miner didn't produce a block.");
 
             uint timeHeader = (uint)this.dateTimeProvider.GetAdjustedTimeAsUnixTimestamp();
             timeHeader -= timeHeader % this.network.ConsensusOptions.TargetSpacingSeconds;


### PR DESCRIPTION
Fixes the formatting around displaying mining slots and increases the number of characters displayed.

![image](https://user-images.githubusercontent.com/29645989/100530370-54b1c200-3245-11eb-8f2d-0156581b2b23.png)

The output also clearly shows one's own mining slot. Improves the "correctness" of the slots displayed as federation changes.