### PR TITLE
Update StraxMain Reward Batching activation height

### DIFF
--- a/src/Stratis.Bitcoin.Networks/StraxMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StraxMain.cs
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.Networks
             this.DefaultBanTimeSeconds = 11250; // 500 (MaxReorg) * 45 (TargetSpacing) / 2 = 3 hours, 7 minutes and 30 seconds
 
             this.CirrusRewardDummyAddress = "CPqxvnzfXngDi75xBJKqi4e6YrFsinrJka"; // Cirrus main address
-            this.RewardClaimerBatchActivationHeight = 119_185; // Tuesday, 12 January 2021 9:00:00 AM (Estimated)
+            this.RewardClaimerBatchActivationHeight = 119_200; // Tuesday, 12 January 2021 9:00:00 AM (Estimated)
             this.RewardClaimerBlockInterval = 100;
 
             // To successfully process the OP_FEDERATION opcode the federations should be known.


### PR DESCRIPTION
The activation height needs to be divisible by a 100.