### PR TITLE
Fix federation loading on startup

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -255,7 +255,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 var federation = new List<IFederationMember>(((PoAConsensusOptions)this.network.Consensus.Options).GenesisFederationMembers);
 
                 IEnumerable<Poll> executedPolls = this.GetFinishedPolls().Where(x => x.IsExecuted && ((x.VotingData.Key == VoteKey.AddFederationMember) || (x.VotingData.Key == VoteKey.KickFederationMember)));
-                foreach (Poll poll in executedPolls)
+                foreach (Poll poll in executedPolls.OrderBy(a => a.PollExecutedBlockData.Height))
                 {
                     IFederationMember federationMember = ((PoAConsensusFactory)(this.network.Consensus.ConsensusFactory)).DeserializeFederationMember(poll.VotingData.Data);
 


### PR DESCRIPTION
This is the reason why peers are getting banned when they restart the node.

During normal node execution, new federation members are added to the back of the `federationMembers` list. However, a particular member could have started a poll before member X but ended after member X's poll executed. 

Currently, when we construct the list of members from the executed polls on startup, we don't order the list by executed height and as such the federation members list could look different to how the list looks whilst the node is normally running.

E.g. 

```
member X starts poll at height 100
member Y starts poll at height 150

member Y's poll executed at 175 -> Federation list is Y
member X's poll executed at 200 -> Federation list is Y, X
```

Currently when we load the list it will look  like this: 

`X,Y`

If we order by execution height it will be 

`Y,X (which is correct).`

I tested this and now the node starts up normally and continues syncing.