### PR TITLE
Change full node console window title to show which full node is running

### DIFF
--- a/src/Stratis.CirrusD/Program.cs
+++ b/src/Stratis.CirrusD/Program.cs
@@ -35,6 +35,8 @@ namespace Stratis.CirrusD
         {
             try
             {
+                // set the console window title to identify this as a Cirrus full node (for clarity when running Strax and Cirrus on the same machine)
+				Console.Title = "Cirrus full node";
                 var nodeSettings = new NodeSettings(networksSelector: CirrusNetwork.NetworksSelector, protocolVersion: ProtocolVersion.CIRRUS_VERSION, args: args)
                 {
                     MinProtocolVersion = ProtocolVersion.ALT_PROTOCOL_VERSION

--- a/src/Stratis.CirrusD/Program.cs
+++ b/src/Stratis.CirrusD/Program.cs
@@ -36,7 +36,7 @@ namespace Stratis.CirrusD
             try
             {
                 // set the console window title to identify this as a Cirrus full node (for clarity when running Strax and Cirrus on the same machine)
-                Console.Title = "Cirrus full node";
+                Console.Title = "Cirrus Full Node";
                 var nodeSettings = new NodeSettings(networksSelector: CirrusNetwork.NetworksSelector, protocolVersion: ProtocolVersion.CIRRUS_VERSION, args: args)
                 {
                     MinProtocolVersion = ProtocolVersion.ALT_PROTOCOL_VERSION

--- a/src/Stratis.CirrusD/Program.cs
+++ b/src/Stratis.CirrusD/Program.cs
@@ -36,7 +36,7 @@ namespace Stratis.CirrusD
             try
             {
                 // set the console window title to identify this as a Cirrus full node (for clarity when running Strax and Cirrus on the same machine)
-				Console.Title = "Cirrus full node";
+                Console.Title = "Cirrus full node";
                 var nodeSettings = new NodeSettings(networksSelector: CirrusNetwork.NetworksSelector, protocolVersion: ProtocolVersion.CIRRUS_VERSION, args: args)
                 {
                     MinProtocolVersion = ProtocolVersion.ALT_PROTOCOL_VERSION

--- a/src/Stratis.CirrusMinerD/Program.cs
+++ b/src/Stratis.CirrusMinerD/Program.cs
@@ -47,6 +47,9 @@ namespace Stratis.CirrusMinerD
                     throw new ArgumentException($"Gateway node needs to be started specifying either a {SidechainArgument} or a {MainchainArgument} argument");
                 }
 
+                // set the console window title to identify which node this is (for clarity when running Strax and Cirrus on the same machine)
+                Console.Title = isMainchainNode ? "Strax Full Node" : "Cirrus Full Node";
+
                 IFullNode node = isMainchainNode ? GetStraxNode(args) : GetCirrusMiningNode(args);
 
                 if (node != null)

--- a/src/Stratis.CirrusPegD/Program.cs
+++ b/src/Stratis.CirrusPegD/Program.cs
@@ -57,6 +57,9 @@ namespace Stratis.CirrusPegD
                     throw new ArgumentException($"Gateway node needs to be started specifying either a {SidechainArgument} or a {MainchainArgument} argument");
                 }
 
+                // set the console window title to identify which node this is (for clarity when running Strax and Cirrus on the same machine)
+                Console.Title = isMainchainNode ? "Strax Full Node" : "Cirrus Full Node";
+
                 IFullNode node = isMainchainNode ? GetMainchainFullNode(args) : GetSidechainFullNode(args);
 
                 if (node != null)

--- a/src/Stratis.StraxD/Program.cs
+++ b/src/Stratis.StraxD/Program.cs
@@ -28,7 +28,7 @@ namespace Stratis.StraxD
             try
             {
                 // set the console window title to identify this as a Strax full node (for clarity when running Strax and Cirrus on the same machine)
-                Console.Title = "Strax full node";
+                Console.Title = "Strax Full Node";
                 var nodeSettings = new NodeSettings(networksSelector: Networks.Strax, protocolVersion: ProtocolVersion.PROVEN_HEADER_VERSION, args: args)
                 {
                     MinProtocolVersion = ProtocolVersion.PROVEN_HEADER_VERSION

--- a/src/Stratis.StraxD/Program.cs
+++ b/src/Stratis.StraxD/Program.cs
@@ -27,6 +27,8 @@ namespace Stratis.StraxD
         {
             try
             {
+                // set the console window title to identify this as a Strax full node (for clarity when running Strax and Cirrus on the same machine)
+				Console.Title = "Strax full node";
                 var nodeSettings = new NodeSettings(networksSelector: Networks.Strax, protocolVersion: ProtocolVersion.PROVEN_HEADER_VERSION, args: args)
                 {
                     MinProtocolVersion = ProtocolVersion.PROVEN_HEADER_VERSION

--- a/src/Stratis.StraxD/Program.cs
+++ b/src/Stratis.StraxD/Program.cs
@@ -28,7 +28,7 @@ namespace Stratis.StraxD
             try
             {
                 // set the console window title to identify this as a Strax full node (for clarity when running Strax and Cirrus on the same machine)
-				Console.Title = "Strax full node";
+                Console.Title = "Strax full node";
                 var nodeSettings = new NodeSettings(networksSelector: Networks.Strax, protocolVersion: ProtocolVersion.PROVEN_HEADER_VERSION, args: args)
                 {
                     MinProtocolVersion = ProtocolVersion.PROVEN_HEADER_VERSION


### PR DESCRIPTION
Added a line to the node start up to set the console window title to identify which full node this is (for clarity when running Strax and Cirrus on the same machine, especially thinking of MNs)

(Note: I've verified this works on my own machine, but full disclosure that I'm new to C# and most of my education has been reverse engineering code in this repo)