### PR TITLE
Issue with write protected memory in LevelDB (Transactionality?) (CirrusD)

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockRepositoryTests.cs
@@ -21,8 +21,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                byte[] blockRow = engine.Get(DBH.Key(BlockRepository.CommonTableName, new byte[0]));
-                bool txIndexRow = BitConverter.ToBoolean(engine.Get(DBH.Key(BlockRepository.CommonTableName, new byte[1])));
+                byte[] blockRow = engine.Get(BlockRepository.CommonTableName, new byte[0]);
+                bool txIndexRow = BitConverter.ToBoolean(engine.Get(BlockRepository.CommonTableName, new byte[1]));
 
                 Assert.Equal(this.Network.GetGenesis().GetHash(), this.DBreezeSerializer.Deserialize<HashHeightPair>(blockRow).Hash);
                 Assert.False(txIndexRow);
@@ -36,8 +36,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[0]), this.DBreezeSerializer.Serialize(new HashHeightPair(new uint256(56), 1)));
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[1]), BitConverter.GetBytes(true));
+                engine.Put(BlockRepository.CommonTableName, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(new uint256(56), 1)));
+                engine.Put(BlockRepository.CommonTableName, new byte[1], BitConverter.GetBytes(true));
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -46,8 +46,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                byte[] blockRow = engine.Get(DBH.Key(BlockRepository.CommonTableName, new byte[0]));
-                bool txIndexRow = BitConverter.ToBoolean(engine.Get(DBH.Key(BlockRepository.CommonTableName, new byte[1])));
+                byte[] blockRow = engine.Get(BlockRepository.CommonTableName, new byte[0]);
+                bool txIndexRow = BitConverter.ToBoolean(engine.Get(BlockRepository.CommonTableName, new byte[1]));
 
                 Assert.Equal(new HashHeightPair(new uint256(56), 1), this.DBreezeSerializer.Deserialize<HashHeightPair>(blockRow));
                 Assert.True(txIndexRow);
@@ -61,8 +61,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[0]), this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[1]), BitConverter.GetBytes(false));
+                engine.Put(BlockRepository.CommonTableName, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
+                engine.Put(BlockRepository.CommonTableName, new byte[1], BitConverter.GetBytes(false));
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -79,8 +79,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
                 var blockId = new uint256(8920);
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[0]), this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[1]), BitConverter.GetBytes(true));
+                engine.Put(BlockRepository.CommonTableName, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
+                engine.Put(BlockRepository.CommonTableName, new byte[1], BitConverter.GetBytes(true));
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -102,10 +102,10 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
                 block.Header.GetHash();
                 block.Transactions.Add(trans);
 
-                engine.Put(DBH.Key(BlockRepository.BlockTableName, block.Header.GetHash().ToBytes()), block.ToBytes());
-                engine.Put(DBH.Key(BlockRepository.TransactionTableName, trans.GetHash().ToBytes()), block.Header.GetHash().ToBytes());
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[0]), this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[1]), BitConverter.GetBytes(true));
+                engine.Put(BlockRepository.BlockTableName, block.Header.GetHash().ToBytes(), block.ToBytes());
+                engine.Put(BlockRepository.TransactionTableName, trans.GetHash().ToBytes(), block.Header.GetHash().ToBytes());
+                engine.Put(BlockRepository.CommonTableName, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
+                engine.Put(BlockRepository.CommonTableName, new byte[1], BitConverter.GetBytes(true));
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -121,8 +121,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[0]), this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[1]), BitConverter.GetBytes(false));
+                engine.Put(BlockRepository.CommonTableName, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
+                engine.Put(BlockRepository.CommonTableName, new byte[1], BitConverter.GetBytes(false));
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -138,8 +138,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[0]), this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[1]), BitConverter.GetBytes(true));
+                engine.Put(BlockRepository.CommonTableName, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
+                engine.Put(BlockRepository.CommonTableName, new byte[1], BitConverter.GetBytes(true));
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -155,9 +155,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.TransactionTableName, new uint256(26).ToBytes()), new uint256(42).ToBytes());
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[0]), this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[1]), BitConverter.GetBytes(true));
+                engine.Put(BlockRepository.TransactionTableName, new uint256(26).ToBytes(), new uint256(42).ToBytes());
+                engine.Put(BlockRepository.CommonTableName, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
+                engine.Put(BlockRepository.CommonTableName, new byte[1], BitConverter.GetBytes(true));
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -193,8 +193,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[0]), this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[1]), BitConverter.GetBytes(true));
+                engine.Put(BlockRepository.CommonTableName, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(uint256.Zero, 1)));
+                engine.Put(BlockRepository.CommonTableName, new byte[1], BitConverter.GetBytes(true));
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -204,7 +204,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                byte[] blockHashKeyRow = engine.Get(DBH.Key(BlockRepository.CommonTableName, new byte[0]));
+                byte[] blockHashKeyRow = engine.Get(BlockRepository.CommonTableName, new byte[0]);
 
                 Dictionary<byte[], byte[]> blockDict = engine.SelectDictionary(BlockRepository.BlockTableName);
                 Dictionary<byte[], byte[]> transDict = engine.SelectDictionary(BlockRepository.TransactionTableName);
@@ -233,7 +233,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             string dir = CreateTestDir(this);
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[1]), BitConverter.GetBytes(true));
+                engine.Put(BlockRepository.CommonTableName, new byte[1], BitConverter.GetBytes(true));
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -243,7 +243,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                bool txIndexRow = BitConverter.ToBoolean(engine.Get(DBH.Key(BlockRepository.CommonTableName, new byte[1])));
+                bool txIndexRow = BitConverter.ToBoolean(engine.Get(BlockRepository.CommonTableName, new byte[1]));
                 Assert.False(txIndexRow);
             }
         }
@@ -256,7 +256,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.BlockTableName, block.GetHash().ToBytes()), block.ToBytes());
+                engine.Put(BlockRepository.BlockTableName, block.GetHash().ToBytes(), block.ToBytes());
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -281,7 +281,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
                 for (int i = 0; i < blocks.Length; i++)
-                    engine.Put(DBH.Key(BlockRepository.BlockTableName, blocks[i].GetHash().ToBytes()), blocks[i].ToBytes());
+                    engine.Put(BlockRepository.BlockTableName, blocks[i].GetHash().ToBytes(), blocks[i].ToBytes());
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -313,7 +313,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.BlockTableName, block.GetHash().ToBytes()), block.ToBytes());
+                engine.Put(BlockRepository.BlockTableName, block.GetHash().ToBytes(), block.ToBytes());
             }
 
             using (IBlockRepository repository = this.SetupRepository(this.Network, dir))
@@ -342,9 +342,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.BlockTableName, block.GetHash().ToBytes()), block.ToBytes());
-                engine.Put(DBH.Key(BlockRepository.TransactionTableName, block.Transactions[0].GetHash().ToBytes()), block.GetHash().ToBytes());
-                engine.Put(DBH.Key(BlockRepository.CommonTableName, new byte[1]), BitConverter.GetBytes(true));
+                engine.Put(BlockRepository.BlockTableName, block.GetHash().ToBytes(), block.ToBytes());
+                engine.Put(BlockRepository.TransactionTableName, block.Transactions[0].GetHash().ToBytes(), block.GetHash().ToBytes());
+                engine.Put(BlockRepository.CommonTableName, new byte[1], BitConverter.GetBytes(true));
             }
 
             var tip = new HashHeightPair(new uint256(45), 100);
@@ -356,7 +356,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                byte[] blockHashKeyRow = engine.Get(DBH.Key(BlockRepository.CommonTableName, new byte[0]));
+                byte[] blockHashKeyRow = engine.Get(BlockRepository.CommonTableName, new byte[0]);
                 Dictionary<byte[], byte[]> blockDict = engine.SelectDictionary(BlockRepository.BlockTableName);
                 Dictionary<byte[], byte[]> transDict = engine.SelectDictionary(BlockRepository.TransactionTableName);
 
@@ -377,7 +377,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             // Set up database to mimic that created when TxIndex was off. No transactions stored.
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.BlockTableName, block.GetHash().ToBytes()), block.ToBytes());
+                engine.Put(BlockRepository.BlockTableName, block.GetHash().ToBytes(), block.ToBytes());
             }
 
             // Turn TxIndex on and then reindex database, as would happen on node startup if -txindex and -reindex are set.
@@ -416,8 +416,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             // Set up database to mimic that created when TxIndex was on. Transaction from block is stored.
             using (var engine = new DB(new Options() { CreateIfMissing = true }, dir))
             {
-                engine.Put(DBH.Key(BlockRepository.BlockTableName, block.GetHash().ToBytes()), block.ToBytes());
-                engine.Put(DBH.Key(BlockRepository.TransactionTableName, transaction.GetHash().ToBytes()), block.GetHash().ToBytes());
+                engine.Put(BlockRepository.BlockTableName, block.GetHash().ToBytes(), block.ToBytes());
+                engine.Put(BlockRepository.TransactionTableName, transaction.GetHash().ToBytes(), block.GetHash().ToBytes());
             }
 
             // Turn TxIndex off and then reindex database, as would happen on node startup if -txindex=0 and -reindex are set.

--- a/src/Stratis.Bitcoin.Features.BlockStore/Pruning/PrunedBlockRepository.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Pruning/PrunedBlockRepository.cs
@@ -44,7 +44,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Pruning
 
                 this.PrunedTip = new HashHeightPair(genesis.GetHash(), 0);
 
-                this.blockRepository.Leveldb.Put(DBH.Key(BlockRepository.CommonTableName, prunedTipKey), this.dBreezeSerializer.Serialize(this.PrunedTip));
+                this.blockRepository.Leveldb.Put(BlockRepository.CommonTableName, prunedTipKey, this.dBreezeSerializer.Serialize(this.PrunedTip));
             }
 
             if (nodeInitializing)
@@ -107,7 +107,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Pruning
             if (this.PrunedTip != null) 
                 return;
 
-            byte[] row = leveldb.Get(DBH.Key(BlockRepository.CommonTableName, prunedTipKey));
+            byte[] row = leveldb.Get(BlockRepository.CommonTableName, prunedTipKey);
 
             if (row != null)
                 this.PrunedTip = this.dBreezeSerializer.Deserialize<HashHeightPair>(row);

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/ProvenBlockHeaders/ProvenBlockHeaderRepositoryTests.cs
@@ -60,8 +60,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, folder))
             {
-                var headerOut = this.dBreezeSerializer.Deserialize<ProvenBlockHeader>(engine.Get(DBH.Key(ProvenBlockHeaderTable, BitConverter.GetBytes(blockHashHeightPair.Height))));
-                var hashHeightPairOut = this.DBreezeSerializer.Deserialize<HashHeightPair>(engine.Get(DBH.Key(BlockHashHeightTable, new byte[] { 1 })));
+                var headerOut = this.dBreezeSerializer.Deserialize<ProvenBlockHeader>(engine.Get(ProvenBlockHeaderTable, BitConverter.GetBytes(blockHashHeightPair.Height)));
+                var hashHeightPairOut = this.DBreezeSerializer.Deserialize<HashHeightPair>(engine.Get(BlockHashHeightTable, new byte[] { 1 }));
 
                 headerOut.Should().NotBeNull();
                 headerOut.GetHash().Should().Be(provenBlockHeaderIn.GetHash());
@@ -114,7 +114,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, folder))
             {
-                engine.Put(DBH.Key(ProvenBlockHeaderTable, BitConverter.GetBytes(blockHeight)), this.dBreezeSerializer.Serialize(headerIn));
+                engine.Put(ProvenBlockHeaderTable, BitConverter.GetBytes(blockHeight), this.dBreezeSerializer.Serialize(headerIn));
             }
 
             // Query the repository for the item that was inserted in the above code.
@@ -134,8 +134,8 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.ProvenBlockHeaders
 
             using (var engine = new DB(new Options() { CreateIfMissing = true }, folder))
             {
-                engine.Put(DBH.Key(ProvenBlockHeaderTable, BitConverter.GetBytes(1)), this.dBreezeSerializer.Serialize(CreateNewProvenBlockHeaderMock()));
-                engine.Put(DBH.Key(BlockHashHeightTable, new byte[0]), this.DBreezeSerializer.Serialize(new HashHeightPair(new uint256(), 1)));
+                engine.Put(ProvenBlockHeaderTable, BitConverter.GetBytes(1), this.dBreezeSerializer.Serialize(CreateNewProvenBlockHeaderMock()));
+                engine.Put(BlockHashHeightTable, new byte[0], this.DBreezeSerializer.Serialize(new HashHeightPair(new uint256(), 1)));
             }
 
             using (ProvenBlockHeaderRepository repo = this.SetupRepository(this.Network, folder))

--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/ProvenBlockHeaderRepository.cs
@@ -120,7 +120,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
 
                 lock (this.locker)
                 {
-                    row = this.leveldb.Get(DBH.Key(provenBlockHeaderTable, BitConverter.GetBytes(blockHeight)));
+                    row = this.leveldb.Get(provenBlockHeaderTable, BitConverter.GetBytes(blockHeight));
                 }
 
                 if (row != null)
@@ -165,7 +165,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
 
             lock (this.locker)
             {
-                this.leveldb.Put(DBH.Key(blockHashHeightTable, blockHashHeightKey), this.dBreezeSerializer.Serialize(newTip));
+                this.leveldb.Put(blockHashHeightTable, blockHashHeightKey, this.dBreezeSerializer.Serialize(newTip));
             }
         }
 
@@ -178,7 +178,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
             using (var batch = new WriteBatch())
             {
                 foreach (KeyValuePair<int, ProvenBlockHeader> header in headers)
-                    batch.Put(DBH.Key(provenBlockHeaderTable, BitConverter.GetBytes(header.Key)), this.dBreezeSerializer.Serialize(header.Value));
+                    batch.Put(provenBlockHeaderTable, BitConverter.GetBytes(header.Key), this.dBreezeSerializer.Serialize(header.Value));
 
                 lock (this.locker)
                 {
@@ -201,7 +201,7 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
             byte[] row = null;
             lock (this.locker)
             {
-                row = this.leveldb.Get(DBH.Key(blockHashHeightTable, blockHashHeightKey));
+                row = this.leveldb.Get(blockHashHeightTable, blockHashHeightKey);
             }
 
             if (row != null)

--- a/src/Stratis.Bitcoin.Tests/Base/ChainRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Base/ChainRepositoryTest.cs
@@ -77,7 +77,7 @@ namespace Stratis.Bitcoin.Tests.Base
 
                     foreach (ChainedHeader block in blocks)
                     {
-                        batch.Put(DBH.Key(1, BitConverter.GetBytes(block.Height)),
+                        batch.Put(1, BitConverter.GetBytes(block.Height),
                             new ChainRepository.ChainRepositoryData()
                                     { Hash = block.HashBlock, Work = block.ChainWorkBytes }
                                 .ToBytes(this.Network.Consensus.ConsensusFactory));

--- a/src/Stratis.Bitcoin/Consensus/LeveldbHeaderStore.cs
+++ b/src/Stratis.Bitcoin/Consensus/LeveldbHeaderStore.cs
@@ -49,7 +49,7 @@ namespace Stratis.Bitcoin.Consensus
 
             lock (this.locker)
             {
-                bytes = this.leveldb.Get(DBH.Key(HeaderTableName, bytes));
+                bytes = this.leveldb.Get(HeaderTableName, bytes);
             }
 
             if (bytes == null)
@@ -87,7 +87,7 @@ namespace Stratis.Bitcoin.Consensus
 
             lock (this.locker)
             {
-                this.leveldb.Put(DBH.Key(HeaderTableName, blockHeader.GetHash().ToBytes()), blockHeader.ToBytes(consensusFactory));
+                this.leveldb.Put(HeaderTableName, blockHeader.GetHash().ToBytes(), blockHeader.ToBytes(consensusFactory));
             }
 
             return true;
@@ -99,7 +99,7 @@ namespace Stratis.Bitcoin.Consensus
 
             lock (this.locker)
             {
-                bytes = this.leveldb.Get(DBH.Key(ChainTableName, BitConverter.GetBytes(height)));
+                bytes = this.leveldb.Get(ChainTableName, BitConverter.GetBytes(height));
             }
 
             if (bytes == null)
@@ -119,7 +119,7 @@ namespace Stratis.Bitcoin.Consensus
             {
                 foreach (var item in items)
                 {
-                    batch.Put(DBH.Key(ChainTableName, BitConverter.GetBytes(item.Height)), item.Data.ToBytes(this.network.Consensus.ConsensusFactory));
+                    batch.Put(ChainTableName, BitConverter.GetBytes(item.Height), item.Data.ToBytes(this.network.Consensus.ConsensusFactory));
                 }
 
                 lock (this.locker)

--- a/src/Stratis.Bitcoin/Utilities/LeveldbHelper.cs
+++ b/src/Stratis.Bitcoin/Utilities/LeveldbHelper.cs
@@ -6,22 +6,40 @@ namespace Stratis.Bitcoin.Utilities
 {
     public static class DBH
     {
-        public static byte[] Key(byte table, byte[] key)
+        public static byte[] Get(this DB db, byte table, byte[] key)
         {
-            var dbkey = new byte[key.Length + 1];
+            Span<byte> dbkey = stackalloc byte[key.Length + 1];
             dbkey[0] = table;
-            key.AsSpan().CopyTo(dbkey[1..]);
+            key.AsSpan().CopyTo(dbkey.Slice(1));
 
-            return dbkey;
+            return db.Get(dbkey.ToArray());
         }
 
-        public static byte[] Key(byte table, ReadOnlySpan<byte> key)
+        public static void Put(this DB db, byte table, byte[] key, byte[] value)
         {
-            var dbkey = new byte[key.Length + 1];
+            Span<byte> dbkey = stackalloc byte[key.Length + 1];
             dbkey[0] = table;
-            key.CopyTo(dbkey[1..]);
+            key.AsSpan().CopyTo(dbkey.Slice(1));
 
-            return dbkey;
+            db.Put(dbkey.ToArray(), value);
+        }
+
+        public static void Delete(this DB db, byte table, byte[] key)
+        {
+            Span<byte> dbkey = stackalloc byte[key.Length + 1];
+            dbkey[0] = table;
+            key.AsSpan().CopyTo(dbkey.Slice(1));
+
+            db.Delete(dbkey.ToArray());
+        }
+
+        public static void Put(this WriteBatch batch, byte table, byte[] key, byte[] value)
+        {
+            Span<byte> dbkey = stackalloc byte[key.Length + 1];
+            dbkey[0] = table;
+            key.AsSpan().CopyTo(dbkey.Slice(1));
+
+            batch.Put(dbkey.ToArray(), value);
         }
 
         public static Dictionary<byte[], byte[]> SelectDictionary(this DB db, byte table)

--- a/src/Stratis.Bitcoin/Utilities/LeveldbHelper.cs
+++ b/src/Stratis.Bitcoin/Utilities/LeveldbHelper.cs
@@ -8,7 +8,7 @@ namespace Stratis.Bitcoin.Utilities
     {
         public static byte[] Key(byte table, byte[] key)
         {
-            Span<byte> dbkey = stackalloc byte[key.Length + 1];
+            Span<byte> dbkey = new byte[key.Length + 1];
             dbkey[0] = table;
             key.AsSpan().CopyTo(dbkey.Slice(1));
 
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Utilities
 
         public static byte[] Key(byte table, ReadOnlySpan<byte> key)
         {
-            Span<byte> dbkey = stackalloc byte[key.Length + 1];
+            Span<byte> dbkey = new byte[key.Length + 1];
             dbkey[0] = table;
             key.CopyTo(dbkey.Slice(1));
 

--- a/src/Stratis.Bitcoin/Utilities/LeveldbHelper.cs
+++ b/src/Stratis.Bitcoin/Utilities/LeveldbHelper.cs
@@ -8,20 +8,20 @@ namespace Stratis.Bitcoin.Utilities
     {
         public static byte[] Key(byte table, byte[] key)
         {
-            Span<byte> dbkey = new byte[key.Length + 1];
+            var dbkey = new byte[key.Length + 1];
             dbkey[0] = table;
-            key.AsSpan().CopyTo(dbkey.Slice(1));
+            key.AsSpan().CopyTo(dbkey[1..]);
 
-            return dbkey.ToArray();
+            return dbkey;
         }
 
         public static byte[] Key(byte table, ReadOnlySpan<byte> key)
         {
-            Span<byte> dbkey = new byte[key.Length + 1];
+            var dbkey = new byte[key.Length + 1];
             dbkey[0] = table;
-            key.CopyTo(dbkey.Slice(1));
+            key.CopyTo(dbkey[1..]);
 
-            return dbkey.ToArray();
+            return dbkey;
         }
 
         public static Dictionary<byte[], byte[]> SelectDictionary(this DB db, byte table)


### PR DESCRIPTION
https://dev.azure.com/Stratisplatformuk/HPI/_workitems/edit/5292/

"A stack allocated memory block created during the method execution is automatically discarded when that method returns."
https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/operators/stackalloc