### PR TITLE
Avoid duplicates during add/remove withdrawal

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NBitcoin;
@@ -104,16 +105,23 @@ namespace Stratis.Features.FederatedPeg.Wallet
         {
             lock (this.lockObject)
             {
-                this.transactionDict.Add(transactionData.Key, transactionData);
+                try
+                {
+                    this.transactionDict.Add(transactionData.Key, transactionData);
 
-                if (transactionData.IsSpendable())
-                    this.spendableTransactionList.Add(transactionData, transactionData);
+                    if (transactionData.IsSpendable())
+                        this.spendableTransactionList.Add(transactionData, transactionData);
 
-                this.AddWithdrawal(transactionData);
+                    this.AddWithdrawal(transactionData);
 
-                this.AddSpentTransactionByHeight(transactionData);
+                    this.AddSpentTransactionByHeight(transactionData);
 
-                transactionData.Subscribe(this);
+                    transactionData.Subscribe(this);
+                }
+                catch (Exception err)
+                {
+                    throw new System.Exception("An error occurred during transaction data addition.", err);
+                }
             }
         }
 
@@ -127,18 +135,25 @@ namespace Stratis.Features.FederatedPeg.Wallet
         {
             lock (this.lockObject)
             {
-                bool res = this.transactionDict.Remove(transactionData.Key);
+                try
+                {
+                    bool res = this.transactionDict.Remove(transactionData.Key);
 
-                if (this.spendableTransactionList.ContainsKey(transactionData))
-                    this.spendableTransactionList.Remove(transactionData);
+                    if (this.spendableTransactionList.ContainsKey(transactionData))
+                        this.spendableTransactionList.Remove(transactionData);
 
-                this.RemoveWithdrawal(transactionData);
+                    this.RemoveWithdrawal(transactionData);
 
-                this.RemoveSpentTransactionByHeight(transactionData);
+                    this.RemoveSpentTransactionByHeight(transactionData);
 
-                transactionData.Subscribe(null);
+                    transactionData.Subscribe(null);
 
-                return res;
+                    return res;
+                }
+                catch (Exception err)
+                {
+                    throw new System.Exception("An error occurred during transaction data removal.", err);
+                }
             }
         }
 

--- a/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
@@ -43,7 +43,8 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 this.withdrawalsByDepositDict.Add(transactionData.SpendingDetails.WithdrawalDetails.MatchingDepositId, txList);
             }
 
-            txList.Add(transactionData);
+            if (!txList.Any(i => i.Id == transactionData.Id && i.Index == transactionData.Index))
+                txList.Add(transactionData);
         }
 
         private void RemoveWithdrawal(TransactionData transactionData)
@@ -57,10 +58,12 @@ namespace Stratis.Features.FederatedPeg.Wallet
             {
                 int pos = txList.FindIndex(i => i.Id == transactionData.Id && i.Index == transactionData.Index);
                 if (pos >= 0)
+                {
                     txList.RemoveAt(pos);
 
-                if (txList.Count == 0)
-                    this.withdrawalsByDepositDict.Remove(matchingDepositId);
+                    if (txList.Count == 0)
+                        this.withdrawalsByDepositDict.Remove(matchingDepositId);
+                }
             }
         }
 


### PR DESCRIPTION
- Checks for duplicates when transaction data is added to ensure removal will remove the only entry.
- Adds context information to highlight if issues are arising during transaction data addition / removal.

https://dev.azure.com/stratisplatformuk/HPI/_workitems/edit/5294