### PR TITLE
SmartContracts and Standards forwards compatibility

### DIFF
--- a/src/Stratis.SmartContracts.CLR.Tests/ContractAssemblyLoaderTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractAssemblyLoaderTests.cs
@@ -56,11 +56,11 @@ public class FruitVendor : SmartContract, IStandardToken
         {
             // Create the byte code of a contract that contains new data types that are not (normally) supported by the current node.
             string smartContracts130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts, Version=1.3.0.0"));
-            SmartContractLoadContext smartContracts130Ctx = new SmartContractLoadContext(AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()));
+            AssemblyLoadContext smartContracts130Ctx = new AssemblyLoadContext(nameof(smartContracts130Ctx));
             Assembly smartContracts130 = smartContracts130Ctx.LoadFromAssemblyPath(smartContracts130Path);
 
             string smartContractsStandards130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts.Standards, Version=1.3.0.0"));
-            SmartContractLoadContext smartContractsStandards130Ctx = new SmartContractLoadContext(AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()));
+            AssemblyLoadContext smartContractsStandards130Ctx = new AssemblyLoadContext(nameof(smartContractsStandards130Ctx));
             Assembly smartContractsStandards130 = smartContractsStandards130Ctx.LoadFromAssemblyPath(smartContractsStandards130Path);
 
             Assembly Runtime = Assembly.Load("System.Runtime");

--- a/src/Stratis.SmartContracts.CLR.Tests/ContractAssemblyLoaderTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractAssemblyLoaderTests.cs
@@ -55,11 +55,11 @@ public class FruitVendor : SmartContract, IStandardToken
         public void ContractAssemblyLoaderIsForwardCompatibleWithSmartContractAndStandardsUpdates()
         {
             // Create the byte code of a contract that contains new data types that are not (normally) supported by the current node.
-            string smartContracts130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts, Version=1.3.0"));
+            string smartContracts130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts, Version=1.3.0.0"));
             SmartContractLoadContext smartContracts130Ctx = new SmartContractLoadContext(AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()));
             Assembly smartContracts130 = smartContracts130Ctx.LoadFromAssemblyPath(smartContracts130Path);
 
-            string smartContractsStandards130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts.Standards, Version=1.3.0"));
+            string smartContractsStandards130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts.Standards, Version=1.3.0.0"));
             SmartContractLoadContext smartContractsStandards130Ctx = new SmartContractLoadContext(AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()));
             Assembly smartContractsStandards130 = smartContractsStandards130Ctx.LoadFromAssemblyPath(smartContractsStandards130Path);
 

--- a/src/Stratis.SmartContracts.CLR.Tests/ContractAssemblyLoaderTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractAssemblyLoaderTests.cs
@@ -1,0 +1,86 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using Stratis.SmartContracts.CLR.Compilation;
+using Stratis.SmartContracts.CLR.Loader;
+using Xunit;
+
+namespace Stratis.SmartContracts.CLR.Tests
+{
+    public class ContractAssemblyLoaderTests
+    {
+        string testContract = @"
+using Stratis.SmartContracts;
+using Stratis.SmartContracts.Standards;
+
+public class FruitVendor : SmartContract, IStandardToken
+{
+    public UInt256 TotalSupply => 0;
+
+    public uint Decimals => 0;
+
+    public FruitVendor(ISmartContractState state) : base(state)
+    {
+    }
+
+    public UInt256 GetBalance(Address address)
+    {
+        return 0;
+    }
+
+    public bool TransferTo(Address address, UInt256 amount)
+    {
+        return true;
+    }
+
+    public bool TransferFrom(Address from, Address to, UInt256 amount)
+    {
+        return true;
+    }
+
+    public bool Approve(Address spender, UInt256 currentAmount, UInt256 amount)
+    {
+        return true;
+    }
+
+    public UInt256 Allowance(Address owner, Address spender)
+    {
+        return 0;
+    }
+}
+        ";
+
+        [Fact]
+        public void ContractAssemblyLoaderIsForwardCompatibleWithSmartContractAndStandardsUpdates()
+        {
+            // Create the byte code of a contract that contains new data types that are not (normally) supported by the current node.
+            string smartContracts130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts, Version=1.3.0"));
+            SmartContractLoadContext smartContracts130Ctx = new SmartContractLoadContext(AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()));
+            Assembly smartContracts130 = smartContracts130Ctx.LoadFromAssemblyPath(smartContracts130Path);
+
+            string smartContractsStandards130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts.Standards, Version=1.3.0"));
+            SmartContractLoadContext smartContractsStandards130Ctx = new SmartContractLoadContext(AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()));
+            Assembly smartContractsStandards130 = smartContractsStandards130Ctx.LoadFromAssemblyPath(smartContractsStandards130Path);
+
+            Assembly Runtime = Assembly.Load("System.Runtime");
+            Assembly Core = typeof(object).Assembly;
+            HashSet<Assembly> allowedAssemblies = new HashSet<Assembly> {
+                Runtime,
+                Core,
+                smartContracts130,
+                typeof(Enumerable).Assembly,
+                smartContractsStandards130
+            };
+
+            ContractCompilationResult result = ContractCompiler.Compile(this.testContract, allowedAssemblies: allowedAssemblies );
+            byte[] bytes = result.Compilation;
+
+            // Test that the node is able to load the futuristic contract.
+            ContractAssemblyLoader loader = new ContractAssemblyLoader();
+            CSharpFunctionalExtensions.Result<IContractAssembly> result2 = loader.Load(new ContractByteCode(bytes));
+            IContractAssembly assembly = result2.Value;
+            Assert.Equal("FruitVendor", assembly.Assembly.GetTypes().First().Name);
+        }
+    }
+}

--- a/src/Stratis.SmartContracts.CLR.Tests/ContractAssemblyLoaderTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/ContractAssemblyLoaderTests.cs
@@ -55,11 +55,11 @@ public class FruitVendor : SmartContract, IStandardToken
         public void ContractAssemblyLoaderIsForwardCompatibleWithSmartContractAndStandardsUpdates()
         {
             // Create the byte code of a contract that contains new data types that are not (normally) supported by the current node.
-            string smartContracts130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts, Version=1.3.0.0"));
+            string smartContracts130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts, Version=1.3.0.0"), out _);
             AssemblyLoadContext smartContracts130Ctx = new AssemblyLoadContext(nameof(smartContracts130Ctx));
             Assembly smartContracts130 = smartContracts130Ctx.LoadFromAssemblyPath(smartContracts130Path);
 
-            string smartContractsStandards130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts.Standards, Version=1.3.0.0"));
+            string smartContractsStandards130Path = SmartContractLoadContext.GetExactAssembly(new AssemblyName("Stratis.SmartContracts.Standards, Version=1.3.0.0"), out _);
             AssemblyLoadContext smartContractsStandards130Ctx = new AssemblyLoadContext(nameof(smartContractsStandards130Ctx));
             Assembly smartContractsStandards130 = smartContractsStandards130Ctx.LoadFromAssemblyPath(smartContractsStandards130Path);
 

--- a/src/Stratis.SmartContracts.CLR/Loader/ContractAssemblyLoader.cs
+++ b/src/Stratis.SmartContracts.CLR/Loader/ContractAssemblyLoader.cs
@@ -12,7 +12,7 @@ namespace Stratis.SmartContracts.CLR.Loader
     public class SmartContractLoadContext : AssemblyLoadContext
     {
         private AssemblyLoadContext defaultContext;
-        private static Dictionary<AssemblyName, byte[]> cache = new Dictionary<AssemblyName, byte[]>();
+        private static Dictionary<string, byte[]> cache = new Dictionary<string, byte[]>();
 
         public SmartContractLoadContext(AssemblyLoadContext defaultContext)
         {
@@ -61,10 +61,10 @@ namespace Stratis.SmartContracts.CLR.Loader
             // Ensure that an exact compatible version is used.
             if (assemblyName.Name == "Stratis.SmartContracts" || assemblyName.Name == "Stratis.SmartContracts.Standards")
             {
-                if (!cache.TryGetValue(assemblyName, out byte[] bytes))
+                if (!cache.TryGetValue(assemblyName.FullName, out byte[] bytes))
                 {
                     bytes = File.ReadAllBytes(GetExactAssembly(assemblyName));
-                    cache[assemblyName] = bytes;
+                    cache[assemblyName.FullName] = bytes;
                 }
 
                 using (var stream = new MemoryStream(bytes))

--- a/src/Stratis.SmartContracts.CLR/Loader/ContractAssemblyLoader.cs
+++ b/src/Stratis.SmartContracts.CLR/Loader/ContractAssemblyLoader.cs
@@ -1,27 +1,79 @@
 ﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
 using System.Reflection;
+using System.Runtime.Loader;
 using CSharpFunctionalExtensions;
 
 namespace Stratis.SmartContracts.CLR.Loader
 {
+    public class SmartContractLoadContext : AssemblyLoadContext
+    {
+        private AssemblyLoadContext defaultContext;
+
+        public SmartContractLoadContext(AssemblyLoadContext defaultContext)
+        {
+            this.defaultContext = defaultContext;
+        }
+
+        public static string GetExactAssembly(AssemblyName assemblyName)
+        {
+            // The DLL is not included with our distribution. See if we can get it from NuGet.org.
+            string version = assemblyName.Version.ToString();
+            string folderName = $"{assemblyName.Name.ToLower()}.{version}";
+            string assemblyFolder = Path.GetFullPath("LegacyStandardsDLLs");
+            string assemblyPath = Path.Combine(assemblyFolder, folderName);
+            if (!Directory.Exists(assemblyPath))
+            {
+                string downloadFile = $"{assemblyPath}.nupkg";
+
+                if (!File.Exists(downloadFile))
+                {
+                    Directory.CreateDirectory(assemblyFolder);
+
+                    using (var client = new WebClient())
+                    {
+                        // TODO: DLLs should be distributed via the Cirrus blockchain.
+                        string downloadLink = $"http://www.nuget.org/api/v2/package/{assemblyName.Name.ToLower()}/{version}";
+                        client.DownloadFile(downloadLink, downloadFile);
+                    }
+                }
+
+                ZipFile.ExtractToDirectory(downloadFile, assemblyPath);
+            }
+
+            string[] files = Directory.GetFiles(Path.Combine(assemblyPath, "lib"), $"{assemblyName.Name}.dll", SearchOption.AllDirectories);
+            return  (files.Length == 1) ? files[0] : null;
+        }
+
+        protected override Assembly Load(AssemblyName assemblyName)
+        {
+            // Ensure that an exact compatible version is used.
+            if (assemblyName.Name == "Stratis.SmartContracts" || assemblyName.Name == "Stratis.SmartContracts.Standards")
+                return this.LoadFromAssemblyPath(GetExactAssembly(assemblyName));
+
+            return this.defaultContext.LoadFromAssemblyName(assemblyName);
+        }
+    }
+
     /// <summary>
     /// Loads assemblies from bytecode.
     /// </summary>
-    /// <para>
-    /// TODO this may return cached assemblies in the future.
-    /// </para>
     public class ContractAssemblyLoader : ILoader
     {
         /// <summary>
-        /// Loads a contract from a raw byte array into an anonymous <see cref="AssemblyLoadContext"/>.
+        /// Loads a contract from a raw byte array into a custom <see cref="AssemblyLoadContext"/>.
         /// </summary>
         public Result<IContractAssembly> Load(ContractByteCode bytes)
         {
-            // Assembly.Load(byte[]) loads the assembly into a new anonymous AssemblyLoadContext
-            // TODO in the future, we will use a custom AssemblyLoadContext
+            // Assembly.Load(byte[]) loads the assembly into a custom AssemblyLoadContext
             try
             {
-                Assembly assembly = Assembly.Load(bytes.Value);
+                SmartContractLoadContext context = new SmartContractLoadContext(AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()));
+
+                MemoryStream s = new MemoryStream(bytes.Value);
+                Assembly assembly = context.LoadFromStream(s);
 
                 return Result.Ok<IContractAssembly>(new ContractAssembly(assembly));
             }

--- a/src/Stratis.SmartContracts.CLR/Loader/ContractAssemblyLoader.cs
+++ b/src/Stratis.SmartContracts.CLR/Loader/ContractAssemblyLoader.cs
@@ -32,11 +32,18 @@ namespace Stratis.SmartContracts.CLR.Loader
                 {
                     Directory.CreateDirectory(assemblyFolder);
 
-                    using (var client = new WebClient())
+                    string downloadLink = $"http://www.nuget.org/api/v2/package/{assemblyName.Name.ToLower()}/{version}";
+
+                    try
                     {
-                        // TODO: DLLs should be distributed via the Cirrus blockchain.
-                        string downloadLink = $"http://www.nuget.org/api/v2/package/{assemblyName.Name.ToLower()}/{version}";
-                        client.DownloadFile(downloadLink, downloadFile);
+                        using (var client = new WebClient())
+                        {
+                            client.DownloadFile(downloadLink, downloadFile);
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        throw new FileNotFoundException($"Could not find '{downloadFile}'. Get the file from '{downloadLink}' and copy it to this location.");
                     }
                 }
 

--- a/src/Stratis.SmartContracts.CLR/Loader/ContractAssemblyLoader.cs
+++ b/src/Stratis.SmartContracts.CLR/Loader/ContractAssemblyLoader.cs
@@ -6,26 +6,32 @@ using System.Net;
 using System.Reflection;
 using System.Runtime.Loader;
 using CSharpFunctionalExtensions;
+using Microsoft.Extensions.Logging;
 
 namespace Stratis.SmartContracts.CLR.Loader
 {
     public class SmartContractLoadContext : AssemblyLoadContext
     {
-        private AssemblyLoadContext defaultContext;
+        private readonly ILogger logger;
+        private readonly AssemblyLoadContext defaultContext;
         private static Dictionary<string, byte[]> cache = new Dictionary<string, byte[]>();
 
-        public SmartContractLoadContext(AssemblyLoadContext defaultContext)
+        public SmartContractLoadContext(AssemblyLoadContext defaultContext, ILogger logger)
         {
+            this.logger = logger;
             this.defaultContext = defaultContext;
         }
 
-        public static string GetExactAssembly(AssemblyName assemblyName)
+        public static string GetExactAssembly(AssemblyName assemblyName, out string errorMessage)
         {
             // The DLL is not included with our distribution. See if we can get it from NuGet.org.
             string version = assemblyName.Version.ToString();
             string folderName = $"{assemblyName.Name.ToLower()}.{version}";
             string assemblyFolder = Path.GetFullPath("LegacyStandardsDLLs");
             string assemblyPath = Path.Combine(assemblyFolder, folderName);
+
+            errorMessage = null;
+
             if (!Directory.Exists(assemblyPath))
             {
                 string downloadFile = $"{assemblyPath}.nupkg";
@@ -45,7 +51,8 @@ namespace Stratis.SmartContracts.CLR.Loader
                     }
                     catch (Exception)
                     {
-                        throw new FileNotFoundException($"Could not find '{downloadFile}'. Get the file from '{downloadLink}' and copy it to this location.");
+                        errorMessage = $"Could not find '{downloadFile}'. Get the file from '{downloadLink}' and copy it to this location.";
+                        return null;
                     }
                 }
 
@@ -63,9 +70,23 @@ namespace Stratis.SmartContracts.CLR.Loader
             {
                 if (!cache.TryGetValue(assemblyName.FullName, out byte[] bytes))
                 {
-                    bytes = File.ReadAllBytes(GetExactAssembly(assemblyName));
+                    string exactAssembly = GetExactAssembly(assemblyName, out string error);
+                    if (exactAssembly == null)
+                    {
+                        if (this.logger == null)
+                            throw new Exception(error);
+
+                        cache[assemblyName.FullName] = null;
+                        this.logger.LogWarning(error);
+                        return this.defaultContext.LoadFromAssemblyName(assemblyName);
+                    }
+
+                    bytes = File.ReadAllBytes(exactAssembly);
                     cache[assemblyName.FullName] = bytes;
                 }
+
+                if (bytes == null)
+                    return this.defaultContext.LoadFromAssemblyName(assemblyName);
 
                 using (var stream = new MemoryStream(bytes))
                 {
@@ -82,6 +103,13 @@ namespace Stratis.SmartContracts.CLR.Loader
     /// </summary>
     public class ContractAssemblyLoader : ILoader
     {
+        private readonly ILogger logger;
+
+        public ContractAssemblyLoader(ILoggerFactory loggerFactory = null)
+        {
+            this.logger = loggerFactory?.CreateLogger(typeof(ContractAssemblyLoader).Name);
+        }
+
         /// <summary>
         /// Loads a contract from a raw byte array into a custom <see cref="AssemblyLoadContext"/>.
         /// </summary>
@@ -90,7 +118,7 @@ namespace Stratis.SmartContracts.CLR.Loader
             // Assembly.Load(byte[]) loads the assembly into a custom AssemblyLoadContext
             try
             {
-                SmartContractLoadContext context = new SmartContractLoadContext(AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()));
+                SmartContractLoadContext context = new SmartContractLoadContext(AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()), this.logger) ;
 
                 MemoryStream s = new MemoryStream(bytes.Value);
                 Assembly assembly = context.LoadFromStream(s);


### PR DESCRIPTION
Ensures that legacy smart contracts use the legacy versions of `Stratis.SmartContracts` and `Stratis.SmartContracts.Standards`.

The current (questionable) behavior is to always use the latest versions of these assemblies. That means that the behavior of legacy smart contracts could conceivable change as these assemblies evolve - which, basically breaks the non-mutability assumption of the blockchain. This becomes an issue once changes such as PR #365 need to be released.