### PR TITLE
Test for null key in RecoverFromSignature

### DIFF
--- a/src/NBitcoin/PubKey.cs
+++ b/src/NBitcoin/PubKey.cs
@@ -306,7 +306,7 @@ namespace NBitcoin
         public static PubKey RecoverFromSignature(int recId, ECDSASignature sig, uint256 hash, bool compressed)
         {
             ECKey key = ECKey.RecoverFromSignature(recId, sig, hash, compressed);
-            return key.GetPubKey(compressed);
+            return key?.GetPubKey(compressed);
         }
 
         public PubKey Derivate(byte[] cc, uint nChild, out byte[] ccChild)


### PR DESCRIPTION
I've noticed that the internal `RecoverFromSignature` sometimes returns `null`. This PR ensures that the `null` gets passed along instead of raising an error. This will lead to better behavior in methods such as `GetFederationMemberForBlockInternal`.