### PR TITLE
Move node controller to API feature

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
@@ -142,6 +142,9 @@ namespace Stratis.Bitcoin.Features.Api
                         services.AddSingleton(options);
                         services.AddSingleton<ApiSettings>();
                         services.AddSingleton<ICertificateStore, CertificateStore>();
+
+                        // Controller
+                        services.AddTransient<NodeController>();
                     });
             });
 

--- a/src/Stratis.Bitcoin.Tests/Controllers/NodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Controllers/NodeControllerTest.cs
@@ -15,6 +15,7 @@ using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Controllers;
 using Stratis.Bitcoin.Controllers.Models;
+using Stratis.Bitcoin.Features.Api;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.P2P;
 using Stratis.Bitcoin.P2P.Peer;

--- a/src/Stratis.Bitcoin.Tests/Controllers/NodeControllerTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Controllers/NodeControllerTest.cs
@@ -13,7 +13,6 @@ using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
-using Stratis.Bitcoin.Controllers;
 using Stratis.Bitcoin.Controllers.Models;
 using Stratis.Bitcoin.Features.Api;
 using Stratis.Bitcoin.Interfaces;
@@ -258,11 +257,8 @@ namespace Stratis.Bitcoin.Tests.Controllers
             var txId = new uint256(12142124);
             this.pooledTransaction.Setup(p => p.GetTransaction(txId))
                 .ReturnsAsync(transaction);
-            var blockStore = new Mock<IBlockStore>();
-            blockStore.Setup(b => b.GetBlockIdByTransactionId(txId))
+            this.blockStore.Setup(b => b.GetBlockIdByTransactionId(txId))
                 .Returns(block.HashBlock);
-            this.fullNode.Setup(f => f.NodeFeature<IBlockStore>(false))
-                .Returns(blockStore.Object);
             string txid = txId.ToString();
             bool verbose = true;
 

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -466,9 +466,6 @@ namespace Stratis.Bitcoin.Base
 
                     // Console
                     services.AddSingleton<INodeStats, NodeStats>();
-
-                    // Controller
-                    services.AddTransient<NodeController>();
                 });
             });
 


### PR DESCRIPTION
The API version of `getrawtransaction` was returning different results to the RPC version, despite both having the same JSON model for their return value. This is because `IBlockStore` is not injected into the base feature, it is injected from the block store feature.

With the controller moved to the API feature, getrawtransaction now returns the block hash and confirmation count of the transaction like its RPC counterpart.