### PR TITLE
Offline cold staking setup

### DIFF
--- a/src/NBitcoin/Script.cs
+++ b/src/NBitcoin/Script.cs
@@ -344,7 +344,8 @@ namespace NBitcoin
         P2WPKH,
         P2WSH,
         MultiSig,
-        Federation
+        Federation,
+        ColdStaking
     }
 
     public class ScriptSigs
@@ -949,6 +950,21 @@ namespace NBitcoin
                     return PayToMultiSigTemplate.Instance.CheckScriptPubKey(this);
                 case ScriptType.Federation:
                     return PayToFederationTemplate.Instance.CheckScriptPubKey(this);
+                case ScriptType.ColdStaking:
+                    // TODO: Use the proper script template when the template list is moved into the network
+                    byte[] bytes = this.ToBytes(true);
+                    return (bytes.Length == 51)
+                           && (bytes[0] == (byte)OpcodeType.OP_DUP)
+                           && (bytes[1] == (byte)OpcodeType.OP_HASH160)
+                           && (bytes[2] == (byte)OpcodeType.OP_ROT)
+                           && (bytes[3] == (byte)OpcodeType.OP_IF)
+                           && (bytes[4] == (byte)OpcodeType.OP_CHECKCOLDSTAKEVERIFY)
+                           && (bytes[5] == 0x14)
+                           && (bytes[26] == (byte)OpcodeType.OP_ELSE)
+                           && (bytes[27] == 0x14)
+                           && (bytes[48] == (byte)OpcodeType.OP_ENDIF)
+                           && (bytes[49] == (byte)OpcodeType.OP_EQUALVERIFY)
+                           && (bytes[50] == (byte)OpcodeType.OP_CHECKSIG);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(type), type, "The value is not a valid script type");
             }

--- a/src/Stratis.Bitcoin.Features.ColdStaking.Tests/ColdStakingControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking.Tests/ColdStakingControllerTest.cs
@@ -287,10 +287,10 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Tests
             this.coldStakingManager.CreateWallet(walletPassword, walletName1, walletPassphrase, new Mnemonic(walletMnemonic1));
             this.coldStakingManager.CreateWallet(walletPassword, walletName2, walletPassphrase, new Mnemonic(walletMnemonic2));
 
-            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName1, true, walletPassword);
-            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName1, false, walletPassword);
-            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName2, true, walletPassword);
-            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName2, false, walletPassword);
+            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName1, true, walletPassword, null);
+            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName1, false, walletPassword, null);
+            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName2, true, walletPassword, null);
+            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName2, false, walletPassword, null);
 
             HdAddress coldAddress1 = this.coldStakingManager.GetFirstUnusedColdStakingAddress(walletName1, true);
             HdAddress hotAddress1 = this.coldStakingManager.GetFirstUnusedColdStakingAddress(walletName1, false);
@@ -373,8 +373,8 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Tests
             this.coldStakingManager.CreateWallet(walletPassword, walletName1, walletPassphrase, new Mnemonic(walletMnemonic1));
 
             // Create existing accounts.
-            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName1, true, walletPassword);
-            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName1, false, walletPassword);
+            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName1, true, walletPassword, null);
+            this.coldStakingManager.GetOrCreateColdStakingAccount(walletName1, false, walletPassword, null);
 
             // Try to get cold wallet address on existing account without supplying the wallet password.
             IActionResult result1 = this.coldStakingController.GetColdStakingAddress(new GetColdStakingAddressRequest
@@ -813,7 +813,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Tests
         private Transaction AddSpendableColdstakingTransactionToWallet(Wallet.Wallet wallet, bool script = false)
         {
             // Get first unused cold staking address.
-            HdAccount account = this.coldStakingManager.GetOrCreateColdStakingAccount(wallet.Name, true, walletPassword);
+            HdAccount account = this.coldStakingManager.GetOrCreateColdStakingAccount(wallet.Name, true, walletPassword, null);
             HdAddress address = this.coldStakingManager.GetFirstUnusedColdStakingAddress(wallet.Name, true);
 
             TxDestination hotPubKey = BitcoinAddress.Create(hotWalletAddress1, wallet.Network).ScriptPubKey.GetDestination(wallet.Network);
@@ -1055,7 +1055,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Tests
 
             Transaction prevTran = this.AddSpendableColdstakingTransactionToWallet(wallet2);
 
-            HdAddress receivingAddress = this.coldStakingManager.GetOrCreateColdStakingAccount(walletName2, true, walletPassword).ExternalAddresses.First();
+            HdAddress receivingAddress = this.coldStakingManager.GetOrCreateColdStakingAccount(walletName2, true, walletPassword, null).ExternalAddresses.First();
 
             IActionResult result = this.coldStakingController.ColdStakingWithdrawal(new ColdStakingWithdrawalRequest
             {

--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingFeature.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingFeature.cs
@@ -19,6 +19,7 @@ using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Broadcasting;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Features.Wallet.Services;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 
@@ -246,6 +247,9 @@ namespace Stratis.Bitcoin.Features.ColdStaking
                 {
                     services.RemoveSingleton<IWalletManager>();
                     services.AddSingleton<IWalletManager, ColdStakingManager>();
+
+                    services.RemoveSingleton<IWalletService>();
+                    services.AddSingleton<IWalletService, ColdStakingWalletService>();
 
                     services.AddSingleton<ScriptAddressReader>();
                     services.Replace(new ServiceDescriptor(typeof(IScriptAddressReader), typeof(ColdStakingDestinationReader), ServiceLifetime.Singleton));

--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingWalletService.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingWalletService.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using NBitcoin;
+using NBitcoin.Policy;
+using Stratis.Bitcoin.Builder.Feature;
+using Stratis.Bitcoin.Connection;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.Wallet;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Features.Wallet.Models;
+using Stratis.Bitcoin.Features.Wallet.Services;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.ColdStaking
+{
+    /// <summary>
+    /// Contains modified implementations of the <see cref="IWalletService"/> methods suitable for cold staking.
+    /// </summary>
+    public class ColdStakingWalletService : WalletService
+    {
+        public ColdStakingWalletService(ILoggerFactory loggerFactory, IWalletManager walletManager, IConsensusManager consensusManager, IWalletTransactionHandler walletTransactionHandler, IWalletSyncManager walletSyncManager, IConnectionManager connectionManager, Network network, ChainIndexer chainIndexer, IBroadcasterManager broadcasterManager, IDateTimeProvider dateTimeProvider, IUtxoIndexer utxoIndexer, IWalletFeePolicy walletFeePolicy) : base(loggerFactory, walletManager, consensusManager, walletTransactionHandler, walletSyncManager, connectionManager, network, chainIndexer, broadcasterManager, dateTimeProvider, utxoIndexer, walletFeePolicy)
+        {
+        }
+
+        public override async Task<WalletBuildTransactionModel> OfflineSignRequest(OfflineSignRequest request, CancellationToken cancellationToken)
+        {
+            return await Task.Run(() =>
+            {
+                Transaction unsignedTransaction = this.network.CreateTransaction(request.UnsignedTransaction);
+
+                uint256 originalTxId = unsignedTransaction.GetHash();
+
+                var builder = new TransactionBuilder(this.network);
+                var coins = new List<Coin>();
+                var signingKeys = new List<ISecret>();
+
+                ExtKey seedExtKey = this.walletManager.GetExtKey(new WalletAccountReference() { AccountName = request.WalletAccount, WalletName = request.WalletName }, request.WalletPassword);
+
+                // Have to determine which private key to use for each UTXO being spent.
+                foreach (UtxoDescriptor utxo in request.Utxos)
+                {
+                    Script scriptPubKey = Script.FromHex(utxo.ScriptPubKey);
+
+                    coins.Add(new Coin(uint256.Parse(utxo.TransactionId), uint.Parse(utxo.Index), Money.Parse(utxo.Amount), scriptPubKey));
+
+                    // Now try get the associated private key. We therefore need to determine the address that contains the UTXO.
+                    string address = scriptPubKey.GetDestinationAddress(this.network).ToString();
+                    var accounts = this.walletManager.GetAccounts(request.WalletName);
+                    HdAddress hdAddress = accounts.SelectMany(hdAccount => hdAccount.GetCombinedAddresses()).FirstOrDefault(a => a.Address == address || a.Bech32Address == address);
+
+                    // It is possible that the address is outside the gap limit. So if it is not found we optimistically presume the address descriptors will fill in the missing information later.
+                    if (hdAddress != null)
+                    {
+                        ExtKey addressExtKey = seedExtKey.Derive(new KeyPath(hdAddress.HdPath));
+                        BitcoinExtKey addressPrivateKey = addressExtKey.GetWif(this.network);
+                        signingKeys.Add(addressPrivateKey);
+                    }
+                }
+
+                // Address descriptors are 'easier' to look the private key up against if provided, but may not always be available.
+                foreach (AddressDescriptor address in request.Addresses)
+                {
+                    ExtKey addressExtKey = seedExtKey.Derive(new KeyPath(address.KeyPath));
+                    BitcoinExtKey addressPrivateKey = addressExtKey.GetWif(this.network);
+                    signingKeys.Add(addressPrivateKey);
+                }
+
+                // Offline cold staking transaction handling.
+                if (unsignedTransaction.Outputs.Any(o => o.ScriptPubKey.IsScriptType(ScriptType.ColdStaking)))
+                {
+                    // This will always be added in 'cold' mode if we are processing an offline signing request.
+                    builder.Extensions.Add(new ColdStakingBuilderExtension(false));
+                }
+
+                builder.AddCoins(coins);
+                builder.AddKeys(signingKeys.ToArray());
+                builder.SignTransactionInPlace(unsignedTransaction);
+
+                if (!builder.Verify(unsignedTransaction, out TransactionPolicyError[] errors))
+                {
+                    throw new FeatureException(HttpStatusCode.BadRequest, "Failed to validate signed transaction.",
+                        $"Failed to validate signed transaction '{unsignedTransaction.GetHash()}' from offline request '{originalTxId}'.");
+                }
+
+                var builtTransactionModel = new WalletBuildTransactionModel() { TransactionId = unsignedTransaction.GetHash(), Hex = unsignedTransaction.ToHex(), Fee = request.Fee };
+
+                return builtTransactionModel;
+            }, cancellationToken);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.ColdStaking/Controllers/ColdStakingController.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/Controllers/ColdStakingController.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -6,6 +8,7 @@ using NBitcoin;
 using Stratis.Bitcoin.Features.ColdStaking.Models;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
+using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Bitcoin.Utilities.JsonErrors;
 using Stratis.Bitcoin.Utilities.ModelStateErrors;
@@ -112,9 +115,19 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Controllers
 
             try
             {
+                ExtPubKey extPubKey = null;
+
+                try
+                {
+                    extPubKey = ExtPubKey.Parse(request.ExtPubKey);
+                }
+                catch
+                {
+                }
+
                 var model = new CreateColdStakingAccountResponse
                 {
-                    AccountName = this.ColdStakingManager.GetOrCreateColdStakingAccount(request.WalletName, request.IsColdWalletAccount, request.WalletPassword).Name
+                    AccountName = this.ColdStakingManager.GetOrCreateColdStakingAccount(request.WalletName, request.IsColdWalletAccount, request.WalletPassword, extPubKey).Name
                 };
 
                 this.logger.LogTrace("(-):'{0}'", model);
@@ -210,7 +223,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Controllers
                 Money amount = Money.Parse(request.Amount);
                 Money feeAmount = Money.Parse(request.Fees);
 
-                Transaction transaction = this.ColdStakingManager.GetColdStakingSetupTransaction(
+                (Transaction transaction, _) = this.ColdStakingManager.GetColdStakingSetupTransaction(
                     this.walletTransactionHandler,
                     request.ColdWalletAddress,
                     request.HotWalletAddress,
@@ -219,11 +232,104 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Controllers
                     request.WalletPassword,
                     amount,
                     feeAmount,
+                    request.SubtractFeeFromAmount,
+                    false,
                     request.SegwitChangeAddress);
 
                 var model = new SetupColdStakingResponse
                 {
                     TransactionHex = transaction.ToHex()
+                };
+
+                this.logger.LogTrace("(-):'{0}'", model);
+                return this.Json(model);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                this.logger.LogTrace("(-)[ERROR]");
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Creates a cold staking setup transaction in an unsigned state, so that the unsigned transaction can be transferred to
+        /// an offline node that possesses the necessary private keys to sign it.
+        /// </summary>
+        /// <param name="request">A <see cref="SetupOfflineColdStakingRequest"/> object containing the cold staking setup parameters.</param>
+        /// <returns>A <see cref="BuildOfflineSignResponse"/> object containing the hex representation of the unsigned transaction, as well as other metadata for offline signing.</returns>
+        /// <response code="200">Returns offline setup transaction response</response>
+        /// <response code="400">Invalid request or unexpected exception occurred</response>
+        /// <response code="500">Request is null</response>
+        [Route("setup-offline-cold-staking")]
+        [HttpPost]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType((int)HttpStatusCode.InternalServerError)]
+        public IActionResult SetupOfflineColdStaking([FromBody] SetupOfflineColdStakingRequest request)
+        {
+            Guard.NotNull(request, nameof(request));
+
+            // Checks the request is valid.
+            if (!this.ModelState.IsValid)
+            {
+                this.logger.LogTrace("(-)[MODEL_STATE_INVALID]");
+                return ModelStateErrors.BuildErrorResponse(this.ModelState);
+            }
+
+            try
+            {
+                Money amount = Money.Parse(request.Amount);
+                Money feeAmount = Money.Parse(request.Fees);
+
+                (Transaction transaction, TransactionBuildContext context) = this.ColdStakingManager.GetColdStakingSetupTransaction(
+                    this.walletTransactionHandler,
+                    request.ColdWalletAddress,
+                    request.HotWalletAddress,
+                    request.WalletName,
+                    request.WalletAccount,
+                    null,
+                    amount,
+                    feeAmount,
+                    request.SubtractFeeFromAmount,
+                    true,
+                    request.SegwitChangeAddress);
+
+                // TODO: We use the same code in the regular wallet for offline signing request construction, perhaps it should be moved to a common method
+                // Need to be able to look up the keypath for the UTXOs that were used.
+                IEnumerable<UnspentOutputReference> spendableTransactions = this.ColdStakingManager.GetSpendableTransactionsInAccount(
+                        new WalletAccountReference(request.WalletName, request.WalletAccount)).ToList();
+
+                var utxos = new List<UtxoDescriptor>();
+                var addresses = new List<AddressDescriptor>();
+                foreach (ICoin coin in context.TransactionBuilder.FindSpentCoins(transaction))
+                {
+                    utxos.Add(new UtxoDescriptor()
+                    {
+                        Amount = coin.TxOut.Value.ToUnit(MoneyUnit.BTC).ToString(),
+                        TransactionId = coin.Outpoint.Hash.ToString(),
+                        Index = coin.Outpoint.N.ToString(),
+                        ScriptPubKey = coin.TxOut.ScriptPubKey.ToHex()
+                    });
+
+                    UnspentOutputReference outputReference = spendableTransactions.FirstOrDefault(u => u.Transaction.Id == coin.Outpoint.Hash && u.Transaction.Index == coin.Outpoint.N);
+
+                    if (outputReference != null)
+                    {
+                        bool segwit = outputReference.Transaction.ScriptPubKey.IsScriptType(ScriptType.P2WPKH);
+                        addresses.Add(new AddressDescriptor() { Address = segwit ? outputReference.Address.Bech32Address : outputReference.Address.Address, AddressType = segwit ? "p2wpkh" : "p2pkh", KeyPath = outputReference.Address.HdPath });
+                    }
+                }
+
+                // Return transaction hex, UTXO list, address list. The offline signer will infer from the transaction structure that a cold staking setup is being made.
+                var model = new BuildOfflineSignResponse()
+                {
+                    WalletName = request.WalletName,
+                    WalletAccount = request.WalletAccount,
+                    Fee = context.TransactionFee.ToUnit(MoneyUnit.BTC).ToString(),
+                    UnsignedTransaction = transaction.ToHex(),
+                    Utxos = utxos,
+                    Addresses = addresses
                 };
 
                 this.logger.LogTrace("(-):'{0}'", model);
@@ -266,6 +372,50 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Controllers
                     request.WalletPassword,
                     amount,
                     request.SubtractFeeFromAmount,
+                    false,
+                    request.SegwitChangeAddress);
+
+                this.logger.LogTrace("(-):'{0}'", estimatedFee);
+                return this.Json(estimatedFee);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                this.logger.LogTrace("(-)[ERROR]");
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        [Route("estimate-offline-cold-staking-setup-tx-fee")]
+        [HttpPost]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType((int)HttpStatusCode.InternalServerError)]
+        public IActionResult EstimateOfflineColdStakingSetupFee([FromBody] SetupOfflineColdStakingRequest request)
+        {
+            Guard.NotNull(request, nameof(request));
+
+            // Checks the request is valid.
+            if (!this.ModelState.IsValid)
+            {
+                this.logger.LogTrace("(-)[MODEL_STATE_INVALID]");
+                return ModelStateErrors.BuildErrorResponse(this.ModelState);
+            }
+
+            try
+            {
+                Money amount = Money.Parse(request.Amount);
+
+                Money estimatedFee = this.ColdStakingManager.EstimateSetupTransactionFee(
+                    this.walletTransactionHandler,
+                    request.ColdWalletAddress,
+                    request.HotWalletAddress,
+                    request.WalletName,
+                    request.WalletAccount,
+                    null,
+                    amount,
+                    request.SubtractFeeFromAmount,
+                    true,
                     request.SegwitChangeAddress);
 
                 this.logger.LogTrace("(-):'{0}'", estimatedFee);

--- a/src/Stratis.Bitcoin.Features.ColdStaking/Models/ColdStakingModels.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/Models/ColdStakingModels.cs
@@ -66,6 +66,10 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Models
         [JsonProperty(PropertyName = "isColdWalletAccount")]
         public bool IsColdWalletAccount { get; set; }
 
+        /// <summary>If the cold staking account is being added to an extpubkey wallet, the extpubkey of the cold staking account is required.</summary>
+        [JsonProperty(PropertyName = "extPubKey")]
+        public string ExtPubKey { get; set; }
+
         /// <summary>Creates a string containing the properties of this object.</summary>
         /// <returns>A string containing the properties of the object.</returns>
         public override string ToString()
@@ -201,11 +205,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Models
         }
     }
 
-    /// <summary>
-    /// The data structure used by a client requesting that a cold staking setup be performed.
-    /// Refer to <see cref="Controllers.ColdStakingController.SetupColdStaking"/>.
-    /// </summary>
-    public class SetupColdStakingRequest
+    public class BaseSetupColdStakingRequest
     {
         /// <summary>The Base58 cold wallet address.</summary>
         [Required]
@@ -221,11 +221,6 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Models
         [Required]
         [JsonProperty(PropertyName = "walletName")]
         public string WalletName { get; set; }
-
-        /// <summary>The password of the wallet from which we select coins for cold staking.</summary>
-        [Required]
-        [JsonProperty(PropertyName = "walletPassword")]
-        public string WalletPassword { get; set; }
 
         /// <summary>The wallet account from which we select coins for cold staking.</summary>
         [Required]
@@ -251,6 +246,18 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Models
         /// Whether to send the change to a P2WPKH (segwit bech32) addresses, or a regular P2PKH address
         /// </summary>
         public bool SegwitChangeAddress { get; set; }
+    }
+
+    /// <summary>
+    /// The data structure used by a client requesting that a cold staking setup be performed.
+    /// Refer to <see cref="Controllers.ColdStakingController.SetupColdStaking"/>.
+    /// </summary>
+    public class SetupColdStakingRequest : BaseSetupColdStakingRequest
+    {
+        /// <summary>The password of the wallet from which we select coins for cold staking.</summary>
+        [Required]
+        [JsonProperty(PropertyName = "walletPassword")]
+        public string WalletPassword { get; set; }
 
         /// <summary>Creates a string containing the properties of this object.</summary>
         /// <returns>A string containing the properties of the object.</returns>
@@ -258,6 +265,10 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Models
         {
             return $"{nameof(this.ColdWalletAddress)}={this.ColdWalletAddress},{nameof(this.HotWalletAddress)}={this.HotWalletAddress},{nameof(this.WalletName)}={this.WalletName},{nameof(this.WalletAccount)}={this.WalletAccount},{nameof(this.Amount)}={this.Amount},{nameof(this.Fees)}={this.Fees}";
         }
+    }
+
+    public class SetupOfflineColdStakingRequest : BaseSetupColdStakingRequest
+    {
     }
 
     /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/BuildOfflineSignResponse.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/BuildOfflineSignResponse.cs
@@ -1,11 +1,8 @@
 ﻿using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using NBitcoin;
 using Newtonsoft.Json;
 
 namespace Stratis.Bitcoin.Features.Wallet.Models
 {
-    // TODO: The only difference between this and the offline sign request sent to the offline node is the wallet password. Can they be tidily combined?
     public class BuildOfflineSignResponse
     {
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/OfflineSignRequest.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/OfflineSignRequest.cs
@@ -1,11 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Newtonsoft.Json;
-using Stratis.Bitcoin.Utilities.ValidationAttributes;
 
 namespace Stratis.Bitcoin.Features.Wallet.Models
 {
-    public class OfflineSignRequest
+    /// <summary>
+    /// The signing request to be made against the offline node.
+    /// <remarks>This is intended to exactly match the structure of a <see cref="BuildOfflineSignResponse"/>, but the wallet password is needed as an additional field.</remarks>
+    /// </summary>
+    public class OfflineSignRequest : BuildOfflineSignResponse
     {
         public OfflineSignRequest()
         {
@@ -14,52 +17,10 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         }
 
         /// <summary>
-        /// The wallet containing the UTXO(s) and address(es) needed to sign the transaction offline.
-        /// </summary>
-        [Required]
-        [JsonProperty(PropertyName = "walletName")]
-        public string WalletName { get; set; }
-
-        /// <summary>
-        /// The account containing the UTXO(s) and address(es) needed to sign the transaction offline.
-        /// </summary>
-        [Required]
-        [JsonProperty(PropertyName = "walletAccount")]
-        public string WalletAccount { get; set; }
-
-        /// <summary>
         /// The password to the wallet.
         /// </summary>
         [Required]
         [JsonProperty(PropertyName = "walletPassword")]
         public string WalletPassword { get; set; }
-
-        /// <summary>
-        /// The transaction that needs to be signed by the offline node.
-        /// </summary>
-        [Required]
-        [JsonProperty(PropertyName = "unsignedTransaction")]
-        public string UnsignedTransaction { get; set; }
-
-        /// <summary>
-        /// The transaction fee allocated for the transaction.
-        /// This can be computed by the signer by evaluating the UTXOs and unsigned transaction's outputs, but is included for convenience.
-        /// </summary>
-        [MoneyFormat(isRequired: false, ErrorMessage = "The fee is not in the correct format.")]
-        [JsonProperty(PropertyName = "fee")]
-        public string Fee { get; set; }
-
-        /// <summary>
-        /// A list of UTXO metadata that will be needed by the offline node to sign the transaction and display the correct change etc.
-        /// </summary>
-        [Required]
-        [JsonProperty(PropertyName = "utxos")]
-        public List<UtxoDescriptor> Utxos { get; set; }
-
-        /// <summary>
-        /// An optional list of address metadata, in case the offline node is not expected to be recently synced & requires the exact keypaths.
-        /// </summary>
-        [JsonProperty(PropertyName = "addresses")]
-        public List<AddressDescriptor> Addresses { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
@@ -26,12 +26,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Services
     public class WalletService : IWalletService
     {
         private const int MaxHistoryItemsPerAccount = 1000;
-        private readonly IWalletManager walletManager;
+        protected readonly IWalletManager walletManager;
         private readonly IWalletTransactionHandler walletTransactionHandler;
         private readonly IWalletSyncManager walletSyncManager;
         private readonly IConnectionManager connectionManager;
         private readonly IConsensusManager consensusManager;
-        private readonly Network network;
+        protected readonly Network network;
         private readonly ChainIndexer chainIndexer;
         private readonly IBroadcasterManager broadcasterManager;
         private readonly IDateTimeProvider dateTimeProvider;
@@ -1323,7 +1323,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Services
             }, cancellationToken);
         }
 
-        public async Task<WalletBuildTransactionModel> OfflineSignRequest(OfflineSignRequest request, CancellationToken cancellationToken)
+        public virtual async Task<WalletBuildTransactionModel> OfflineSignRequest(OfflineSignRequest request, CancellationToken cancellationToken)
         {
             return await Task.Run(() =>
             {
@@ -1370,7 +1370,8 @@ namespace Stratis.Bitcoin.Features.Wallet.Services
                 builder.AddKeys(signingKeys.ToArray());
                 builder.SignTransactionInPlace(unsignedTransaction);
 
-                if (!builder.Verify(unsignedTransaction))
+                // TODO: Do something with the errors
+                if (!builder.Verify(unsignedTransaction, out TransactionPolicyError[] errors))
                 {
                     throw new FeatureException(HttpStatusCode.BadRequest, "Failed to validate signed transaction.",
                         $"Failed to validate signed transaction '{unsignedTransaction.GetHash()}' from offline request '{originalTxId}'.");

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/EnvironmentMockUpHelpers/NodeBuilder.cs
@@ -138,6 +138,22 @@ namespace Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers
             return CreateNode(new StratisBitcoinPosRunner(this.GetNextDataFolderName(), network, agent), network.DefaultConfigFilename, configParameters: configParameters);
         }
 
+        /// <summary>
+        /// Creates a Stratis Proof-of-Stake node with the cold staking feature in lieu of the regular wallet.
+        /// <para>
+        /// <see cref="P2P.PeerDiscovery"/> and <see cref="P2P.PeerConnectorDiscovery"/> are disabled by default.
+        /// </para>
+        /// </summary>
+        /// <param name="network">The network the node will run on.</param>
+        /// <param name="agent">Overrides the node's agent prefix.</param>
+        /// <param name="configParameters">Adds to the nodes configuration parameters.</param>
+        /// 
+        /// <returns>The constructed PoS node.</returns>
+        public CoreNode CreateStratisColdStakingNode(Network network, string agent = "StratisBitcoin", NodeConfigParameters configParameters = null)
+        {
+            return CreateNode(new StratisBitcoinColdStakingRunner(this.GetNextDataFolderName(), network, agent), network.DefaultConfigFilename, configParameters: configParameters);
+        }
+
         public CoreNode CloneStratisNode(CoreNode cloneNode, string agent = "StratisBitcoin")
         {
             var node = new CoreNode(new StratisBitcoinPowRunner(cloneNode.FullNode.Settings.DataFolder.RootPath, cloneNode.FullNode.Network, agent), this.ConfigParameters, cloneNode.FullNode.Network.DefaultConfigFilename);

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinColdStakingRunner.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Runners/StratisBitcoinColdStakingRunner.cs
@@ -1,0 +1,58 @@
+﻿using NBitcoin;
+using NBitcoin.Protocol;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Builder;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Features.Api;
+using Stratis.Bitcoin.Features.BlockStore;
+using Stratis.Bitcoin.Features.ColdStaking;
+using Stratis.Bitcoin.Features.Consensus;
+using Stratis.Bitcoin.Features.MemoryPool;
+using Stratis.Bitcoin.Features.Miner;
+using Stratis.Bitcoin.Features.RPC;
+using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
+using Stratis.Bitcoin.Networks;
+using Stratis.Bitcoin.P2P;
+using Stratis.Features.SQLiteWalletRepository;
+
+namespace Stratis.Bitcoin.IntegrationTests.Common.Runners
+{
+    // TODO: Should the regular PoS runner be changed to use cold staking by default instead of this additional class?
+    public sealed class StratisBitcoinColdStakingRunner : NodeRunner
+    {
+        public StratisBitcoinColdStakingRunner(string dataDir, Network network, string agent = "StratisBitcoin")
+            : base(dataDir, agent)
+        {
+            this.Network = network;
+        }
+
+        public override void BuildNode()
+        {
+            var settings = new NodeSettings(this.Network, ProtocolVersion.PROVEN_HEADER_VERSION, this.Agent, args: new string[] { $"-conf={this.Network.DefaultConfigFilename}", "-datadir=" + this.DataFolder });
+
+            var builder = new FullNodeBuilder()
+                .UseNodeSettings(settings)
+                .UseBlockStore()
+                .UsePosConsensus()
+                .UseMempool()
+                .UseColdStakingWallet()
+                .AddSQLiteWalletRepository()
+                .AddPowPosMining(!(this.Network is StratisMain || this.Network is StratisTest || this.Network is StratisRegTest))
+                .AddRPC()
+                .UseApi()
+                .UseTestChainedHeaderTree()
+                .MockIBD();
+
+            if (this.OverrideDateTimeProvider)
+                builder.OverrideDateTimeProviderFor<MiningFeature>();
+
+            if (!this.EnablePeerDiscovery)
+            {
+                builder.RemoveImplementation<PeerConnectorDiscovery>();
+                builder.ReplaceService<IPeerDiscovery, BaseFeature>(new PeerDiscoveryDisabled());
+            }
+
+            this.FullNode = (FullNode)builder.Build();
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Stratis.Bitcoin.IntegrationTests.Common.csproj
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Stratis.Bitcoin.IntegrationTests.Common.csproj
@@ -22,6 +22,7 @@
     <ProjectReference Include="..\NBitcoin\NBitcoin.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Api\Stratis.Bitcoin.Features.Api.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.BlockStore\Stratis.Bitcoin.Features.BlockStore.csproj" />
+    <ProjectReference Include="..\Stratis.Bitcoin.Features.ColdStaking\Stratis.Bitcoin.Features.ColdStaking.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Consensus\Stratis.Bitcoin.Features.Consensus.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.MemoryPool\Stratis.Bitcoin.Features.MemoryPool.csproj" />
     <ProjectReference Include="..\Stratis.Bitcoin.Features.Miner\Stratis.Bitcoin.Features.Miner.csproj" />

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/ColdWalletTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/ColdWalletTests.cs
@@ -127,11 +127,11 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 var hotWalletManager = stratisHotStake.FullNode.WalletManager() as ColdStakingManager;
 
                 // Set up cold staking account on cold wallet.
-                coldWalletManager.GetOrCreateColdStakingAccount(WalletName, true, Password);
+                coldWalletManager.GetOrCreateColdStakingAccount(WalletName, true, Password, null);
                 HdAddress coldWalletAddress = coldWalletManager.GetFirstUnusedColdStakingAddress(WalletName, true);
 
                 // Set up cold staking account on hot wallet.
-                hotWalletManager.GetOrCreateColdStakingAccount(WalletName, false, Password);
+                hotWalletManager.GetOrCreateColdStakingAccount(WalletName, false, Password, null);
                 HdAddress hotWalletAddress = hotWalletManager.GetFirstUnusedColdStakingAddress(WalletName, false);
 
                 var walletAccountReference = new WalletAccountReference(WalletName, Account);
@@ -162,8 +162,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
 
                 // Setup cold staking from the hot wallet.
                 Money amountToSend2 = receiveTotal - network.Consensus.ProofOfWorkReward;
-                Transaction transaction2 = hotWalletManager.GetColdStakingSetupTransaction(stratisHotStake.FullNode.WalletTransactionHandler(),
-                    coldWalletAddress.Address, hotWalletAddress.Address, WalletName, Account, Password, amountToSend2, new Money(0.02m, MoneyUnit.BTC), false, false);
+                (Transaction transaction2, _) = hotWalletManager.GetColdStakingSetupTransaction(stratisHotStake.FullNode.WalletTransactionHandler(),
+                    coldWalletAddress.Address, hotWalletAddress.Address, WalletName, Account, Password, amountToSend2, new Money(0.02m, MoneyUnit.BTC), false, false, false);
 
                 // Broadcast to the other node
                 await stratisHotStake.FullNode.NodeController<WalletController>().SendTransaction(new SendTransactionRequest(transaction2.ToHex()));

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/OfflineSigningTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/OfflineSigningTests.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Flurl;
 using Flurl.Http;
 using NBitcoin;
+using Stratis.Bitcoin.Features.ColdStaking.Models;
+using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Models;
 using Stratis.Bitcoin.IntegrationTests.Common;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
@@ -103,6 +106,197 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
                 TestBase.WaitLoop(() => miningNode.CreateRPCClient().GetRawMempool().Length == 1);
                 TestHelper.MineBlocks(miningNode, 1);
                 TestBase.WaitLoop(() => miningNode.CreateRPCClient().GetRawMempool().Length == 0);
+            }
+        }
+
+        [Fact]
+        public async Task SignColdStakingSetupOffline()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                CoreNode miningNode = builder.CreateStratisColdStakingNode(this.network).WithReadyBlockchainData(ReadyBlockchain.StraxRegTest150Miner).Start();
+                CoreNode onlineNode = builder.CreateStratisColdStakingNode(this.network).Start();
+                CoreNode offlineNode = builder.CreateStratisColdStakingNode(this.network).WithWallet().Start();
+
+                // The offline node never gets connected to anything.
+                TestHelper.ConnectAndSync(miningNode, onlineNode);
+
+                // Get the extpubkey from the offline node to restore on the online node.
+                string extPubKey = await $"http://localhost:{offlineNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/extpubkey")
+                    .SetQueryParams(new { walletName = "mywallet", accountName = "account 0" })
+                    .GetJsonAsync<string>();
+
+                // Load the extpubkey onto the online node.
+                await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/recover-via-extpubkey")
+                    .PostJsonAsync(new WalletExtPubRecoveryRequest
+                    {
+                        Name = "coldwallet",
+                        AccountIndex = 0,
+                        ExtPubKey = extPubKey,
+                        CreationDate = DateTime.Today - TimeSpan.FromDays(1)
+                    })
+                    .ReceiveJson();
+
+                // Get a mnemonic for the hot wallet.
+                string hotWalletMnemonic = await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/mnemonic")
+                    .GetJsonAsync<string>();
+
+                // Restore the hot wallet on the online node.
+                // This is needed because the hot address needs to have a private key available to stake with.
+                await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/recover")
+                    .PostJsonAsync(new WalletRecoveryRequest()
+                    {
+                        Name = "hotwallet",
+                        Mnemonic = hotWalletMnemonic,
+                        Password = "password",
+                        Passphrase = "",
+                        CreationDate = DateTime.Today - TimeSpan.FromDays(1)
+                    })
+                    .ReceiveJson();
+
+                // Get the hot address from the online node.
+                CreateColdStakingAccountResponse hotAccount = await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("coldstaking/cold-staking-account")
+                    .PostJsonAsync(new CreateColdStakingAccountRequest()
+                    {
+                        WalletName = "hotwallet",
+                        WalletPassword = "password",
+                        IsColdWalletAccount = false
+                    })
+                    .ReceiveJson<CreateColdStakingAccountResponse>();
+
+                string hotAddress = (await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("coldstaking/cold-staking-address")
+                    .SetQueryParams(new { walletName = "hotwallet", isColdWalletAddress = "false" })
+                    .GetJsonAsync<GetColdStakingAddressResponse>()).Address;
+
+                string coldWalletUnusedAddress = await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/unusedaddress")
+                    .SetQueryParams(new { walletName = "coldwallet", accountName = "account 0" })
+                    .GetJsonAsync<string>();
+
+                // Send some funds to the hot wallet's default (non-special) account to use for the staking setup.
+                string fundTransaction = (await $"http://localhost:{miningNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/build-transaction")
+                    .PostJsonAsync(new BuildTransactionRequest
+                    {
+                        WalletName = "mywallet",
+                        Password = "password",
+                        AccountName = "account 0",
+                        FeeType = "high",
+                        Recipients = new List<RecipientModel>() { new RecipientModel() { Amount = "5", DestinationAddress = coldWalletUnusedAddress } }
+                    })
+                    .ReceiveJson<WalletBuildTransactionModel>()).Hex;
+
+                await $"http://localhost:{miningNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/send-transaction")
+                    .PostJsonAsync(new SendTransactionRequest()
+                    {
+                        Hex = fundTransaction
+                    })
+                    .ReceiveJson<WalletSendTransactionModel>();
+
+                TestBase.WaitLoop(() => miningNode.CreateRPCClient().GetRawMempool().Length > 0);
+                TestHelper.MineBlocks(miningNode, 1);
+
+                // Set up cold staking account on offline node to get the needed cold address
+                CreateColdStakingAccountResponse coldAccount = await $"http://localhost:{offlineNode.ApiPort}/api"
+                    .AppendPathSegment("coldstaking/cold-staking-account")
+                    .PostJsonAsync(new CreateColdStakingAccountRequest()
+                    {
+                        WalletName = "mywallet",
+                        WalletPassword = "password",
+                        IsColdWalletAccount = true
+                    })
+                    .ReceiveJson<CreateColdStakingAccountResponse>();
+
+                string coldAddress = (await $"http://localhost:{offlineNode.ApiPort}/api"
+                    .AppendPathSegment("coldstaking/cold-staking-address")
+                    .SetQueryParams(new { walletName = "mywallet", isColdWalletAddress = "true" })
+                    .GetJsonAsync<GetColdStakingAddressResponse>()).Address;
+
+                // Get the extpubkey of the cold account from the offline node to restore on the online node.
+                string coldAccountExtPubKey = await $"http://localhost:{offlineNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/extpubkey")
+                    .SetQueryParams(new { walletName = "mywallet", accountName = coldAccount.AccountName })
+                    .GetJsonAsync<string>();
+
+                // Set up the cold account on the online node. This has to be done via extPubKey.
+                await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("coldstaking/cold-staking-account")
+                    .PostJsonAsync(new CreateColdStakingAccountRequest()
+                    {
+                        WalletName = "coldwallet",
+                        WalletPassword = "password",
+                        IsColdWalletAccount = true,
+                        ExtPubKey = coldAccountExtPubKey
+                    })
+                    .ReceiveJson<CreateColdStakingAccountResponse>();
+
+                // Build the offline cold staking template from the online node. No password is needed.
+                BuildOfflineSignResponse offlineTemplate = await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("coldstaking/setup-offline-cold-staking")
+                    .PostJsonAsync(new SetupOfflineColdStakingRequest()
+                    {
+                        ColdWalletAddress = coldAddress,
+                        HotWalletAddress = hotAddress,
+                        WalletName = "coldwallet",
+                        WalletAccount = "account 0",
+                        Amount = "5", // Check that we can send the entire available balance in the setup
+                        Fees = "0.01",
+                        SubtractFeeFromAmount = true,
+                        SegwitChangeAddress = false
+                    })
+                    .ReceiveJson<BuildOfflineSignResponse>();
+
+                // Now build the actual transaction on the offline node. It is not synced with the others and only has the information
+                // in the signing request and its own wallet to construct the transaction with.
+                // Note that the wallet name and account name on the offline node may not actually match those from the online node.
+                WalletBuildTransactionModel builtTransactionModel = await $"http://localhost:{offlineNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/offline-sign-request")
+                    .PostJsonAsync(new OfflineSignRequest()
+                    {
+                        WalletName = "mywallet",
+                        WalletAccount = offlineTemplate.WalletAccount,
+                        WalletPassword = "password",
+                        UnsignedTransaction = offlineTemplate.UnsignedTransaction,
+                        Fee = offlineTemplate.Fee,
+                        Utxos = offlineTemplate.Utxos,
+                        Addresses = offlineTemplate.Addresses
+                    })
+                    .ReceiveJson<WalletBuildTransactionModel>();
+
+                Dictionary<string, int> txCountBefore = await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/transactionCount")
+                    .SetQueryParams(new { walletName = "hotwallet", accountName = hotAccount.AccountName })
+                    .GetJsonAsync<Dictionary<string, int>>();
+
+                Assert.True(txCountBefore.Values.First() == 0);
+
+                // Send the signed transaction from the online node (doesn't really matter, could equally be from the mining node).
+                await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/send-transaction")
+                    .PostJsonAsync(new SendTransactionRequest
+                    {
+                        Hex = builtTransactionModel.Hex
+                    })
+                    .ReceiveJson<WalletSendTransactionModel>();
+
+                // Check that the transaction is valid and therefore relayed, and able to be mined into a block.
+                TestBase.WaitLoop(() => miningNode.CreateRPCClient().GetRawMempool().Length == 1);
+                TestHelper.MineBlocks(miningNode, 1);
+                TestBase.WaitLoop(() => miningNode.CreateRPCClient().GetRawMempool().Length == 0);
+
+                Dictionary<string, int> txCountAfter = await $"http://localhost:{onlineNode.ApiPort}/api"
+                    .AppendPathSegment("wallet/transactionCount")
+                    .SetQueryParams(new { walletName = "hotwallet", accountName = hotAccount.AccountName })
+                    .GetJsonAsync<Dictionary<string, int>>();
+
+                Assert.True(txCountAfter.Values.First() > 0);
             }
         }
     }

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepositoryExt.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepositoryExt.cs
@@ -63,21 +63,8 @@ namespace Stratis.Features.SQLiteWalletRepository
             // We need to examine the entire scriptPubKey of the transaction output in question in order to determine if it is a coldstaking output.
             var scriptPubKey = new Script(Encoders.Hex.DecodeData(transactionData.RedeemScript));
 
-            // Making the actual cold staking script template available here for checking will be quite messy, so just bring in the relevant check.
-            byte[] bytes = scriptPubKey.ToBytes(true);
-            bool isColdStaking = ((bytes.Length == 51)
-                                  && (bytes[0] == (byte)0x76) // OP_DUP
-                                  && (bytes[1] == (byte)0xa9) // OP_HASH160
-                                  && (bytes[2] == (byte)0x7b) // OP_ROT
-                                  && (bytes[3] == (byte)0x63) // OP_IF
-                                  && (bytes[4] == (byte)0xb9) // OP_CHECKCOLDSTAKEVERIFY
-                                  && (bytes[5] == 0x14)
-                                  && (bytes[26] == (byte)0x67) // OP_ELSE
-                                  && (bytes[27] == 0x14)
-                                  && (bytes[48] == (byte)0x68) // OP_ENDIF
-                                  && (bytes[49] == (byte)0x88) // OP_EQUALVERIFY
-                                  && (bytes[50] == (byte)0xac)); // OP_CHECKSIG
-            
+            bool isColdStaking = scriptPubKey.IsScriptType(ScriptType.ColdStaking);
+
             // TODO: Need to make a central determination of whether a UTXO is Segwit or not (i.e. it pays to a P2WPKH scriptPubKey)
 
             var res = new TransactionData()


### PR DESCRIPTION
This extends the offline transaction signing capability of the node to cold staking setup transactions.

The prerequisites are:
1. The offline node, with the full cold wallet restored (does not need to be synced)
2a. The online node, with the wallet from (1) restored via extpubkey (i.e. specifically the cold address account, wallet needs to be synced)
2b. The online node, with the full hot wallet restored (needs to be synced)

The hot wallet needs to be from a separate mnemonic to the offline cold wallet, as it is extremely messy to add a hot account onto the cold extpubkey wallet. Additionally, in order to actually be able to cold stake the hot address private key needs to be available to the online node.

An end-to-end integration test is included demonstrating the rough sequence that is followed in order to be able to complete an offline cold staking setup.