### PR TITLE
Move inbound IP range check logic to network peer server

### DIFF
--- a/src/Stratis.Bitcoin.Tests/P2P/NetworkPeerServerTests.cs
+++ b/src/Stratis.Bitcoin.Tests/P2P/NetworkPeerServerTests.cs
@@ -77,7 +77,7 @@ namespace Stratis.Bitcoin.Tests.P2P
             var ipandport = client.Client.RemoteEndPoint.ToString();
             if (client.Client.RemoteEndPoint.AddressFamily == AddressFamily.InterNetwork)
             {
-                ip = ipandport.Replace(ipandport.Substring(ipandport.IndexOf(':')), "");
+                ip = ipandport.Replace(ipandport[ipandport.IndexOf(':')..], "");
             }
             else
             {
@@ -90,15 +90,15 @@ namespace Stratis.Bitcoin.Tests.P2P
             connectionManagerSettings.Bind.Add(new NodeServerEndpoint(endpointDiscovered, isWhiteListed));
 
             // Act
-            var result = networkPeerServer.InvokeMethod("AllowClientConnection", client);
+            var result = networkPeerServer.InvokeMethod("AllowClientConnection", client, new NetworkPeerCollection(), new List<IPEndPoint>());
 
             // Assert
             Assert.True((inIBD && !isWhiteListed) == closeClient);
 
             this.testOutput.WriteLine(
-                $"In IBD : {inIBD.ToString()}, " +
-                $"Is White Listed : {isWhiteListed.ToString()}, " +
-                $"Close Client : {result.ToString()}");
+                $"In IBD : {inIBD}, " +
+                $"Is White Listed : {isWhiteListed}, " +
+                $"Close Client : {result}");
         }
     }
 }

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Net;
 using System.Net.Sockets;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
@@ -81,13 +80,9 @@ namespace Stratis.Bitcoin.Connection
         /// <summary>Maintains a list of connected peers and ensures their proper disposal.</summary>
         private readonly NetworkPeerDisposer networkPeerDisposer;
 
-        private readonly IVersionProvider versionProvider;
-
         private readonly IAsyncProvider asyncProvider;
 
         private IConsensusManager consensusManager;
-
-        private readonly IAsyncDelegateDequeuer<INetworkPeer> connectedPeersQueue;
 
         /// <summary>Traffic statistics from peers that have been disconnected.</summary>
         private readonly PerformanceCounter disconnectedPerfCounter;
@@ -131,9 +126,7 @@ namespace Stratis.Bitcoin.Connection
             this.Parameters = parameters;
             this.Parameters.ConnectCancellation = this.nodeLifetime.ApplicationStopping;
             this.selfEndpointTracker = selfEndpointTracker;
-            this.versionProvider = versionProvider;
             this.ipRangeFilteringEndpointExclusions = new List<IPEndPoint>();
-            this.connectedPeersQueue = asyncProvider.CreateAndRunAsyncDelegateDequeuer<INetworkPeer>($"{nameof(ConnectionManager)}-{nameof(this.connectedPeersQueue)}", this.OnPeerAdded);
             this.disconnectedPerfCounter = new PerformanceCounter();
 
             this.Parameters.UserAgent = $"{this.ConnectionSettings.Agent}:{versionProvider.GetVersion()} ({(int)this.NodeSettings.ProtocolVersion})";
@@ -205,13 +198,13 @@ namespace Stratis.Bitcoin.Connection
                 NetworkPeerServer server = this.NetworkPeerFactory.CreateNetworkPeerServer(listen.Endpoint, this.ConnectionSettings.ExternalEndpoint, this.Parameters.Version);
 
                 this.Servers.Add(server);
-                var cmb = (cloneParameters.TemplateBehaviors.Single(x => x is IConnectionManagerBehavior) as ConnectionManagerBehavior);
+                var cmb = cloneParameters.TemplateBehaviors.Single(x => x is IConnectionManagerBehavior) as ConnectionManagerBehavior;
                 cmb.Whitelisted = listen.Whitelisted;
 
                 server.InboundNetworkPeerConnectionParameters = cloneParameters;
                 try
                 {
-                    server.Listen();
+                    server.Listen(this.ConnectedPeers, this.ipRangeFilteringEndpointExclusions);
                 }
                 catch (SocketException e)
                 {
@@ -414,72 +407,6 @@ namespace Stratis.Bitcoin.Connection
         public void AddConnectedPeer(INetworkPeer peer)
         {
             this.connectedPeers.Add(peer);
-            this.connectedPeersQueue.Enqueue(peer);
-        }
-
-        private Task OnPeerAdded(INetworkPeer peer, CancellationToken cancellationToken)
-        {
-            // Code in this method is a quick and dirty fix for the race condition described here: https://github.com/stratisproject/StratisBitcoinFullNode/issues/2864
-            // TODO race condition should be eliminated instead of fixing its consequences.
-
-            if (this.ShouldDisconnect(peer))
-                peer.Disconnect("Peer from the same network group.");
-
-            return Task.CompletedTask;
-        }
-
-        /// <summary>
-        /// Determines if the peer should be disconnected.
-        /// Peer should be disconnected in case it's IP is from the same group in which any other peer
-        /// is and the peer wasn't added using -connect or -addNode command line arguments.
-        /// </summary>
-        private bool ShouldDisconnect(INetworkPeer peer)
-        {
-            // Don't disconnect if range filtering is not turned on.
-            if (!this.ConnectionSettings.IpRangeFiltering)
-            {
-                this.logger.LogTrace("(-)[IP_RANGE_FILTERING_OFF]:false");
-                return false;
-            }
-
-            // Don't disconnect if this peer has a local host address.
-            if (peer.PeerEndPoint.Address.IsLocal())
-            {
-                this.logger.LogTrace("(-)[IP_IS_LOCAL]:false");
-                return false;
-            }
-
-            // Don't disconnect if this peer is in -addnode or -connect.
-            if (this.ConnectionSettings.RetrieveAddNodes().Union(this.ConnectionSettings.Connect).Any(ep => peer.PeerEndPoint.MatchIpOnly(ep)))
-            {
-                this.logger.LogTrace("(-)[ADD_NODE_OR_CONNECT]:false");
-                return false;
-            }
-
-            // Don't disconnect if this peer is in the exclude from IP range filtering group.
-            if (this.ipRangeFilteringEndpointExclusions.Any(ip => ip.MatchIpOnly(peer.PeerEndPoint)))
-            {
-                this.logger.LogTrace("(-)[PEER_IN_IPRANGEFILTER_EXCLUSIONS]:false");
-                return false;
-            }
-
-            byte[] peerGroup = peer.PeerEndPoint.MapToIpv6().Address.GetGroup();
-
-            foreach (INetworkPeer connectedPeer in this.ConnectedPeers)
-            {
-                if (peer == connectedPeer)
-                    continue;
-
-                byte[] group = connectedPeer.PeerEndPoint.MapToIpv6().Address.GetGroup();
-
-                if (peerGroup.SequenceEqual(group))
-                {
-                    this.logger.LogTrace("(-)[SAME_GROUP]:true");
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
I have noticed async loops climbing after an inbound peer constantly trying to connect to a node.

This check should be done as and when a peer tries to connect inbound. 

This also eliminates an extra async loop allocation.