### PR TITLE
Remove PoaHeaderSignature rule for CirrusD

### DIFF
--- a/src/Stratis.Features.Collateral/CollateralFeature.cs
+++ b/src/Stratis.Features.Collateral/CollateralFeature.cs
@@ -45,6 +45,16 @@ namespace Stratis.Features.Collateral
             // These rules always execute between all Cirrus nodes.
             fullNodeBuilder.Network.Consensus.ConsensusRules.FullValidationRules.Insert(0, typeof(CheckCollateralCommitmentHeightRule));
 
+            if (!isMiner)
+            {
+                // Remove the PoAHeaderSignatureRule if this is not a miner as CirrusD has no concept of the federation and
+                // any modifications of it.
+                // This rule is only required to ensure that the mining nodes don't mine on top of bad blocks. A consensus error will prevent that from happening."
+                // TODO: The code should be refactored at some point so that we dont do this hack.
+                var indexOf = fullNodeBuilder.Network.Consensus.ConsensusRules.FullValidationRules.IndexOf(typeof(PoAHeaderSignatureRule));
+                fullNodeBuilder.Network.Consensus.ConsensusRules.FullValidationRules.RemoveAt(indexOf);
+            }
+
             // Only configure this if the Cirrus node is a miner (CirrusPegD and CirrusMinerD)
             if (isMiner)
             {


### PR DESCRIPTION
This was inadvertently re-introduced by an earlier PR.