### PR TITLE
Dispose PartialValidator and BlockPuller after ConsensusManager

### DIFF
--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -321,14 +321,14 @@ namespace Stratis.Bitcoin.Base
             this.logger.LogInformation("Disposing time sync behavior.");
             this.timeSyncBehaviorState.Dispose();
 
+            this.logger.LogInformation("Disposing consensus manager.");
+            this.consensusManager.Dispose();
+
             this.logger.LogInformation("Disposing block puller.");
             this.blockPuller.Dispose();
 
             this.logger.LogInformation("Disposing partial validator.");
             this.partialValidator.Dispose();
-
-            this.logger.LogInformation("Disposing consensus manager.");
-            this.consensusManager.Dispose();
 
             this.logger.LogInformation("Disposing consensus rules.");
             this.consensusRules.Dispose();


### PR DESCRIPTION
`ConsensusManager` is dependent on `PartialValidator` and `BlockPuller` and should therefore be disposed last by their creator (`BaseFeature`)

Relates to the log found with https://dev.azure.com/stratisplatformuk/HPI/_workitems/edit/5300/.