### PR TITLE
Fix GetModifiedFederation to use approved polls

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -282,7 +282,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 // Modify the federation with the polls that would have been executed up to the given height.
                 if (this.network.Consensus.ConsensusFactory is PoAConsensusFactory poaConsensusFactory)
                 {
-                    foreach (Poll poll in approvedPolls.OrderBy(a => a.PollExecutedBlockData.Height))
+                    foreach (Poll poll in approvedPolls.OrderBy(a => a.PollVotedInFavorBlockData.Height))
                     {
                         // When block "PollVotedInFavorBlockData"+MaxReorgLength connects, block "PollVotedInFavorBlockData" is executed. See VotingManager.OnBlockConnected.
                         if ((poll.PollVotedInFavorBlockData.Height + this.network.Consensus.MaxReorgLength) > chainedHeader.Height)

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -277,12 +277,12 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             {
                 // Starting with the genesis federation...
                 var modifiedFederation = new List<IFederationMember>(this.poaConsensusOptions.GenesisFederationMembers);
-                IEnumerable<Poll> executedPolls = this.GetExecutedPolls().MemberPolls();
+                IEnumerable<Poll> approvedPolls = this.GetApprovedPolls().MemberPolls();
 
                 // Modify the federation with the polls that would have been executed up to the given height.
                 if (this.network.Consensus.ConsensusFactory is PoAConsensusFactory poaConsensusFactory)
                 {
-                    foreach (Poll poll in executedPolls.OrderBy(a => a.PollExecutedBlockData.Height))
+                    foreach (Poll poll in approvedPolls.OrderBy(a => a.PollExecutedBlockData.Height))
                     {
                         // When block "PollVotedInFavorBlockData"+MaxReorgLength connects, block "PollVotedInFavorBlockData" is executed. See VotingManager.OnBlockConnected.
                         if ((poll.PollVotedInFavorBlockData.Height + this.network.Consensus.MaxReorgLength) > chainedHeader.Height)


### PR DESCRIPTION
`GetModifiedFederation` should not be filtering on executed polls. This makes it insensitive to whether the `VotingManager`s `OnBlockConnected`, which executes the poll, is called before or after it.