### PR TITLE
Make sweep work for less than 500 outputs

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
@@ -1148,7 +1148,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Services
                     // Not many wallets will have this many inputs, but we have to ensure that the resulting transactions are
                     // small enough to be broadcast without standardness problems.
                     // Since there is only 1 output the size of the inputs is the only consideration.
-                    if (total == 0 || currentOutputCount < 500)
+                    if (total == 0 || currentOutputCount > 500)
                         continue;
 
                     BitcoinAddress destination = BitcoinAddress.Create(request.DestinationAddress, this.network);


### PR DESCRIPTION
- This fixes an issue where the sweep would only work if there was more than 500 outputs.
- The "currentOutputCount" is not really used and is reset for every single UTXOs discovered and individual transactions is generated for each UTXOs, they are not combined into a single transaction.
- The sweep might need some refactoring, and the FallbackFee might need to be increased a little bit to work properly and not generate transactions with too low fee during sweep.