### PR TITLE
Null reference in SignedMultisigTransactionBroadcaster and PartialTransactionRequester

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
@@ -55,7 +55,9 @@ namespace Stratis.Features.FederatedPeg.Wallet
 
             if (this.withdrawalsByDepositDict.TryGetValue(matchingDepositId, out List<TransactionData> txList))
             {
-                txList.Remove(transactionData);
+                int pos = txList.FindIndex(i => i.Id == transactionData.Id && i.Index == transactionData.Index);
+                if (pos >= 0)
+                    txList.RemoveAt(pos);
 
                 if (txList.Count == 0)
                     this.withdrawalsByDepositDict.Remove(matchingDepositId);


### PR DESCRIPTION
https://stratisplatformuk.visualstudio.com/STRAX/_workitems/edit/5291
https://stratisplatformuk.visualstudio.com/STRAX/_workitems/edit/5294
```
        private void AddWithdrawal(TransactionData transactionData)
        {
            uint256 matchingDepositId = transactionData.SpendingDetails?.WithdrawalDetails?.MatchingDepositId;
            if (matchingDepositId == null)
                return;
            if (!this.withdrawalsByDepositDict.TryGetValue(matchingDepositId, out List<TransactionData> txList))
            {
                txList = new List<TransactionData>();
                this.withdrawalsByDepositDict.Add(transactionData.SpendingDetails.WithdrawalDetails.MatchingDepositId, txList);
            }
            txList.Add(transactionData);
        }
```

That's the only method that updates `withdrawalsByDepositDict` and, looking at the code, any item in the dictionary should have a non-null `transactionData.SpendingDetails.WithdrawalDetails`.

So, given that the dictionary is the source of the values its kinda weird that it would be null when accessed, right?

However, if the `SpendingDetails` on a given transaction data is replaced with one missing the withdrawal details this issue CAN arise. The only place I found where that happens is `line 792 of FederationWalletManager`. However the `SpendingDetails` is protected by a setter to prevent exactly this type of issue from arising.

The interesting part of the setter method revolves around `AddWithdrawal` and `RemoveWithdrawal`. Looking at `RemoveWithdrawal` it appears the issue could be as simple as missing a comparator for `TransactionData`.

This PR change that code to not require an `Equals` comparison method.