### PR TITLE
Improve Federation Wallet and CCTS sync speed

### DIFF
--- a/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
@@ -233,11 +233,13 @@ namespace Stratis.Features.FederatedPeg
             benchLog.AppendLine();
             benchLog.AppendLine("====== Federation Wallet ======");
 
-            (Money ConfirmedAmount, Money UnConfirmedAmount) balances = this.federationWalletManager.GetSpendableAmount();
+            (Money ConfirmedAmount, Money UnConfirmedAmount) = this.federationWalletManager.GetSpendableAmount();
+
             bool isFederationActive = this.federationWalletManager.IsFederationWalletActive();
+
             benchLog.AppendLine("Federation Wallet: ".PadRight(LoggingConfiguration.ColumnLength)
-                                + " Confirmed balance: " + balances.ConfirmedAmount.ToString().PadRight(LoggingConfiguration.ColumnLength)
-                                + " Reserved for withdrawals: " + balances.UnConfirmedAmount.ToString().PadRight(LoggingConfiguration.ColumnLength)
+                                + " Confirmed balance: " + ConfirmedAmount.ToString().PadRight(LoggingConfiguration.ColumnLength)
+                                + " Reserved for withdrawals: " + UnConfirmedAmount.ToString().PadRight(LoggingConfiguration.ColumnLength)
                                 + " Federation Status: " + (isFederationActive ? "Active" : "Inactive"));
             benchLog.AppendLine();
 

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
@@ -53,6 +53,7 @@ namespace Stratis.Features.FederatedPeg.Interfaces
 
         /// <summary>
         /// Processes a transaction received from the network.
+        /// <para>The caller should be responsible for saving the wallet if it has been updated.</para>
         /// </summary>
         /// <param name="transaction">The transaction.</param>
         /// <param name="blockHeight">The height of the block this transaction came from. Null if it was not a transaction included in a block.</param>

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
@@ -60,7 +60,7 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// <param name="blockHash">The hash of the block this transaction came from. Null if it was not a transaction included in a block.</param>
         /// <param name="block">The block in which this transaction was included.</param>
         /// <returns>A value indicating whether this transaction affects the wallet.</returns>
-        bool ProcessTransaction(Transaction transaction, int? blockHeight = null, uint256 blockHash = null, Block block = null, bool isDistribution = false);
+        bool ProcessTransaction(Transaction transaction, int? blockHeight = null, uint256 blockHash = null, Block block = null);
 
         /// <summary>
         /// Verifies that the transaction's input UTXO's have been reserved by the wallet.

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
@@ -86,7 +86,7 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// <summary>
         /// Gets some general information about a wallet.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>The federation wallet instance.</returns>
         FederationWallet GetWallet();
 
         /// <summary>

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -693,8 +693,8 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                         {
                             dbreezeTransaction.SynchronizeTables(transferTableName, commonTableName);
 
-                            this.federationWalletManager.ProcessTransaction(transfer.PartialTransaction);
-                            this.federationWalletManager.SaveWallet();
+                            if (this.federationWalletManager.ProcessTransaction(transfer.PartialTransaction))
+                                this.federationWalletManager.SaveWallet();
 
                             if (this.ValidateTransaction(transfer.PartialTransaction, true))
                             {
@@ -720,8 +720,10 @@ namespace Stratis.Features.FederatedPeg.TargetChain
 
                             // Restore expected store state in case the calling code retries / continues using the store.
                             transfer.SetPartialTransaction(oldTransaction);
-                            this.federationWalletManager.ProcessTransaction(oldTransaction);
-                            this.federationWalletManager.SaveWallet();
+
+                            if (this.federationWalletManager.ProcessTransaction(oldTransaction))
+                                this.federationWalletManager.SaveWallet();
+
                             this.RollbackAndThrowTransactionError(dbreezeTransaction, err, "MERGE_ERROR");
                         }
 
@@ -799,7 +801,8 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                             Transaction transaction = block.Transactions.Single(t => t.GetHash() == withdrawal.Id);
 
                             // Ensure that the wallet is in step.
-                            this.federationWalletManager.ProcessTransaction(transaction, withdrawal.BlockNumber, withdrawal.BlockHash, block);
+                            if (this.federationWalletManager.ProcessTransaction(transaction, withdrawal.BlockNumber, withdrawal.BlockHash, block))
+                                this.federationWalletManager.SaveWallet();
 
                             if (crossChainTransfers[i] == null)
                             {

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -418,6 +418,8 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                         if (!this.Synchronize())
                             return;
 
+                        this.logger.LogInformation($"{maturedBlockDeposits.Count} blocks received, containing {maturedBlockDeposits.SelectMany(d => d.Deposits).Count()} a total of deposits.");
+
                         foreach (MaturedBlockDepositsModel maturedDeposit in maturedBlockDeposits)
                         {
                             if (maturedDeposit.BlockInfo.BlockHeight != this.NextMatureDepositHeight)
@@ -483,7 +485,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                                     {
                                         status = CrossChainTransferStatus.Rejected;
                                     }
-                                    else if ((tracker.Count(t => t.Value == CrossChainTransferStatus.Partial) 
+                                    else if ((tracker.Count(t => t.Value == CrossChainTransferStatus.Partial)
                                         + this.depositsIdsByStatus.Count(t => t.Key == CrossChainTransferStatus.Partial)) >= MaximumPartialTransactions)
                                     {
                                         haveSuspendedTransfers = true;

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -418,7 +418,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                         if (!this.Synchronize())
                             return;
 
-                        this.logger.LogInformation($"{maturedBlockDeposits.Count} blocks received, containing a total of {maturedBlockDeposits.SelectMany(d => d.Deposits).Count()} deposits.");
+                        this.logger.LogInformation($"{maturedBlockDeposits.Count} blocks received, containing a total of {maturedBlockDeposits.SelectMany(d => d.Deposits).Where(a => a.Amount > 0).Count()} deposits.");
 
                         foreach (MaturedBlockDepositsModel maturedDeposit in maturedBlockDeposits)
                         {

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -69,6 +69,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         private readonly DBreezeSerializer dBreezeSerializer;
         private readonly Network network;
         private readonly ChainIndexer chainIndexer;
+        private readonly Script cirrusRewardDummyAddressScriptPubKey;
         private readonly IWithdrawalExtractor withdrawalExtractor;
         private readonly IBlockRepository blockRepository;
         private readonly CancellationTokenSource cancellation;
@@ -116,6 +117,8 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             this.settings = settings;
             this.signals = signals;
             this.stateRepositoryRoot = stateRepositoryRoot;
+
+            this.cirrusRewardDummyAddressScriptPubKey = BitcoinAddress.Create(this.network.CirrusRewardDummyAddress).ScriptPubKey;
 
             // Future-proof store name.
             string depositStoreName = "federatedTransfers" + settings.MultiSigAddress.ToString();
@@ -498,7 +501,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                                         {
                                             bool isdistribution = false;
                                             if (!this.settings.IsMainChain)
-                                                isdistribution = recipient.ScriptPubKey == BitcoinAddress.Create(this.network.CirrusRewardDummyAddress).ScriptPubKey;
+                                                isdistribution = recipient.ScriptPubKey == this.cirrusRewardDummyAddressScriptPubKey;
 
                                             // Reserve the UTXOs before building the next transaction.
                                             walletUpdated |= this.federationWalletManager.ProcessTransaction(transaction, isDistribution: isdistribution);

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -418,7 +418,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                         if (!this.Synchronize())
                             return;
 
-                        this.logger.LogInformation($"{maturedBlockDeposits.Count} blocks received, containing {maturedBlockDeposits.SelectMany(d => d.Deposits).Count()} a total of deposits.");
+                        this.logger.LogInformation($"{maturedBlockDeposits.Count} blocks received, containing a total of {maturedBlockDeposits.SelectMany(d => d.Deposits).Count()} deposits.");
 
                         foreach (MaturedBlockDepositsModel maturedDeposit in maturedBlockDeposits)
                         {

--- a/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/CrossChainTransferStore.cs
@@ -69,7 +69,6 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         private readonly DBreezeSerializer dBreezeSerializer;
         private readonly Network network;
         private readonly ChainIndexer chainIndexer;
-        private readonly Script cirrusRewardDummyAddressScriptPubKey;
         private readonly IWithdrawalExtractor withdrawalExtractor;
         private readonly IBlockRepository blockRepository;
         private readonly CancellationTokenSource cancellation;
@@ -117,8 +116,6 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             this.settings = settings;
             this.signals = signals;
             this.stateRepositoryRoot = stateRepositoryRoot;
-
-            this.cirrusRewardDummyAddressScriptPubKey = BitcoinAddress.Create(this.network.CirrusRewardDummyAddress).ScriptPubKey;
 
             // Future-proof store name.
             string depositStoreName = "federatedTransfers" + settings.MultiSigAddress.ToString();
@@ -499,12 +496,8 @@ namespace Stratis.Features.FederatedPeg.TargetChain
 
                                         if (transaction != null)
                                         {
-                                            bool isdistribution = false;
-                                            if (!this.settings.IsMainChain)
-                                                isdistribution = recipient.ScriptPubKey == this.cirrusRewardDummyAddressScriptPubKey;
-
                                             // Reserve the UTXOs before building the next transaction.
-                                            walletUpdated |= this.federationWalletManager.ProcessTransaction(transaction, isDistribution: isdistribution);
+                                            walletUpdated |= this.federationWalletManager.ProcessTransaction(transaction);
 
                                             if (!this.ValidateTransaction(transaction))
                                             {

--- a/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
@@ -79,6 +79,8 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         /// <returns><c>true</c> if delay between next time we should ask for blocks is required; <c>false</c> otherwise.</returns>
         protected async Task<bool> SyncDepositsAsync()
         {
+            this.logger.LogInformation($"Fetching deposits from height {this.crossChainTransferStore.NextMatureDepositHeight}");
+
             SerializableResult<List<MaturedBlockDepositsModel>> model = await this.federationGatewayClient.GetMaturedBlockDepositsAsync(this.crossChainTransferStore.NextMatureDepositHeight, this.nodeLifetime.ApplicationStopping).ConfigureAwait(false);
 
             if (model == null)

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalExtractor.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalExtractor.cs
@@ -97,7 +97,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             }
             else
             {
-                // Reward distribution trnsactions will have more than 3 outputs.
+                // Reward distribution transactions will have more than 3 outputs.
                 IEnumerable<TxOut> txOuts = transaction.Outputs.Where(output => output.ScriptPubKey != this.multisigAddress.ScriptPubKey && !output.ScriptPubKey.IsUnspendable);
                 if (!txOuts.Any())
                     return null;

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
@@ -31,6 +31,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         private readonly IFederatedPegSettings federatedPegSettings;
         private readonly ISignals signals;
         private readonly IRewardDistributionManager distributionManager;
+        private int previousDistributionHeight;
 
         public WithdrawalTransactionBuilder(
             ILoggerFactory loggerFactory,
@@ -50,6 +51,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             this.distributionManager = distributionManager;
 
             this.cirrusRewardDummyAddressScriptPubKey = BitcoinAddress.Create(this.network.CirrusRewardDummyAddress).ScriptPubKey;
+            this.previousDistributionHeight = 0;
         }
 
         /// <inheritdoc />
@@ -74,23 +76,18 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                     Time = this.network.Consensus.IsProofOfStake ? blockTime : (uint?)null
                 };
 
+                multiSigContext.Recipients = new List<Recipient> { recipient.WithPaymentReducedByFee(FederatedPegSettings.CrossChainTransferFee) };
+
                 // Withdrawals from the sidechain won't have the OP_RETURN transaction tag, so we need to check against the ScriptPubKey of the Cirrus Dummy address.
                 if (!this.federatedPegSettings.IsMainChain && recipient.ScriptPubKey.Length > 0 && recipient.ScriptPubKey == this.cirrusRewardDummyAddressScriptPubKey)
                 {
                     // Use the distribution manager to determine the actual list of recipients.
                     // TODO: This would probably be neater if it was moved to the CCTS with the current method accepting a list of recipients instead
-                    multiSigContext.Recipients = this.distributionManager.Distribute(blockHeight, recipient.WithPaymentReducedByFee(FederatedPegSettings.CrossChainTransferFee).Amount); // Reduce the overall amount by the fee first before splitting it up.
-
-                    // This should never happen as we should always have at least one federation member with a configured wallet.
-                    if (multiSigContext.Recipients.Count == 0)
+                    if (this.previousDistributionHeight != blockHeight)
                     {
-                        this.logger.LogWarning("Could not identify recipients for the distribution transaction, adding dummy recipient to avoid the CCTS suspending irrecoverably.");
-                        multiSigContext.Recipients = new List<Recipient> { recipient.WithPaymentReducedByFee(FederatedPegSettings.CrossChainTransferFee) };
+                        multiSigContext.Recipients = this.distributionManager.Distribute(blockHeight, recipient.WithPaymentReducedByFee(FederatedPegSettings.CrossChainTransferFee).Amount); // Reduce the overall amount by the fee first before splitting it up.
+                        this.previousDistributionHeight = blockHeight;
                     }
-                }
-                else
-                {
-                    multiSigContext.Recipients = new List<Recipient> { recipient.WithPaymentReducedByFee(FederatedPegSettings.CrossChainTransferFee) }; // The fee known to the user is taken.
                 }
 
                 // TODO: Amend this so we're not picking coins twice.

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
@@ -88,7 +88,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                         multiSigContext.Recipients = this.distributionManager.Distribute(blockHeight, recipient.WithPaymentReducedByFee(FederatedPegSettings.CrossChainTransferFee).Amount); // Reduce the overall amount by the fee first before splitting it up.
 
                         // This can be transient as it is just to stop distribution happening multiple times
-                        // on blocks that contain more than on deposit.
+                        // on blocks that contain more than one deposit.
                         this.previousDistributionHeight = blockHeight;
                     }
                 }

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
@@ -86,6 +86,9 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                     if (this.previousDistributionHeight != blockHeight)
                     {
                         multiSigContext.Recipients = this.distributionManager.Distribute(blockHeight, recipient.WithPaymentReducedByFee(FederatedPegSettings.CrossChainTransferFee).Amount); // Reduce the overall amount by the fee first before splitting it up.
+
+                        // This can be transient as it is just to stop distribution happening multiple times
+                        // on blocks that contain more than on deposit.
                         this.previousDistributionHeight = blockHeight;
                     }
                 }

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
@@ -25,6 +25,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         private readonly ILogger logger;
         private readonly Network network;
 
+        private readonly Script cirrusRewardDummyAddressScriptPubKey;
         private readonly IFederationWalletManager federationWalletManager;
         private readonly IFederationWalletTransactionHandler federationWalletTransactionHandler;
         private readonly IFederatedPegSettings federatedPegSettings;
@@ -47,6 +48,8 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             this.federatedPegSettings = federatedPegSettings;
             this.signals = signals;
             this.distributionManager = distributionManager;
+
+            this.cirrusRewardDummyAddressScriptPubKey = BitcoinAddress.Create(this.network.CirrusRewardDummyAddress).ScriptPubKey;
         }
 
         /// <inheritdoc />
@@ -72,7 +75,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 };
 
                 // Withdrawals from the sidechain won't have the OP_RETURN transaction tag, so we need to check against the ScriptPubKey of the Cirrus Dummy address.
-                if (!this.federatedPegSettings.IsMainChain && recipient.ScriptPubKey.Length > 0 && recipient.ScriptPubKey == BitcoinAddress.Create(this.network.CirrusRewardDummyAddress).ScriptPubKey)
+                if (!this.federatedPegSettings.IsMainChain && recipient.ScriptPubKey.Length > 0 && recipient.ScriptPubKey == this.cirrusRewardDummyAddressScriptPubKey)
                 {
                     // Use the distribution manager to determine the actual list of recipients.
                     // TODO: This would probably be neater if it was moved to the CCTS with the current method accepting a list of recipients instead

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -530,16 +530,6 @@ namespace Stratis.Features.FederatedPeg.Wallet
                     foundSendingTrx = true;
                 }
 
-                // Figure out what to do when this transaction is found to affect the wallet.
-                if (foundSendingTrx || foundReceivingTrx)
-                {
-                    // Save the wallet when the transaction was not included in a block.
-                    //if (blockHeight == null)
-                    //{
-                    //this.SaveWallet();
-                    //}
-                }
-
                 return foundSendingTrx || foundReceivingTrx;
             }
         }

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -433,7 +433,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
         }
 
         /// <inheritdoc />
-        public bool ProcessTransaction(Transaction transaction, int? blockHeight = null, uint256 blockHash = null, Block block = null, bool isDistribution = false)
+        public bool ProcessTransaction(Transaction transaction, int? blockHeight = null, uint256 blockHash = null, Block block = null)
         {
             Guard.NotNull(transaction, nameof(transaction));
             Guard.Assert(blockHash == (blockHash ?? block?.GetHash()));

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -713,8 +713,6 @@ namespace Stratis.Features.FederatedPeg.Wallet
                     foundTransaction.CreationTime = DateTimeOffset.FromUnixTimeSeconds(block.Header.Time);
                 }
             }
-
-            //this.SaveWallet();
         }
 
         /// <summary>

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -417,9 +417,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 {
                     bool trxFound = this.ProcessTransaction(transaction, chainedHeader.Height, chainedHeader.HashBlock, block);
                     if (trxFound)
-                    {
                         walletUpdated = true;
-                    }
                 }
 
                 walletUpdated |= this.CleanTransactionsPastMaxReorg(chainedHeader.Height);
@@ -430,9 +428,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 this.UpdateLastBlockSyncedHeight(chainedHeader);
 
                 if (walletUpdated)
-                {
                     this.SaveWallet();
-                }
             }
         }
 
@@ -538,10 +534,10 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 if (foundSendingTrx || foundReceivingTrx)
                 {
                     // Save the wallet when the transaction was not included in a block.
-                    if (blockHeight == null)
-                    {
-                        this.SaveWallet();
-                    }
+                    //if (blockHeight == null)
+                    //{
+                    //this.SaveWallet();
+                    //}
                 }
 
                 return foundSendingTrx || foundReceivingTrx;
@@ -728,7 +724,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 }
             }
 
-            this.TransactionFoundInternal(script);
+            //this.SaveWallet();
         }
 
         /// <summary>
@@ -861,12 +857,6 @@ namespace Stratis.Features.FederatedPeg.Wallet
             }
 
             return spendingDetails;
-        }
-
-        public void TransactionFoundInternal(Script script)
-        {
-            // Persists the wallet file.
-            this.SaveWallet();
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
In this PR there are 2 major improvements:

1. The reward distribution builder walks back the chain to determine the encoded commitment heights for each block and does so for each deposit block received. This means that it unnecessarily walks over the same part of the chain multiple times. We can cache the set so that the lookup is faster. This improved the build withdrawal reward transaction code from 11000ms to 400ms.
2. The federation wallet gets saved unnecessarily often. On some code paths it gets saved 3-4 in a row. This is OK if the wallet remains small but once the reward transactions start coming in grows quickly and a save can task 100-150ms. I've changed this so that caller checks if any wallet modifications were made before saving.