### PR TITLE
Add consolidate endpoint and adjust subtractfee logic

### DIFF
--- a/src/NBitcoin/TransactionBuilder.cs
+++ b/src/NBitcoin/TransactionBuilder.cs
@@ -1545,7 +1545,7 @@ namespace NBitcoin
         /// Estimate the physical size of the transaction
         /// </summary>
         /// <param name="tx">The transaction to be estimated</param>
-        /// <returns></returns>
+        /// <returns>The estimated size of the transaction in bytes.</returns>
         public int EstimateSize(Transaction tx)
         {
             return EstimateSize(tx, false);
@@ -1617,7 +1617,7 @@ namespace NBitcoin
             }
 
             if (scriptSigSize == -1)
-                scriptSigSize += coin.TxOut.ScriptPubKey.Length; //Using heurestic to approximate size of unknown scriptPubKey
+                scriptSigSize += coin.TxOut.ScriptPubKey.Length; //Using heuristic to approximate size of unknown scriptPubKey
 
             if (coin.GetHashVersion(this.Network) == HashVersion.Witness)
                 witSize += scriptSigSize + 1; //Account for the push

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractWalletTransactionHandler.cs
@@ -57,8 +57,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
             if (context.Recipients.Any(recipient => recipient.Amount == Money.Zero && !recipient.ScriptPubKey.IsSmartContractExec()))
                 throw new WalletException("No amount specified.");
 
+            // TODO: Port the necessary logic from the regular wallet transaction handler
             if (context.Recipients.Any(a => a.SubtractFeeFromAmount))
-                throw new NotImplementedException("Substracting the fee from the recipient is not supported yet.");
+                throw new NotImplementedException("Subtracting the fee from the recipient is not supported yet.");
 
             foreach (Recipient recipient in context.Recipients)
                 context.TransactionBuilder.Send(recipient.ScriptPubKey, recipient.Amount);

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -829,6 +829,15 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
             return await this.Execute(request, cancellationToken, async (req, token) => this.Json(await this.walletService.OfflineSignRequest(req, token)));
         }
 
+        [HttpPost]
+        [Route("consolidate")]
+        public async Task<IActionResult> Consolidate([FromBody] ConsolidationRequest request,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            return await this.Execute(request, cancellationToken,
+                async (req, token) => this.Json(await this.walletService.Consolidate(req, token)));
+        }
+
         private TransactionItemModel FindSimilarReceivedTransactionOutput(List<TransactionItemModel> items,
             TransactionData transaction)
         {

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletTransactionHandler.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletTransactionHandler.cs
@@ -40,5 +40,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <param name="context">The context that is used to build a new transaction.</param>
         /// <returns>The estimated fee.</returns>
         Money EstimateFee(TransactionBuildContext context);
+
+        int EstimateSize(TransactionBuildContext context);
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -989,4 +989,43 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
 
         public bool Broadcast { get; set; }
     }
+
+    public sealed class ConsolidationRequest : RequestModel
+    {
+        public ConsolidationRequest()
+        {
+            this.AccountName = WalletManager.DefaultAccount;
+        }
+
+        [Required(ErrorMessage = "The name of the wallet is missing.")]
+        public string WalletName { get; set; }
+
+        /// <summary>
+        /// The account from which UTXOs should be consolidated.
+        /// If this is not set the default account of the selected wallet will be used.
+        /// </summary>
+        public string AccountName { get; set; }
+
+        [Required(ErrorMessage = "A password is required.")]
+        public string WalletPassword { get; set; }
+
+        /// <summary>
+        /// If this is set, only UTXOs within this wallet address will be consolidated.
+        /// If it is not set, all the UTXOs within the selected account will be consolidated.
+        /// </summary>
+        public string SingleAddress { get; set; }
+
+        /// <summary>
+        /// Which address the UTXOs should be sent to. It does not have to be within the wallet.
+        /// If it is not provided the UTXOs will be consolidated to an unused address within the specified wallet.
+        /// </summary>
+        public string DestinationAddress { get; set; }
+
+        /// <summary>
+        /// If provided, UTXOs that are larger in value will not be consolidated.
+        /// Dust UTXOs will not be consolidated regardless of their value, so there is an implicit lower bound as well.
+        /// </summary>
+        [MoneyFormat(isRequired: false, ErrorMessage = "The amount is not in the correct format.")]
+        public string UtxoValueThreshold { get; set; }
+    }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Services/IWalletService.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Services/IWalletService.cs
@@ -59,5 +59,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Services
 
         Task<WalletBuildTransactionModel> OfflineSignRequest(OfflineSignRequest request,
             CancellationToken cancellationToken);
+
+        Task<string> Consolidate(ConsolidationRequest request,
+            CancellationToken cancellationToken);
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
@@ -1415,7 +1415,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Services
                 {
                     var threshold = Money.Parse(request.UtxoValueThreshold);
 
-                    utxos = utxos.Where(u => u.Transaction.Amount >= threshold).ToList();
+                    utxos = utxos.Where(u => u.Transaction.Amount <= threshold).ToList();
                 }
 
                 Script destination;


### PR DESCRIPTION
This is a useful function for managing wallets with large numbers of UTXOs.

There was also an undesired limitation on the `SubtractFeeFromAmount` flag whereby it required the `TransactionFee` to be set on the build context. This relaxes that requirement, but only when a single recipient has the flag set. Fortunately, many common use cases only need a single recipient to have the flag set.