### PR TITLE
Fix Finality Bug

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/PosConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/PosConsensusRuleEngine.cs
@@ -56,10 +56,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
 
             // A temporary hack until tip manage will be introduced.
             var coindb = ((CachedCoinView)this.UtxoSet).ICoindb;
-            HashHeightPair hash = coindb.GetTipHash();
-            ChainedHeader tip = chainTip.FindAncestorOrSelf(hash.Hash);
+            ChainedHeader coinDbTip = chainTip.FindAncestorOrSelf(coindb.GetTipHash().Hash);
 
-            this.RewindDataIndexCache.Initialize(tip.Height, this.UtxoSet);
+            this.RewindDataIndexCache.Initialize(coinDbTip.Height, this.UtxoSet);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Tests/Consensus/FinalizedBlockInfoRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/FinalizedBlockInfoRepositoryTest.cs
@@ -29,6 +29,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             using (var repo = new FinalizedBlockInfoRepository(kvRepo, this.loggerFactory, asyncMock.Object))
             {
+                repo.Initialize(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().GetHash(), 0));
                 repo.SaveFinalizedBlockHashAndHeight(uint256.One, 777);
             }
 
@@ -49,6 +50,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             using (var repo = new FinalizedBlockInfoRepository(kvRepo, this.loggerFactory, asyncMock.Object))
             {
+                repo.Initialize(new ChainedHeader(this.Network.GetGenesis().Header, this.Network.GetGenesis().GetHash(), 0));
                 repo.SaveFinalizedBlockHashAndHeight(uint256.One, 777);
                 repo.SaveFinalizedBlockHashAndHeight(uint256.One, 555);
 

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -18,7 +18,6 @@ using Stratis.Bitcoin.Connection;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Consensus.Validators;
-using Stratis.Bitcoin.Controllers;
 using Stratis.Bitcoin.EventBus;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.P2P;
@@ -226,6 +225,10 @@ namespace Stratis.Bitcoin.Base
             // This may be a temporary solution until a better way is found to solve this dependency.
             this.blockStore.Initialize();
 
+            // The finalized repository needs to be initialized before the rules engine in case the
+            // node shutdown enexpectedly and the finalized block info has to be reset.
+            this.finalizedBlockInfoRepository.Initialize(this.chainIndexer.Tip);
+
             this.consensusRules.Initialize(this.chainIndexer.Tip);
 
             await this.consensusManager.InitializeAsync(this.chainIndexer.Tip).ConfigureAwait(false);
@@ -273,8 +276,8 @@ namespace Stratis.Bitcoin.Base
                     await this.provenBlockHeaderStore.SaveAsync().ConfigureAwait(false);
             },
             this.nodeLifetime.ApplicationStopping,
-            repeatEvery: TimeSpan.FromMinutes(1.0),
-            startAfter: TimeSpan.FromMinutes(1.0));
+            repeatEvery: TimeSpan.FromMinutes(2),
+            startAfter: TimeSpan.FromMinutes(2));
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -226,7 +226,7 @@ namespace Stratis.Bitcoin.Base
             this.blockStore.Initialize();
 
             // The finalized repository needs to be initialized before the rules engine in case the
-            // node shutdown enexpectedly and the finalized block info has to be reset.
+            // node shutdown unexpectedly and the finalized block info needs to be reset.
             this.finalizedBlockInfoRepository.Initialize(this.chainIndexer.Tip);
 
             this.consensusRules.Initialize(this.chainIndexer.Tip);

--- a/src/Stratis.Bitcoin/Base/ChainRepository.cs
+++ b/src/Stratis.Bitcoin/Base/ChainRepository.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using LevelDB;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Base

--- a/src/Stratis.Bitcoin/Configuration/Settings/ConsensusSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/Settings/ConsensusSettings.cs
@@ -63,7 +63,7 @@ namespace Stratis.Bitcoin.Configuration.Settings
             this.MaxTipAge = config.GetOrDefault("maxtipage", nodeSettings.Network.MaxTipAge, this.logger);
             this.MaxBlockMemoryInMB = config.GetOrDefault("maxblkmem", 200, this.logger);
             this.MaxCoindbCacheInMB = config.GetOrDefault("dbcache", 200, this.logger);
-            this.CoindbIbdFlushMin = config.GetOrDefault("dbflush", 10, this.logger);
+            this.CoindbIbdFlushMin = config.GetOrDefault("dbflush", 2, this.logger);
         }
 
         /// <summary>Prints the help information on how to configure the Consensus settings to the logger.</summary>

--- a/src/Stratis.Bitcoin/Consensus/FinalizedBlockInfoRepository.cs
+++ b/src/Stratis.Bitcoin/Consensus/FinalizedBlockInfoRepository.cs
@@ -182,7 +182,7 @@ namespace Stratis.Bitcoin.Consensus
         public void Dispose()
         {
             this.cancellation.Cancel();
-            this.finalizedBlockInfoPersistingTask.GetAwaiter().GetResult();
+            this.finalizedBlockInfoPersistingTask?.GetAwaiter().GetResult();
         }
     }
 }

--- a/src/Stratis.Bitcoin/Consensus/FinalizedBlockInfoRepository.cs
+++ b/src/Stratis.Bitcoin/Consensus/FinalizedBlockInfoRepository.cs
@@ -30,6 +30,10 @@ namespace Stratis.Bitcoin.Consensus
         /// <returns><c>true</c> if new value was set, <c>false</c> if <paramref name="height"/> is lower or equal than current value.</returns>
         bool SaveFinalizedBlockHashAndHeight(uint256 hash, int height);
 
+        /// <summary>
+        /// Initializes the finalized block repository by checking its tip and starting the persist task.
+        /// </summary>
+        /// <param name="chainTip">The current chain's tip.</param>
         void Initialize(ChainedHeader chainTip);
     }
 
@@ -84,8 +88,11 @@ namespace Stratis.Bitcoin.Consensus
             this.cancellation = new CancellationTokenSource();
         }
 
+        /// <inheritdoc />
         public void Initialize(ChainedHeader chainTip)
         {
+            // If the node shut down unexpectedly, it is possible that the finalized height could be 
+            // higher than the chain tip. In this case we have to set the finalized height back to the chain's tip.
             if (this.GetFinalizedBlockInfo()?.Height > chainTip.Height)
             {
                 var resetFinalization = new HashHeightPair(chainTip);

--- a/src/Stratis.Bitcoin/Utilities/NodeStats.cs
+++ b/src/Stratis.Bitcoin/Utilities/NodeStats.cs
@@ -147,7 +147,7 @@ namespace Stratis.Bitcoin.Utilities
 
                 var statsBuilder = new StringBuilder();
 
-                statsBuilder.AppendLine($"======Node stats====== {date}");
+                statsBuilder.AppendLine($"======Node stats===== {date}");
 
                 foreach (var item in inlineStatsBuilders)
                 {

--- a/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
@@ -9,6 +9,11 @@ using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules;
 using Stratis.Bitcoin.Features.PoA.Policies;
 using Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules;
+using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
+using Stratis.Bitcoin.Features.SmartContracts.PoA;
+using Stratis.Bitcoin.Features.SmartContracts.PoA.MempoolRules;
+using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
+using Stratis.Bitcoin.Features.SmartContracts.Rules;
 
 namespace Stratis.SmartContracts.Networks
 {

--- a/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
@@ -9,11 +9,6 @@ using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules;
 using Stratis.Bitcoin.Features.PoA.Policies;
 using Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules;
-using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
-using Stratis.Bitcoin.Features.SmartContracts.PoA;
-using Stratis.Bitcoin.Features.SmartContracts.PoA.MempoolRules;
-using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
-using Stratis.Bitcoin.Features.SmartContracts.Rules;
 
 namespace Stratis.SmartContracts.Networks
 {


### PR DESCRIPTION
The main issue here is that when a unexpected shutdown occurs, the finality hash and height will more than likely be higher than the current chain/coinview tip. This is because we write the finality height more often than what the chain / coinview is flushed to disk.

When this happens we need to set the finality height back to the current chain tip before continuing initialization of the node.

I've also decreased the coinview flush time to 2 minutes and upped the chain flush task to2 minutes so that they are more in line with each other.