### PR TITLE
Require at least 1 confirmation for consolidation

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Services/WalletService.cs
@@ -1389,11 +1389,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Services
 
                 if (!string.IsNullOrWhiteSpace(request.SingleAddress))
                 {
-                    utxos = this.walletManager.GetSpendableTransactionsInWallet(request.WalletName).Where(u => u.Address.Address == request.SingleAddress || u.Address.Address == request.SingleAddress).OrderBy(u2 => u2.Transaction.Amount).ToList();
+                    utxos = this.walletManager.GetSpendableTransactionsInWallet(request.WalletName, 1).Where(u => u.Address.Address == request.SingleAddress || u.Address.Address == request.SingleAddress).OrderBy(u2 => u2.Transaction.Amount).ToList();
                 }
                 else
                 {
-                    utxos = this.walletManager.GetSpendableTransactionsInAccount(accountReference).OrderBy(u2 => u2.Transaction.Amount).ToList();
+                    utxos = this.walletManager.GetSpendableTransactionsInAccount(accountReference, 1).OrderBy(u2 => u2.Transaction.Amount).ToList();
                 }
 
                 if (utxos.Count == 0)


### PR DESCRIPTION
This filtering needs to be done up front as the wallet transaction handler would otherwise expect the inputs to all be confirmed in the wallet, throwing an error if one or more of the spendable inputs is in the mempool.