### PR TITLE
Add watch only wallet details to api model

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -473,7 +473,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         public async Task<IActionResult> ListWallets(CancellationToken cancellationToken = default(CancellationToken))
         {
             return await this.ExecuteAsAsync((object)null, cancellationToken, (req, token) =>
-               this.Json(new WalletInfoModel(this.walletManager.GetWalletsNames())), false);
+               this.Json(new WalletInfoModel(this.walletManager.GetWalletsNames(), this.walletManager.GetWatchOnlyWalletsNames())), false);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -349,6 +349,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         IEnumerable<string> GetWalletsNames();
 
         /// <summary>
+        /// Gets all the wallets' names that have been restored via an account extPubKey.
+        /// </summary>
+        /// <returns>A collection of the watch only wallets' names.</returns>
+        IEnumerable<string> GetWatchOnlyWalletsNames();
+
+        /// <summary>
         /// Gets a wallet given its name.
         /// </summary>
         /// <param name="walletName">The name of the wallet to get.</param>

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/WalletInfoModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/WalletInfoModel.cs
@@ -9,12 +9,16 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         {
         }
 
-        public WalletInfoModel(IEnumerable<string> walletNames)
+        public WalletInfoModel(IEnumerable<string> walletNames, IEnumerable<string> watchOnlyWallets)
         {
             this.WalletNames = walletNames;
+            this.WatchOnlyWallets = watchOnlyWallets;
         }
 
         [JsonProperty(PropertyName = "walletNames")]
         public IEnumerable<string> WalletNames { get; set; }
+
+        [JsonProperty(PropertyName = "watchOnlyWallets")]
+        public IEnumerable<string> WatchOnlyWallets { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -1315,6 +1315,22 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <inheritdoc />
+        public IEnumerable<string> GetWatchOnlyWalletsNames()
+        {
+            var watchOnlyWallets = new List<string>();
+
+            foreach (string walletName in this.WalletRepository.GetWalletNames())
+            {
+                Wallet wallet = this.WalletRepository.GetWallet(walletName);
+
+                if (wallet.IsExtPubKeyWallet)
+                    watchOnlyWallets.Add(walletName);
+            }
+
+            return watchOnlyWallets;
+        }
+
+        /// <inheritdoc />
         public Wallet GetWallet(string walletName)
         {
             var wallet = this.WalletRepository.GetWallet(walletName);


### PR DESCRIPTION
Augment existing model in a backwards-compatible way so that wallets lacking private keys can be identified from the API.