### PR TITLE
Standardize vote data bytes

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/CollateralPoAConsensusFactory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/CollateralPoAConsensusFactory.cs
@@ -38,7 +38,7 @@ namespace Stratis.Bitcoin.Features.PoA
             string json = Serializer.ToString(model);
 
             // Standardize the bytes produced as its often used in poll matching.
-            if (Environment.NewLine == "\r\n")
+            if (Environment.NewLine != "\n")
                 json = json.Replace(Environment.NewLine, "\n");
 
             byte[] jsonBytes = Encoding.ASCII.GetBytes(json);

--- a/src/Stratis.Bitcoin.Features.PoA/CollateralPoAConsensusFactory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/CollateralPoAConsensusFactory.cs
@@ -36,6 +36,11 @@ namespace Stratis.Bitcoin.Features.PoA
             };
 
             string json = Serializer.ToString(model);
+
+            // Standardize the bytes produced as its often used in poll matching.
+            if (Environment.NewLine == "\r\n")
+                json = json.Replace(Environment.NewLine, "\n");
+
             byte[] jsonBytes = Encoding.ASCII.GetBytes(json);
 
             return jsonBytes;


### PR DESCRIPTION
**This is an important find as it could be one of the root causes of many issues.**

Different vote data bytes are being produced on Windows / Linux due to the difference in new-line character.

Due to this being the primary means of poll identification this leads to existing polls not being identified correctly between Windows  and Linux. These two sets of users essentially each generate their own set of polls to vote on.

This PR standardizes new polls to be serialized using the Linux linefeed character:

```
            string json = Serializer.ToString(model);

            // Standardize the bytes produced as its often used in poll matching.
            if (Environment.NewLine != "\n")
                json = json.Replace(Environment.NewLine, "\n");

            byte[] jsonBytes = Encoding.ASCII.GetBytes(json);

            return jsonBytes;
```

This is intended to be the lowest impact change possible. Suggested follow-up is to expire pending polls older than 5 days or so.