### PR TITLE
Add FederationHistory class

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -120,9 +120,16 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
                 new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, nodeSettings.DataFolder, dbreezeSerializer, signals, finalizedBlockRepo, network);
 
             var federationHistory = new Mock<IFederationHistory>();
-            federationHistory.Setup(x => x.GetFederationMemberForBlock(It.IsAny<ChainedHeader>())).Returns<ChainedHeader>((a) => {
+            federationHistory.Setup(x => x.GetFederationMemberForBlock(It.IsAny<ChainedHeader>())).Returns<ChainedHeader>((chainedHeader) => {
                 List<IFederationMember> members = ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;
-                return members[a.Height % members.Count];
+                return members[chainedHeader.Height % members.Count];
+            });
+            federationHistory.Setup(x => x.GetFederationMemberForBlock(It.IsAny<ChainedHeader>(), It.IsAny<List<IFederationMember>>())).Returns<ChainedHeader, List<IFederationMember>>((chainedHeader, members) => {
+                members = members ?? ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;
+                return members[chainedHeader.Height % members.Count];
+            });
+            federationHistory.Setup(x => x.GetFederationForBlock(It.IsAny<ChainedHeader>())).Returns<ChainedHeader>((chainedHeader) => {
+                return ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;
             });
 
             votingManager.Initialize(federationHistory.Object);

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -34,6 +34,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         protected readonly ConsensusSettings consensusSettings;
         protected readonly ChainIndexer ChainIndexer;
         protected readonly IFederationManager federationManager;
+        protected readonly IFederationHistory federationHistory;
         protected readonly VotingManager votingManager;
         protected readonly Mock<IPollResultExecutor> resultExecutorMock;
         protected readonly Mock<ChainIndexer> chainIndexerMock;
@@ -55,7 +56,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             IDateTimeProvider timeProvider = new DateTimeProvider();
             this.consensusSettings = new ConsensusSettings(NodeSettings.Default(this.network));
 
-            this.federationManager = CreateFederationManager(this, this.network, this.loggerFactory, this.signals);
+            (this.federationManager, this.federationHistory) = CreateFederationManager(this, this.network, this.loggerFactory, this.signals);
 
             this.chainIndexerMock = new Mock<ChainIndexer>();
             var header = new BlockHeader();
@@ -74,23 +75,21 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             this.votingManager = new VotingManager(this.federationManager, this.loggerFactory, this.resultExecutorMock.Object, new NodeStats(timeProvider, this.loggerFactory),
                  dataFolder, this.dBreezeSerializer, this.signals, finalizedBlockRepo, this.network);
 
-            var federationHistory = new FederationHistory(this.federationManager, this.votingManager);
-
-            this.votingManager.Initialize(federationHistory);
+            this.votingManager.Initialize(this.federationHistory);
 
             this.chainState = new ChainState();
 
             this.rulesEngine = new PoAConsensusRuleEngine(this.network, this.loggerFactory, new DateTimeProvider(), this.ChainIndexer, new NodeDeployments(this.network, this.ChainIndexer),
                 this.consensusSettings, new Checkpoints(this.network, this.consensusSettings), new Mock<ICoinView>().Object, this.chainState, new InvalidBlockHashStore(timeProvider),
                 new NodeStats(timeProvider, this.loggerFactory), this.slotsManager, this.poaHeaderValidator, this.votingManager, this.federationManager, this.asyncProvider, 
-                new ConsensusRulesContainer(), federationHistory);
+                new ConsensusRulesContainer(), this.federationHistory);
 
             List<ChainedHeader> headers = ChainedHeadersHelper.CreateConsecutiveHeaders(50, null, false, null, this.network);
 
             this.currentHeader = headers.Last();
         }
 
-        public static IFederationManager CreateFederationManager(object caller, Network network, LoggerFactory loggerFactory, ISignals signals)
+        public static (IFederationManager federationManager, IFederationHistory federationHistory) CreateFederationManager(object caller, Network network, LoggerFactory loggerFactory, ISignals signals)
         {
             string dir = TestBase.CreateTestDir(caller);
 
@@ -119,15 +118,21 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             chainIndexerMock.Setup(x => x.Tip).Returns(new ChainedHeader(header, header.GetHash(), 0));
             var votingManager = new VotingManager(federationManager, loggerFactory, 
                 new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, nodeSettings.DataFolder, dbreezeSerializer, signals, finalizedBlockRepo, network);
-            var federationHistory = new FederationHistory(federationManager, votingManager);
-            votingManager.Initialize(federationHistory);
+
+            var federationHistory = new Mock<IFederationHistory>();
+            federationHistory.Setup(x => x.GetFederationMemberForBlock(It.IsAny<ChainedHeader>())).Returns<ChainedHeader>((a) => {
+                List<IFederationMember> members = ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;
+                return members[a.Height % members.Count];
+            });
+
+            votingManager.Initialize(federationHistory.Object);
             fullNode.Setup(x => x.NodeService<VotingManager>(It.IsAny<bool>())).Returns(votingManager);
             federationManager.Initialize();
 
-            return federationManager;
+            return (federationManager, federationHistory.Object);
         }
 
-        public static IFederationManager CreateFederationManager(object caller)
+        public static (IFederationManager federationManager, IFederationHistory federationHistory) CreateFederationManager(object caller)
         {
             return CreateFederationManager(caller, new TestPoANetwork(), new ExtendedLoggerFactory(), new Signals.Signals(new LoggerFactory(), null));
         }

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/HeaderTimeChecksPoARuleTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/HeaderTimeChecksPoARuleTests.cs
@@ -67,7 +67,8 @@ namespace Stratis.Bitcoin.Features.PoA.Tests.Rules
 
             this.rulesEngine = new PoAConsensusRuleEngine(this.network, this.loggerFactory, provider.Object, this.ChainIndexer, new NodeDeployments(this.network, this.ChainIndexer),
                 this.consensusSettings, new Checkpoints(this.network, this.consensusSettings), new Mock<ICoinView>().Object, new ChainState(), new InvalidBlockHashStore(provider.Object),
-                new NodeStats(provider.Object, this.loggerFactory), this.slotsManager, this.poaHeaderValidator, this.votingManager, this.federationManager, this.asyncProvider, new ConsensusRulesContainer());
+                new NodeStats(provider.Object, this.loggerFactory), this.slotsManager, this.poaHeaderValidator, this.votingManager, this.federationManager, this.asyncProvider, 
+                new ConsensusRulesContainer(), null);
 
             this.timeChecksRule.Parent = this.rulesEngine;
             this.timeChecksRule.Initialize();
@@ -109,7 +110,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests.Rules
 
             this.rulesEngine = new PoAConsensusRuleEngine(this.network, this.loggerFactory, timeProvider.Object, this.ChainIndexer, new NodeDeployments(this.network, this.ChainIndexer),
                 this.consensusSettings, new Checkpoints(this.network, this.consensusSettings), new Mock<ICoinView>().Object, this.chainState, new InvalidBlockHashStore(timeProvider.Object),
-                new NodeStats(timeProvider.Object, this.loggerFactory), this.slotsManager, this.poaHeaderValidator, this.votingManager, this.federationManager, this.asyncProvider, new ConsensusRulesContainer());
+                new NodeStats(timeProvider.Object, this.loggerFactory), this.slotsManager, this.poaHeaderValidator, this.votingManager, this.federationManager, this.asyncProvider, new ConsensusRulesContainer(), null);
 
             var timeRule = new HeaderTimeChecksPoARule();
             this.InitRule(timeRule);

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/PoAHeaderSignatureRuleTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/PoAHeaderSignatureRuleTests.cs
@@ -29,6 +29,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests.Rules
             var ruleContext = new RuleContext(validationContext, DateTimeOffset.Now);
 
             Key randomKey = new KeyTool(new DataFolder(string.Empty)).GeneratePrivateKey();
+
             this.poaHeaderValidator.Sign(randomKey, this.currentHeader.Header as PoABlockHeader);
 
             this.chainState.ConsensusTip = new ChainedHeader(this.network.GetGenesis().Header, this.network.GetGenesis().GetHash(), 0);

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
@@ -23,7 +23,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             this.network = new TestPoANetwork();
             this.consensusOptions = this.network.ConsensusOptions;
 
-            this.federationManager = PoATestsBase.CreateFederationManager(this);
+            this.federationManager = PoATestsBase.CreateFederationManager(this).federationManager;
             this.chainIndexer = new Mock<ChainIndexer>();
             this.slotsManager = new SlotsManager(this.network, this.federationManager, this.chainIndexer.Object, new LoggerFactory());
         }
@@ -46,7 +46,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             Key key = tool.GeneratePrivateKey();
             this.network = new TestPoANetwork(new List<PubKey>() { tool.GeneratePrivateKey().PubKey, key.PubKey, tool.GeneratePrivateKey().PubKey });
 
-            IFederationManager fedManager = PoATestsBase.CreateFederationManager(this, this.network, new ExtendedLoggerFactory(), new Signals.Signals(new LoggerFactory(), null));
+            IFederationManager fedManager = PoATestsBase.CreateFederationManager(this, this.network, new ExtendedLoggerFactory(), new Signals.Signals(new LoggerFactory(), null)).federationManager;
             var header = new BlockHeader();
             this.chainIndexer.Setup(x => x.Tip).Returns(new ChainedHeader(header, header.GetHash(), 0));
             this.slotsManager = new SlotsManager(this.network, fedManager, this.chainIndexer.Object, new LoggerFactory());

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/SlotsManagerTests.cs
@@ -40,24 +40,6 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         }
 
         [Fact]
-        public void ValidSlotAssigned()
-        {
-            List<IFederationMember> federationMembers = this.federationManager.GetFederationMembers();
-            uint roundStart = this.consensusOptions.TargetSpacingSeconds * (uint)federationMembers.Count * 5;
-
-            int currentFedIndex = -1;
-
-            for (int i = 0; i < 20; i++)
-            {
-                currentFedIndex++;
-                if (currentFedIndex > federationMembers.Count - 1)
-                    currentFedIndex = 0;
-
-                Assert.Equal(federationMembers[currentFedIndex].PubKey, this.slotsManager.GetFederationMemberForTimestamp(roundStart + this.consensusOptions.TargetSpacingSeconds * (uint)i).PubKey);
-            }
-        }
-
-        [Fact]
         public void GetMiningTimestamp()
         {
             var tool = new KeyTool(new DataFolder(string.Empty));

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -33,6 +33,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
             var engine = this.Parent as PoAConsensusRuleEngine;
 
+            // TODO: Consider adding these via a constructor on this rule.
             this.slotsManager = engine.SlotsManager;
             this.federationHistory = engine.FederationHistory;
             this.validator = engine.PoaHeaderValidator;
@@ -72,9 +73,11 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
             uint roundTime = this.slotsManager.GetRoundLengthSeconds(federation.Count);
 
+            // Look at the last round of blocks to find the previous time that the miner mined.
             ChainedHeader prevHeader = context.ValidationContext.ChainedHeaderToValidate.Previous;
             while (prevHeader.Previous != null && (header.Time - prevHeader.Header.Time) < roundTime)
             {
+                // If the miner is found again within the same round then throw a consensus error.
                 PubKey nextPubKey = this.federationHistory.GetFederationMemberForBlock(prevHeader)?.PubKey;
                 if (nextPubKey == pubKey)
                 {

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -1,13 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using NBitcoin.Crypto;
 using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
-using Stratis.Bitcoin.Features.PoA.Voting;
 
 namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 {
@@ -21,11 +18,9 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
         private ISlotsManager slotsManager;
 
+        private IFederationHistory federationHistory;
+
         private uint maxReorg;
-
-        private bool votingEnabled;
-
-        private VotingManager votingManager;
 
         private IChainState chainState;
 
@@ -39,76 +34,54 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             var engine = this.Parent as PoAConsensusRuleEngine;
 
             this.slotsManager = engine.SlotsManager;
+            this.federationHistory = engine.FederationHistory;
             this.validator = engine.PoaHeaderValidator;
-            this.votingManager = engine.VotingManager;
             this.chainState = engine.ChainState;
             this.network = this.Parent.Network;
 
             this.maxReorg = this.network.Consensus.MaxReorgLength;
-            this.votingEnabled = ((PoAConsensusOptions)this.network.Consensus.Options).VotingEnabled;
         }
 
         public override async Task RunAsync(RuleContext context)
         {
-            var header = context.ValidationContext.ChainedHeaderToValidate.Header as PoABlockHeader;
+            ChainedHeader chainedHeader = context.ValidationContext.ChainedHeaderToValidate;
 
-            PubKey pubKey = this.slotsManager.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate, this.votingManager).PubKey;
+            var header = chainedHeader.Header as PoABlockHeader;
 
-            if (!this.validator.VerifySignature(pubKey, header))
+            List<IFederationMember> federation = this.federationHistory.GetFederationForBlock(chainedHeader);
+
+            PubKey pubKey = this.federationHistory.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate, federation)?.PubKey;
+
+            if (pubKey == null || !this.validator.VerifySignature(pubKey, header))
             {
-                if (this.votingEnabled)
+                ChainedHeader currentHeader = context.ValidationContext.ChainedHeaderToValidate;
+
+                // If we're evaluating a batch of received headers it's possible that we're so far beyond the current tip
+                // that we have not yet processed all the votes that may determine the federation make-up.
+                bool mightBeInsufficient = currentHeader.Height - this.chainState.ConsensusTip.Height > this.maxReorg;
+                if (mightBeInsufficient)
                 {
-                    ChainedHeader currentHeader = context.ValidationContext.ChainedHeaderToValidate;
-
-                    // If we're evaluating a batch of received headers it's possible that we're so far beyond the current tip
-                    // that we have not yet processed all the votes that may determine the federation make-up.
-                    bool mightBeInsufficient = currentHeader.Height - this.chainState.ConsensusTip.Height > this.maxReorg;
-                    if (mightBeInsufficient)
-                    {
-                        // Mark header as insufficient to avoid banning the peer that presented it.
-                        // When we advance consensus we will be able to validate it.
-                        context.ValidationContext.InsufficientHeaderInformation = true;
-                    }
+                    // Mark header as insufficient to avoid banning the peer that presented it.
+                    // When we advance consensus we will be able to validate it.
+                    context.ValidationContext.InsufficientHeaderInformation = true;
                 }
-
-                try
-                {
-                    // Gather all past and present mining public keys.
-                    IEnumerable<PubKey> genesisFederation = ((PoAConsensusOptions)this.network.Consensus.Options).GenesisFederationMembers.Select(m => m.PubKey);
-                    var knownKeys = new HashSet<PubKey>(genesisFederation);
-                    foreach (Poll poll in this.votingManager.GetApprovedPolls().Where(x => ((x.VotingData.Key == VoteKey.AddFederationMember) || (x.VotingData.Key == VoteKey.KickFederationMember))))
-                    {
-                        IFederationMember federationMember = ((PoAConsensusFactory)(this.network.Consensus.ConsensusFactory)).DeserializeFederationMember(poll.VotingData.Data);
-                        knownKeys.Add(federationMember.PubKey);
-                    }
-
-                    // Try to provide the public key that signed the block.
-                    var signature = ECDSASignature.FromDER(header.BlockSignature.Signature);
-                    for (int recId = 0; recId < 4; recId++)
-                    {
-                        PubKey pubKeyForSig = PubKey.RecoverFromSignature(recId, signature, header.GetHash(), true);
-                        if (pubKeyForSig == null)
-                        {
-                            this.Logger.LogDebug($"Could not match candidate keys to any known key.");
-                            break;
-                        }
-
-                        this.Logger.LogDebug($"Attempting to match candidate key '{ pubKeyForSig.ToHex() }' to known keys.");
-
-                        if (!knownKeys.Any(pk => pk == pubKeyForSig))
-                            continue;
-
-                        IEnumerable<PubKey> modifiedFederation = this.votingManager?.GetModifiedFederation(context.ValidationContext.ChainedHeaderToValidate).Select(m => m.PubKey) ?? genesisFederation;
-
-                        this.Logger.LogDebug($"Block {context.ValidationContext.ChainedHeaderToValidate}:{context.ValidationContext.ChainedHeaderToValidate.Header.Time} is signed by '{pubKeyForSig.ToHex()}' but expected '{pubKey}' from: { string.Join(" ", modifiedFederation.Select(pk => pk.ToHex()))}.");
-
-                        break;
-                    };
-                }
-                catch (Exception) { }
 
                 this.Logger.LogDebug("(-)[INVALID_SIGNATURE]");
                 PoAConsensusErrors.InvalidHeaderSignature.Throw();
+            }
+
+            uint roundTime = this.slotsManager.GetRoundLengthSeconds(federation.Count);
+
+            ChainedHeader prevHeader = context.ValidationContext.ChainedHeaderToValidate.Previous;
+            while (prevHeader.Previous != null && (header.Time - prevHeader.Header.Time) < roundTime)
+            {
+                PubKey nextPubKey = this.federationHistory.GetFederationMemberForBlock(prevHeader)?.PubKey;
+                if (nextPubKey == pubKey)
+                {
+                    this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
+                    ConsensusErrors.BlockTimestampTooEarly.Throw();
+                }
+                prevHeader = prevHeader.Previous;
             }
         }
     }

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -52,7 +52,7 @@ namespace Stratis.Bitcoin.Features.PoA
             if (this.minersByBlockHash.TryGetValue(chainedHeader.HashBlock, out IFederationMember federationMember))
                 return federationMember;
 
-            return GetFederationMemberForBlock(chainedHeader, this.GetFederationForBlock(chainedHeader));
+            return GetFederationMemberForBlockInternal(chainedHeader, this.GetFederationForBlock(chainedHeader));
         }
 
         /// <inheritdoc />
@@ -61,6 +61,11 @@ namespace Stratis.Bitcoin.Features.PoA
             if (this.minersByBlockHash.TryGetValue(chainedHeader.HashBlock, out IFederationMember federationMember))
                 return federationMember;
 
+            return GetFederationMemberForBlockInternal(chainedHeader, federation);
+        }
+
+        private IFederationMember GetFederationMemberForBlockInternal(ChainedHeader chainedHeader, List<IFederationMember> federation)
+        {
             // Try to provide the public key that signed the block.
             try
             {
@@ -73,7 +78,7 @@ namespace Stratis.Bitcoin.Features.PoA
                     if (pubKeyForSig == null)
                         break;
 
-                    federationMember = federation.FirstOrDefault(m => m.PubKey == pubKeyForSig);
+                    IFederationMember federationMember = federation.FirstOrDefault(m => m.PubKey == pubKeyForSig);
                     if (federationMember != null)
                     {
                         this.minersByBlockHash[chainedHeader.HashBlock] = federationMember;

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using NBitcoin.Crypto;
+using Stratis.Bitcoin.Features.PoA.Voting;
+
+namespace Stratis.Bitcoin.Features.PoA
+{
+    public interface IFederationHistory
+    {
+        /// <summary>Gets the federation member for a specified block.</summary>
+        /// <param name="chainedHeader">Identifies the block and timestamp.</param>
+        /// <returns>The federation member or <c>null</c> if the member could not be determined.</returns>
+        /// <exception cref="ConsensusErrorException">In case timestamp is invalid.</exception>
+        IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader);
+
+        /// <summary>Gets the federation member for a specified block.</summary>
+        /// <param name="chainedHeader">Identifies the block and timestamp.</param>
+        /// <param name="federation">The federation members at the block height.</param>
+        /// <returns>The federation member or <c>null</c> if the member could not be determined.</returns>
+        IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader, List<IFederationMember> federation);
+
+        /// <summary>Gets the federation for a specified block.</summary>
+        /// <param name="chainedHeader">Identifies the block and timestamp.</param>
+        /// <returns>The federation member or <c>null</c> if the member could not be determined.</returns>
+        List<IFederationMember> GetFederationForBlock(ChainedHeader chainedHeader);
+    }
+
+    public class FederationHistory : IFederationHistory
+    {
+        private readonly IFederationManager federationManager;
+        private readonly VotingManager votingManager;
+        private readonly Dictionary<uint256, IFederationMember> minersByBlockHash;
+
+        public FederationHistory(IFederationManager federationManager, VotingManager votingManager = null)
+        {
+            this.federationManager = federationManager;
+            this.votingManager = votingManager;
+            this.minersByBlockHash = new Dictionary<uint256, IFederationMember>();
+        }
+
+        /// <inheritdoc />
+        public List<IFederationMember> GetFederationForBlock(ChainedHeader chainedHeader)
+        {
+            return (this.votingManager == null) ? this.federationManager.GetFederationMembers() : this.votingManager.GetModifiedFederation(chainedHeader);
+        }
+
+        /// <inheritdoc />
+        public IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader)
+        {
+            if (this.minersByBlockHash.TryGetValue(chainedHeader.HashBlock, out IFederationMember federationMember))
+                return federationMember;
+
+            return GetFederationMemberForBlock(chainedHeader, this.GetFederationForBlock(chainedHeader));
+        }
+
+        /// <inheritdoc />
+        public IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader, List<IFederationMember> federation)
+        {
+            if (this.minersByBlockHash.TryGetValue(chainedHeader.HashBlock, out IFederationMember federationMember))
+                return federationMember;
+
+            // Try to provide the public key that signed the block.
+            try
+            {
+                var header = chainedHeader.Header as PoABlockHeader;
+
+                var signature = ECDSASignature.FromDER(header.BlockSignature.Signature);
+                for (int recId = 0; recId < 4; recId++)
+                {
+                    PubKey pubKeyForSig = PubKey.RecoverFromSignature(recId, signature, header.GetHash(), true);
+                    if (pubKeyForSig == null)
+                        break;
+
+                    federationMember = federation.FirstOrDefault(m => m.PubKey == pubKeyForSig);
+                    if (federationMember != null)
+                    {
+                        this.minersByBlockHash[chainedHeader.HashBlock] = federationMember;
+                        return federationMember;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -9,13 +9,15 @@ namespace Stratis.Bitcoin.Features.PoA
 {
     public interface IFederationHistory
     {
-        /// <summary>Gets the federation member for a specified block.</summary>
+        /// <summary>Gets the federation member for a specified block by first looking at a cache 
+        /// and then the signature in <see cref="PoABlockHeader.BlockSignature"/>.</summary>
         /// <param name="chainedHeader">Identifies the block and timestamp.</param>
         /// <returns>The federation member or <c>null</c> if the member could not be determined.</returns>
         /// <exception cref="ConsensusErrorException">In case timestamp is invalid.</exception>
         IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader);
 
-        /// <summary>Gets the federation member for a specified block.</summary>
+        /// <summary>Gets the federation member for a specified block by first looking at a cache 
+        /// and then the signature in <see cref="PoABlockHeader.BlockSignature"/>.</summary>
         /// <param name="chainedHeader">Identifies the block and timestamp.</param>
         /// <param name="federation">The federation members at the block height.</param>
         /// <returns>The federation member or <c>null</c> if the member could not be determined.</returns>
@@ -27,6 +29,11 @@ namespace Stratis.Bitcoin.Features.PoA
         List<IFederationMember> GetFederationForBlock(ChainedHeader chainedHeader);
     }
 
+    /// <summary>
+    /// This component can be used to determine the member that mined a block for any block height.
+    /// It also provides the federation at any block height by leveraging the functionality
+    /// implemented by <see cref="VotingManager.GetModifiedFederation(ChainedHeader)"/>.
+    /// </summary>
     public class FederationHistory : IFederationHistory
     {
         private readonly IFederationManager federationManager;

--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusRuleEngine.cs
@@ -18,6 +18,8 @@ namespace Stratis.Bitcoin.Features.PoA
     {
         public ISlotsManager SlotsManager { get; private set; }
 
+        public IFederationHistory FederationHistory { get; private set; }
+
         public PoABlockHeaderValidator PoaHeaderValidator { get; private set; }
 
         public VotingManager VotingManager { get; private set; }
@@ -27,13 +29,15 @@ namespace Stratis.Bitcoin.Features.PoA
         public PoAConsensusRuleEngine(Network network, ILoggerFactory loggerFactory, IDateTimeProvider dateTimeProvider, ChainIndexer chainIndexer,
             NodeDeployments nodeDeployments, ConsensusSettings consensusSettings, ICheckpoints checkpoints, ICoinView utxoSet, IChainState chainState,
             IInvalidBlockHashStore invalidBlockHashStore, INodeStats nodeStats, ISlotsManager slotsManager, PoABlockHeaderValidator poaHeaderValidator,
-            VotingManager votingManager, IFederationManager federationManager, IAsyncProvider asyncProvider, ConsensusRulesContainer consensusRulesContainer)
+            VotingManager votingManager, IFederationManager federationManager, IAsyncProvider asyncProvider, ConsensusRulesContainer consensusRulesContainer,
+            IFederationHistory federationHistory)
             : base(network, loggerFactory, dateTimeProvider, chainIndexer, nodeDeployments, consensusSettings, checkpoints, utxoSet, chainState, invalidBlockHashStore, nodeStats, asyncProvider, consensusRulesContainer)
         {
             this.SlotsManager = slotsManager;
             this.PoaHeaderValidator = poaHeaderValidator;
             this.VotingManager = votingManager;
             this.FederationManager = federationManager;
+            this.FederationHistory = federationHistory;
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
@@ -41,6 +41,8 @@ namespace Stratis.Bitcoin.Features.PoA
 
         private readonly VotingManager votingManager;
 
+        private readonly IFederationHistory federationHistory;
+
         private readonly Network network;
 
         private readonly IWhitelistedHashesRepository whitelistedHashesRepository;
@@ -53,7 +55,7 @@ namespace Stratis.Bitcoin.Features.PoA
 
         public PoAFeature(IFederationManager federationManager, PayloadProvider payloadProvider, IConnectionManager connectionManager, ChainIndexer chainIndexer,
             IInitialBlockDownloadState initialBlockDownloadState, IConsensusManager consensusManager, IPeerBanning peerBanning, ILoggerFactory loggerFactory,
-            VotingManager votingManager, Network network, IWhitelistedHashesRepository whitelistedHashesRepository,
+            VotingManager votingManager, IFederationHistory federationHistory, Network network, IWhitelistedHashesRepository whitelistedHashesRepository,
             IIdleFederationMembersKicker idleFederationMembersKicker, IChainState chainState, IBlockStoreQueue blockStoreQueue, IPoAMiner miner = null)
         {
             this.federationManager = federationManager;
@@ -65,6 +67,7 @@ namespace Stratis.Bitcoin.Features.PoA
             this.loggerFactory = loggerFactory;
             this.miner = miner;
             this.votingManager = votingManager;
+            this.federationHistory = federationHistory;
             this.whitelistedHashesRepository = whitelistedHashesRepository;
             this.network = network;
             this.idleFederationMembersKicker = idleFederationMembersKicker;
@@ -93,11 +96,11 @@ namespace Stratis.Bitcoin.Features.PoA
                 if (options.AutoKickIdleMembers)
                 {
                     this.idleFederationMembersKicker.Initialize();
-                    this.votingManager.Initialize(this.idleFederationMembersKicker);
+                    this.votingManager.Initialize(this.federationHistory, this.idleFederationMembersKicker);
                 }
                 else
                 {
-                    this.votingManager.Initialize();
+                    this.votingManager.Initialize(this.federationHistory);
                 }
             }
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -37,9 +37,9 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
         private readonly IFederationManager federationManager;
 
-        private readonly ISlotsManager slotsManager;
-
         private readonly VotingManager votingManager;
+
+        private readonly IFederationHistory federationHistory;
 
         private readonly ILogger logger;
 
@@ -55,15 +55,15 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         private const string fedMembersByLastActiveTimeKey = "fedMembersByLastActiveTime";
 
         public IdleFederationMembersKicker(ISignals signals, Network network, IKeyValueRepository keyValueRepository, IConsensusManager consensusManager,
-            IFederationManager federationManager, ISlotsManager slotsManager, VotingManager votingManager, ILoggerFactory loggerFactory)
+            IFederationManager federationManager, VotingManager votingManager, IFederationHistory federationHistory, ILoggerFactory loggerFactory)
         {
             this.signals = signals;
             this.network = network;
             this.keyValueRepository = keyValueRepository;
             this.consensusManager = consensusManager;
             this.federationManager = federationManager;
-            this.slotsManager = slotsManager;
             this.votingManager = votingManager;
+            this.federationHistory = federationHistory;
 
             this.consensusFactory = this.network.Consensus.ConsensusFactory as PoAConsensusFactory;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
@@ -175,7 +175,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
             try
             {
-                PubKey pubKey = this.slotsManager.GetFederationMemberForBlock(consensusTip, this.votingManager).PubKey;
+                PubKey pubKey = this.federationHistory.GetFederationMemberForBlock(consensusTip).PubKey;
                 this.fedPubKeysByLastActiveTime.AddOrReplace(pubKey, consensusTip.Header.Time);
                 this.SaveMembersByLastActiveTime();
 
@@ -217,7 +217,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         private void UpdateFederationMembersLastActiveTime(BlockConnected blockConnected)
         {
             // The pubkey of the member that signed the block.
-            PubKey key = this.slotsManager.GetFederationMemberForBlock(blockConnected.ConnectedBlock.ChainedHeader, this.votingManager).PubKey;
+            PubKey key = this.federationHistory.GetFederationMemberForBlock(blockConnected.ConnectedBlock.ChainedHeader).PubKey;
 
             // Update the dictionary.
             this.fedPubKeysByLastActiveTime.AddOrReplace(key, blockConnected.ConnectedBlock.ChainedHeader.Header.Time);

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/IFullNodeBuilderExtensions.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/IFullNodeBuilderExtensions.cs
@@ -25,6 +25,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA
                     .FeatureServices(services =>
                     {
                         // Voting & Polls 
+                        services.AddSingleton<IFederationHistory, FederationHistory>();
                         services.AddSingleton<VotingManager>();
                         services.AddSingleton<IWhitelistedHashesRepository, WhitelistedHashesRepository>();
                         services.AddSingleton<IPollResultExecutor, PollResultExecutor>();

--- a/src/Stratis.Bitcoin.Tests.Common/ChainedHeadersHelper.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/ChainedHeadersHelper.cs
@@ -36,9 +36,12 @@ namespace Stratis.Bitcoin.Tests.Common
 
             uint256 hashPrevBlock = tip.HashBlock;
 
+            uint time = 0;
+
             for (int i = 0; i < count; i++)
             {
                 BlockHeader header = network.Consensus.ConsensusFactory.CreateBlockHeader();
+                header.Time = time += (uint)network.Consensus.TargetSpacing.TotalSeconds;
                 header.Nonce = (uint)Interlocked.Increment(ref currentNonce);
                 header.HashPrevBlock = hashPrevBlock;
                 header.Bits = bits ?? Target.Difficulty1;

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -6,7 +6,6 @@ using NBitcoin;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Features.BlockStore.AddressIndexing;
 using Stratis.Bitcoin.Features.PoA;
-using Stratis.Bitcoin.Features.PoA.Voting;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Utilities;
 using Stratis.Features.PoA.Collateral;
@@ -21,8 +20,6 @@ namespace Stratis.Features.Collateral
 
         private readonly ICollateralChecker collateralChecker;
 
-        private readonly ISlotsManager slotsManager;
-
         private readonly IDateTimeProvider dateTime;
 
         private readonly Network network;
@@ -30,17 +27,16 @@ namespace Stratis.Features.Collateral
         /// <summary>For how many seconds the block should be banned in case collateral check failed.</summary>
         private readonly int collateralCheckBanDurationSeconds;
 
-        private readonly VotingManager votingManager;
+        private readonly IFederationHistory federationHistory;
 
         public CheckCollateralFullValidationRule(IInitialBlockDownloadState ibdState, ICollateralChecker collateralChecker,
-            ISlotsManager slotsManager, IDateTimeProvider dateTime, Network network, VotingManager votingManager)
+            IDateTimeProvider dateTime, Network network, IFederationHistory federationHistory)
         {
             this.network = network;
             this.ibdState = ibdState;
             this.collateralChecker = collateralChecker;
-            this.slotsManager = slotsManager;
             this.dateTime = dateTime;
-            this.votingManager = votingManager;
+            this.federationHistory = federationHistory;
 
             this.collateralCheckBanDurationSeconds = (int)(this.network.Consensus.Options as PoAConsensusOptions).TargetSpacingSeconds / 2;
         }
@@ -82,7 +78,7 @@ namespace Stratis.Features.Collateral
                 PoAConsensusErrors.InvalidCollateralAmountCommitmentTooNew.Throw();
             }
 
-            IFederationMember federationMember = this.slotsManager.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate, this.votingManager);
+            IFederationMember federationMember = this.federationHistory.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate);
             if (!this.collateralChecker.CheckCollateral(federationMember, commitmentHeight.Value))
             {
                 // By setting rejectUntil we avoid banning a peer that provided a block.

--- a/src/Stratis.Features.Collateral/ConsensusRules/MandatoryCollateralMemberVotingRule.cs
+++ b/src/Stratis.Features.Collateral/ConsensusRules/MandatoryCollateralMemberVotingRule.cs
@@ -16,8 +16,7 @@ namespace Stratis.Bitcoin.Features.Collateral.ConsensusRules
         private VotingDataEncoder votingDataEncoder;
         private PoAConsensusRuleEngine ruleEngine;
         private IFederationManager federationManager;
-        private VotingManager votingManager;
-        private ISlotsManager slotsManager;
+        private IFederationHistory federationHistory;
 
         [NoTrace]
         public override void Initialize()
@@ -25,8 +24,7 @@ namespace Stratis.Bitcoin.Features.Collateral.ConsensusRules
             this.votingDataEncoder = new VotingDataEncoder(this.Parent.LoggerFactory);
             this.ruleEngine = (PoAConsensusRuleEngine)this.Parent;
             this.federationManager = this.ruleEngine.FederationManager;
-            this.votingManager = this.ruleEngine.VotingManager;
-            this.slotsManager = this.ruleEngine.SlotsManager;
+            this.federationHistory = this.ruleEngine.FederationHistory;
 
             base.Initialize();
         }
@@ -46,7 +44,7 @@ namespace Stratis.Bitcoin.Features.Collateral.ConsensusRules
                 return Task.CompletedTask;
 
             // Ignore any polls that the miner has already voted on.
-            PubKey blockMiner = this.slotsManager.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate, this.votingManager).PubKey;
+            PubKey blockMiner = this.federationHistory.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate).PubKey;
             pendingPolls = pendingPolls.Where(p => !p.PubKeysHexVotedInFavor.Any(pk => pk == blockMiner.ToHex())).ToList();
 
             // Exit if there is nothing remaining.

--- a/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
@@ -35,10 +35,6 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.slotsManagerMock = new Mock<ISlotsManager>();
 
             this.ibdMock.Setup(x => x.IsInitialBlockDownload()).Returns(false);
-            this.slotsManagerMock
-                .Setup(x => x.GetFederationMemberForTimestamp(It.IsAny<uint>(), null))
-                .Returns(new CollateralFederationMember(new Key().PubKey, false, new Money(1), "addr1"));
-
             this.ruleContext = new RuleContext(new ValidationContext(), DateTimeOffset.Now);
             var header = new BlockHeader() { Time = 5234 };
             this.ruleContext.ValidationContext.BlockToValidate = new Block(header);
@@ -77,7 +73,12 @@ namespace Stratis.Features.FederatedPeg.Tests
             var consensusManager = new Mock<IConsensusManager>();
             fullnode.Setup(x => x.NodeService<IConsensusManager>(false)).Returns(consensusManager.Object);
 
-            this.rule = new CheckCollateralFullValidationRule(this.ibdMock.Object, this.collateralCheckerMock.Object, this.slotsManagerMock.Object, new Mock<IDateTimeProvider>().Object, new PoANetwork(), null)
+            var federationHistory = new Mock<IFederationHistory>();
+            federationHistory
+                .Setup(x => x.GetFederationMemberForBlock(It.IsAny<ChainedHeader>()))
+                .Returns(new CollateralFederationMember(new Key().PubKey, false, new Money(1), "addr1"));
+
+            this.rule = new CheckCollateralFullValidationRule(this.ibdMock.Object, this.collateralCheckerMock.Object, new Mock<IDateTimeProvider>().Object, new PoANetwork(), federationHistory.Object)
             {
                 Logger = logger
             };

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -71,9 +71,9 @@ namespace Stratis.Features.FederatedPeg.Tests
             var fullNode = new Mock<IFullNode>();
 
             IFederationManager federationManager = new FederationManager(counterChainSettings, fullNode.Object, network, nodeSettings, loggerFactory, signals);
-            var slotsManager = new SlotsManager(network, federationManager, chainIndexerMock.Object, loggerFactory);
-            var votingManager = new VotingManager(federationManager, loggerFactory, slotsManager, new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, nodeSettings.DataFolder, dbreezeSerializer, signals, finalizedBlockRepo, network);
-            votingManager.Initialize();
+            var votingManager = new VotingManager(federationManager, loggerFactory, new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, nodeSettings.DataFolder, dbreezeSerializer, signals, finalizedBlockRepo, network);
+            var federationHistory = new FederationHistory(federationManager, votingManager);
+            votingManager.Initialize(federationHistory);
 
             fullNode.Setup(x => x.NodeService<VotingManager>(It.IsAny<bool>())).Returns(votingManager);
 

--- a/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationGatewayControllerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationGatewayControllerTests.cs
@@ -256,9 +256,9 @@ namespace Stratis.Features.FederatedPeg.Tests.ControllersTests
             var header = new BlockHeader();
             chainIndexerMock.Setup(x => x.Tip).Returns(new ChainedHeader(header, header.GetHash(), 0));
 
-            var slotsManager = new SlotsManager(this.network, this.federationManager, chainIndexerMock.Object, this.loggerFactory);
-            var votingManager = new VotingManager(this.federationManager, this.loggerFactory, slotsManager, new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, nodeSettings.DataFolder, dbreezeSerializer, this.signals, finalizedBlockRepo, this.network);
-            votingManager.Initialize();
+            var votingManager = new VotingManager(this.federationManager, this.loggerFactory, new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, nodeSettings.DataFolder, dbreezeSerializer, this.signals, finalizedBlockRepo, this.network);
+            var federationHistory = new FederationHistory(this.federationManager, votingManager);
+            votingManager.Initialize(federationHistory);
 
             return votingManager;
         }


### PR DESCRIPTION
Implements a separate `FederationHistory` class to track the federation over time.

Also:
- Removes the `GetFederationMemberForTimestamp` method in favor of  `GetFederationMemberForBlock`.
- Refactors the `PoAHeaderSignatureRule` method. This rule executes in about 5 ms after these changes. See https://stratisplatformuk.visualstudio.com/HPI/_workitems/edit/5272/