### PR TITLE
Use header size constant for faster start-ups

### DIFF
--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -250,7 +250,7 @@ namespace Stratis.Bitcoin.Consensus
             {
                 current.Previous.Next.Add(current);
                 this.chainedHeadersByHash.Add(current.HashBlock, current);
-                this.ChainedBlocksDataBytes += current.Header.HeaderSize;
+                this.ChainedBlocksDataBytes += BlockHeader.Size;
 
                 // TODO when pruned node is implemented it should be header only for pruned blocks
                 current.BlockDataAvailability = BlockDataAvailabilityState.BlockAvailable;
@@ -261,7 +261,7 @@ namespace Stratis.Bitcoin.Consensus
 
             // Add the genesis block.
             this.chainedHeadersByHash.Add(current.HashBlock, current);
-            this.ChainedBlocksDataBytes += current.Header.HeaderSize;
+            this.ChainedBlocksDataBytes += BlockHeader.Size;
 
             if (current.HashBlock != this.network.GenesisHash)
             {
@@ -605,7 +605,7 @@ namespace Stratis.Bitcoin.Consensus
         {
             header.Previous.Next.Remove(header);
             this.chainedHeadersByHash.Remove(header.HashBlock);
-            this.ChainedBlocksDataBytes -= header.Header.HeaderSize;
+            this.ChainedBlocksDataBytes -= BlockHeader.Size;
 
             if (header.Block != null)
             {
@@ -1103,7 +1103,7 @@ namespace Stratis.Bitcoin.Consensus
 
             previousChainedHeader.Next.Add(newChainedHeader);
             this.chainedHeadersByHash.Add(newChainedHeader.HashBlock, newChainedHeader);
-            this.ChainedBlocksDataBytes += newChainedHeader.Header.HeaderSize;
+            this.ChainedBlocksDataBytes += BlockHeader.Size;
 
             return newChainedHeader;
         }

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -44,9 +44,6 @@ namespace Stratis.Bitcoin.Consensus
         /// <summary>Total amount of unconsumed blocks.</summary>
         long UnconsumedBlocksCount { get; }
 
-        /// <summary>Total size of ChainedHeaders data in bytes.</summary>
-        long ChainedBlocksDataBytes { get; }
-
         /// <summary>
         /// Initialize the tree with consensus tip.
         /// </summary>
@@ -181,9 +178,6 @@ namespace Stratis.Bitcoin.Consensus
         /// <inheritdoc />
         public long UnconsumedBlocksCount { get; private set; }
 
-        /// <inheritdoc />
-        public long ChainedBlocksDataBytes { get; private set; }
-
         /// <summary>A special peer identifier that represents our local node.</summary>
         internal const int LocalPeerId = -1;
 
@@ -250,7 +244,6 @@ namespace Stratis.Bitcoin.Consensus
             {
                 current.Previous.Next.Add(current);
                 this.chainedHeadersByHash.Add(current.HashBlock, current);
-                this.ChainedBlocksDataBytes += BlockHeader.Size;
 
                 // TODO when pruned node is implemented it should be header only for pruned blocks
                 current.BlockDataAvailability = BlockDataAvailabilityState.BlockAvailable;
@@ -261,7 +254,6 @@ namespace Stratis.Bitcoin.Consensus
 
             // Add the genesis block.
             this.chainedHeadersByHash.Add(current.HashBlock, current);
-            this.ChainedBlocksDataBytes += BlockHeader.Size;
 
             if (current.HashBlock != this.network.GenesisHash)
             {
@@ -605,7 +597,6 @@ namespace Stratis.Bitcoin.Consensus
         {
             header.Previous.Next.Remove(header);
             this.chainedHeadersByHash.Remove(header.HashBlock);
-            this.ChainedBlocksDataBytes -= BlockHeader.Size;
 
             if (header.Block != null)
             {
@@ -1103,7 +1094,6 @@ namespace Stratis.Bitcoin.Consensus
 
             previousChainedHeader.Next.Add(newChainedHeader);
             this.chainedHeadersByHash.Add(newChainedHeader.HashBlock, newChainedHeader);
-            this.ChainedBlocksDataBytes += BlockHeader.Size;
 
             return newChainedHeader;
         }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -1505,8 +1505,6 @@ namespace Stratis.Bitcoin.Consensus
                 log.AppendLine($"Tip Age: { TimeSpan.FromSeconds(tipAge).ToString(@"dd\.hh\:mm\:ss") } (maximum is { TimeSpan.FromSeconds(maxTipAge).ToString(@"dd\.hh\:mm\:ss") })");
                 log.AppendLine($"In IBD Stage: { (this.isIbd ? "Yes" : "No") }");
 
-                log.AppendLine($"Chained header tree size: {this.chainedHeaderTree.ChainedBlocksDataBytes.BytesToMegaBytes()} MB");
-
                 string unconsumedBlocks = this.FormatBigNumber(this.chainedHeaderTree.UnconsumedBlocksCount);
 
                 double filledPercentage = Math.Round((this.chainedHeaderTree.UnconsumedBlocksDataBytes / (double)this.maxUnconsumedBlocksDataBytes) * 100, 2);


### PR DESCRIPTION
The code below will at times take extremely long to run:

```
        public void Initialize(ChainedHeader consensusTip)
        {
            ChainedHeader current = consensusTip;

            while (current.Previous != null)
            {
                current.Previous.Next.Add(current);
                this.chainedHeadersByHash.Add(current.HashBlock, current);
                this.ChainedBlocksDataBytes += current.Header.HeaderSize;

                // TODO when pruned node is implemented it should be header only for pruned blocks
                current.BlockDataAvailability = BlockDataAvailabilityState.BlockAvailable;
                current.BlockValidationState = ValidationState.FullyValidated;

                current = current.Previous;
            }
```

This is due to `this.ChainedBlocksDataBytes += current.Header.HeaderSize;`

```
        public BlockHeader Header
        {
            get { return this.ChainStore.GetHeader(this, this.HashBlock); }
        }
```

This line of code actually reads the header from the chain store database just to access the underlying constant `BlockHeader.Size`:

```
public const int Size = 80;
...
public virtual long HeaderSize => Size;
```