### PR TITLE
Add miner delay when collateral info not available

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -175,6 +175,9 @@ namespace Stratis.Bitcoin.Features.PoA
 
                     if (chainedHeader == null)
                     {
+                        int attemptDelayMs = 10_000;
+                        await Task.Delay(attemptDelayMs, this.cancellation.Token).ConfigureAwait(false);
+
                         continue;
                     }
 

--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -175,7 +175,7 @@ namespace Stratis.Bitcoin.Features.PoA
 
                     if (chainedHeader == null)
                     {
-                        int attemptDelayMs = 10_000;
+                        int attemptDelayMs = 500;
                         await Task.Delay(attemptDelayMs, this.cancellation.Token).ConfigureAwait(false);
 
                         continue;


### PR DESCRIPTION
Currently the code enters a tight CPU consuming loop.