### PR TITLE
Suppress TIME_TOO_EARLY errors when the federation changes

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -81,6 +81,10 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 PubKey nextPubKey = this.federationHistory.GetFederationMemberForBlock(prevHeader)?.PubKey;
                 if (nextPubKey == pubKey)
                 {
+                    // Exclude this one block that somehow got included in the chain where the miner managed to mine too early.
+                    if (prevHeader.HashBlock != uint256.Parse("7d67ea42010f03971edd6ba5e1b644d09c9fd0191ca8d312255c12d23f7cd147"))
+                        continue;
+
                     // Mining slots shift when the federation changes. 
                     // Only raise an error if the federation did not change.
                     uint newRoundTime = this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader).Count);

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -71,9 +71,8 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 PoAConsensusErrors.InvalidHeaderSignature.Throw();
             }
 
-            uint roundTime = this.slotsManager.GetRoundLengthSeconds(federation.Count);
-
             // Look at the last round of blocks to find the previous time that the miner mined.
+            uint roundTime = this.slotsManager.GetRoundLengthSeconds(federation.Count);
             
             for (ChainedHeader prevHeader = chainedHeader.Previous; prevHeader.Previous != null; prevHeader = prevHeader.Previous)
             {
@@ -84,15 +83,15 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 if (this.federationHistory.GetFederationMemberForBlock(prevHeader)?.PubKey != pubKey)
                     continue;
 
-                // Exclude this one block that somehow got included in the chain where the miner managed to mine too early.
-                if (prevHeader.HashBlock != uint256.Parse("7d67ea42010f03971edd6ba5e1b644d09c9fd0191ca8d312255c12d23f7cd147"))
-                    continue;
-
                 // Mining slots shift when the federation changes. 
                 // Only raise an error if the federation did not change.
                 uint newRoundTime = this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader).Count);
                 if (newRoundTime == roundTime)
                 {
+                    // Exempt this one block that somehow got included in the chain where the miner managed to mine too early.
+                    if (prevHeader.HashBlock == uint256.Parse("7d67ea42010f03971edd6ba5e1b644d09c9fd0191ca8d312255c12d23f7cd147"))
+                        continue;
+
                     this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
                     ConsensusErrors.BlockTimestampTooEarly.Throw();
                 }

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -86,20 +86,15 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 // Mining slots shift when the federation changes. 
                 // Only raise an error if the federation did not change.
                 uint newRoundTime = this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader).Count);
-                if (newRoundTime == roundTime)
-                {
-                    // Exempt this one block that somehow got included in the chain where the miner managed to mine too early.
-                    if (prevHeader.HashBlock == uint256.Parse("7d67ea42010f03971edd6ba5e1b644d09c9fd0191ca8d312255c12d23f7cd147"))
-                        continue;
+                if (newRoundTime != roundTime)
+                    break;
 
-                    this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
-                    ConsensusErrors.BlockTimestampTooEarly.Throw();
-                }
+                // Exempt this one block that somehow got included in the chain where the miner managed to mine too early.
+                if (prevHeader.HashBlock == uint256.Parse("7d67ea42010f03971edd6ba5e1b644d09c9fd0191ca8d312255c12d23f7cd147"))
+                    break;
 
-                roundTime = newRoundTime;
-                header = prevHeader.Header as PoABlockHeader;
-                if (header == null)
-                    break;                                
+                this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
+                ConsensusErrors.BlockTimestampTooEarly.Throw();
             }
         }
     }

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -74,31 +74,33 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             uint roundTime = this.slotsManager.GetRoundLengthSeconds(federation.Count);
 
             // Look at the last round of blocks to find the previous time that the miner mined.
-            ChainedHeader prevHeader = context.ValidationContext.ChainedHeaderToValidate.Previous;
-            while (prevHeader.Previous != null && (header.Time - prevHeader.Header.Time) < roundTime)
+            
+            for (ChainedHeader prevHeader = chainedHeader.Previous; prevHeader.Previous != null; prevHeader = prevHeader.Previous)
             {
-                // If the miner is found again within the same round then throw a consensus error.
-                PubKey nextPubKey = this.federationHistory.GetFederationMemberForBlock(prevHeader)?.PubKey;
-                if (nextPubKey == pubKey)
-                {
-                    // Exclude this one block that somehow got included in the chain where the miner managed to mine too early.
-                    if (prevHeader.HashBlock != uint256.Parse("7d67ea42010f03971edd6ba5e1b644d09c9fd0191ca8d312255c12d23f7cd147"))
-                        continue;
+                if ((header.Time - prevHeader.Header.Time) >= roundTime)
+                    break;
 
-                    // Mining slots shift when the federation changes. 
-                    // Only raise an error if the federation did not change.
-                    uint newRoundTime = this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader).Count);
-                    if (newRoundTime == roundTime)
-                    {
-                        this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
-                        ConsensusErrors.BlockTimestampTooEarly.Throw();
-                    }
-                    roundTime = newRoundTime;
-                    header = prevHeader.Header as PoABlockHeader;
-                    if (header == null)
-                        break;
+                // If the miner is found again within the same round then throw a consensus error.
+                if (this.federationHistory.GetFederationMemberForBlock(prevHeader)?.PubKey != pubKey)
+                    continue;
+
+                // Exclude this one block that somehow got included in the chain where the miner managed to mine too early.
+                if (prevHeader.HashBlock != uint256.Parse("7d67ea42010f03971edd6ba5e1b644d09c9fd0191ca8d312255c12d23f7cd147"))
+                    continue;
+
+                // Mining slots shift when the federation changes. 
+                // Only raise an error if the federation did not change.
+                uint newRoundTime = this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader).Count);
+                if (newRoundTime == roundTime)
+                {
+                    this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
+                    ConsensusErrors.BlockTimestampTooEarly.Throw();
                 }
-                prevHeader = prevHeader.Previous;
+
+                roundTime = newRoundTime;
+                header = prevHeader.Header as PoABlockHeader;
+                if (header == null)
+                    break;                                
             }
         }
     }


### PR DESCRIPTION
```
// Mining slots shift when the federation changes. 
// Only raise an error if the federation did not change.
```