### PR TITLE
Fix overflow in payload statistics

### DIFF
--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -356,7 +356,7 @@ namespace Stratis.Bitcoin.Connection
 
             builder.AppendLine();
 
-            string ToMB(int bytes)
+            string ToMB(long bytes)
             {
                 return string.Format("{0:0.000}", (double)((bytes + 500) / 1000) / 1000);
             }
@@ -364,8 +364,8 @@ namespace Stratis.Bitcoin.Connection
             var metrics = this.payloadProvider.GetPayloadTypeMetrics();
             if (metrics.Count > 0)
             {
-                int bytesIn = metrics.Sum(m => m.Value.BytesReceivedCount);
-                int bytesOut = metrics.Sum(m => m.Value.BytesSentCount);
+                long bytesIn = metrics.Sum(m => m.Value.BytesReceivedCount);
+                long bytesOut = metrics.Sum(m => m.Value.BytesSentCount);
                 builder.AppendLine($"---Payload Bandwidth Breakdown (In/Out MB = {ToMB(bytesIn)}/{ToMB(bytesOut)})---");
                 int i = 0;
                 foreach (Type payloadType in metrics.Keys)

--- a/src/Stratis.Bitcoin/P2P/Protocol/Payloads/PayloadAttribute.cs
+++ b/src/Stratis.Bitcoin/P2P/Protocol/Payloads/PayloadAttribute.cs
@@ -37,9 +37,9 @@ namespace Stratis.Bitcoin.P2P.Protocol.Payloads
 
         public int SentCount { get; set; }
 
-        public int BytesSentCount { get; set; }
+        public long BytesSentCount { get; set; }
 
-        public int BytesReceivedCount { get; set; }
+        public long BytesReceivedCount { get; set; }
     }
 
     /// <summary>


### PR DESCRIPTION
```
      ConnectionManager failed to provide statistics: System.OverflowException: Arithmetic operation resulted in an overflow.
         at System.Linq.Enumerable.Sum[TSource](IEnumerable`1 source, Func`2 selector)
         at Stratis.Bitcoin.Connection.ConnectionManager.AddComponentStats(StringBuilder builder) in /home/kevin/StratisFullNode/src/Stratis.Bitcoin/Connection/ConnectionManager.cs:line 368
         at Stratis.Bitcoin.Utilities.NodeStats.<>c__DisplayClass8_2.<GetStats>b__3() in /home/kevin/StratisFullNode/src/Stratis.Bitcoin/Utilities/NodeStats.cs:line 124
```