### PR TITLE
Implements Poll Expiry

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/Voting/Poll.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/Poll.cs
@@ -17,10 +17,13 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         /// <c>true</c> if poll still didn't get enough votes.
         /// <c>false</c> in case majority of fed members voted in favor and result of the poll was scheduled to be applied after max reorg blocks are mined.
         /// </summary>
-        public bool IsPending => this.PollVotedInFavorBlockData == null;
+        public bool IsPending => this.PollVotedInFavorBlockData == null && !this.IsExpired;
 
         /// <summary><c>true</c> if poll wasn't executed yet; <c>false</c> otherwise.</summary>
-        public bool IsExecuted => this.PollExecutedBlockData != null;
+        public bool IsExecuted => this.PollExecutedBlockData?.Height > 0;
+
+        /// <summary><c>true</c> if poll has expired; <c>false</c> otherwise.</summary>
+        public bool IsExpired => this.PollExecutedBlockData?.Height == 0;
 
         public int Id;
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -574,16 +574,21 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
             lock (this.locker)
             {
-                log.AppendLine("Expired Member Polls".PadRight(30) + ": " + GetExpiredPolls().MemberPolls().Count);
-                log.AppendLine("Pending Member Polls".PadRight(30) + ": " + GetPendingPolls().MemberPolls().Count);
-                log.AppendLine("Approved Member Polls".PadRight(30) + ": " + GetFinishedPolls().MemberPolls().Count);
-                log.AppendLine("Executed Member Polls".PadRight(30) + ": " + GetExecutedPolls().MemberPolls().Count);
-                log.AppendLine("Expired Whitelist Polls".PadRight(30) + ": " + GetExpiredPolls().WhitelistPolls().Count);
-                log.AppendLine("Pending Whitelist Polls".PadRight(30) + ": " + GetPendingPolls().WhitelistPolls().Count);
-                log.AppendLine("Approved Whitelist Polls".PadRight(30) + ": " + GetFinishedPolls().WhitelistPolls().Count);
-                log.AppendLine("Executed Whitelist Polls".PadRight(30) + ": " + GetExecutedPolls().WhitelistPolls().Count);
-                log.AppendLine("Scheduled Votes".PadRight(30) + ": " + this.scheduledVotingData.Count);
-                log.AppendLine($"Scheduled votes will be added to the next block this node mines.");
+                log.AppendLine(
+                    "Expired Member Polls".PadRight(30) + ": " + GetExpiredPolls().MemberPolls().Count.ToString().PadRight(16) +
+                    "Expired Whitelist Polls".PadRight(30) + ": " + GetExpiredPolls().WhitelistPolls().Count);
+                log.AppendLine(
+                    "Pending Member Polls".PadRight(30) + ": " + GetPendingPolls().MemberPolls().Count.ToString().PadRight(16) +
+                    "Pending Whitelist Polls".PadRight(30) + ": " + GetPendingPolls().WhitelistPolls().Count);
+                log.AppendLine(
+                    "Approved Member Polls".PadRight(30) + ": " + GetFinishedPolls().MemberPolls().Count.ToString().PadRight(16) +
+                    "Approved Whitelist Polls".PadRight(30) + ": " + GetFinishedPolls().WhitelistPolls().Count);
+                log.AppendLine(
+                    "Executed Member Polls".PadRight(30) + ": " + GetExecutedPolls().MemberPolls().Count.ToString().PadRight(16) +
+                    "Executed Whitelist Polls".PadRight(30) + ": " + GetExecutedPolls().WhitelistPolls().Count);
+                log.AppendLine(
+                    "Scheduled Votes".PadRight(30) + ": " + this.scheduledVotingData.Count.ToString().PadRight(16) +
+                    "Scheduled votes will be added to the next block this node mines.");
             }
         }
 


### PR DESCRIPTION
Implements poll expiry. Since the longest running poll that got applied is about 31,000 blocks a poll expiry of 50,000 blocks should be compatible with legacy blocks. 

- Expired polls are flagged with a `PollExecutedBlockData.Height = 0`.
- The `IsPending` and `IsExecuted` properties are updates, and `IsExpired` is added.
- The `GetFinishedPolls` method is updated to exclude expired polls and the `GetExpired` method is added.
- The `CleanFinishedPollsLocked` and `AlreadyVotingFor` methods are updated to exclude old expired polls.
- The `OnBlockConnected` and `OnBlockDisconnected` methods are updated to expire and un-expire polls.
- Console verbiage is updated to change "finished" to "approved" as that is more descriptive of the poll type.