### PR TITLE
Remove Task.Run from MergeTransactionSignatures

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -1239,32 +1239,6 @@ namespace Stratis.Features.FederatedPeg.Tests
         }
 
         /// <summary>
-        /// Recording deposits when the target is our multisig is ignored, but a different multisig is allowed.
-        /// </summary>
-        [Fact]
-        public async Task GetStackTrace()
-        {
-            var dataFolder = new DataFolder(TestBase.CreateTestDir(this));
-
-            this.Init(dataFolder);
-            this.AddFunding();
-            this.AppendBlocks(WithdrawalTransactionBuilder.MinConfirmations);
-
-            MultiSigAddress multiSigAddress = this.wallet.MultiSigAddress;
-
-            using (ICrossChainTransferStore crossChainTransferStore = this.CreateStore())
-            {
-                crossChainTransferStore.Initialize();
-                crossChainTransferStore.Start();
-
-                TestBase.WaitLoopMessage(() => (this.ChainIndexer.Tip.Height == crossChainTransferStore.TipHashAndHeight.Height, $"ChainIndexer.Height:{this.ChainIndexer.Tip.Height} Store.TipHashHeight:{crossChainTransferStore.TipHashAndHeight.Height}"));
-                Assert.Equal(this.ChainIndexer.Tip.HashBlock, crossChainTransferStore.TipHashAndHeight.HashBlock);
-
-                crossChainTransferStore.MergeTransactionSignatures(new uint256(), new[] { this.network.CreateTransaction() });
-            }
-        }
-
-        /// <summary>
         /// <see cref="CrossChainTransferStore.IsMempoolErrorRecoverable(MempoolError)"/> returns appropriate responses for different types of errors.
         /// </summary>
         [Fact]

--- a/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransferStore.cs
@@ -62,7 +62,7 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// transaction that has been recorded in the wallet.
         /// </remarks>
         /// <returns>The updated transaction.</returns>
-        Task<Transaction> MergeTransactionSignaturesAsync(uint256 depositId, Transaction[] partialTransactions);
+        Transaction MergeTransactionSignatures(uint256 depositId, Transaction[] partialTransactions);
 
         /// <summary>
         /// Get the cross-chain transfer information from the database, identified by the deposit transaction ids.

--- a/src/Stratis.Features.FederatedPeg/PartialTransactionsBehavior.cs
+++ b/src/Stratis.Features.FederatedPeg/PartialTransactionsBehavior.cs
@@ -126,7 +126,7 @@ namespace Stratis.Features.FederatedPeg
 
             uint256 oldHash = transfer[0].PartialTransaction.GetHash();
 
-            Transaction signedTransaction = await this.crossChainTransferStore.MergeTransactionSignaturesAsync(payload.DepositId, new[] { payload.PartialTransaction }).ConfigureAwait(false);
+            Transaction signedTransaction = this.crossChainTransferStore.MergeTransactionSignatures(payload.DepositId, new[] { payload.PartialTransaction });
 
             if (signedTransaction == null)
             {

--- a/src/Stratis.Features.FederatedPeg/TargetChain/PartialTransactionRequester.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/PartialTransactionRequester.cs
@@ -13,7 +13,7 @@ using Stratis.Features.FederatedPeg.Payloads;
 namespace Stratis.Features.FederatedPeg.TargetChain
 {
     /// <summary>
-    /// Requests partial transactions from the peers and calls <see cref="ICrossChainTransferStore.MergeTransactionSignaturesAsync".
+    /// Requests partial transactions from the peers and calls <see cref="ICrossChainTransferStore.MergeTransactionSignatures".
     /// </summary>
     public interface IPartialTransactionRequester
     {


### PR DESCRIPTION
This is causing our exception stack trace to be swallowed and it doesnt really serve any purpose at this stage.