### PR TITLE
Bump version prior to fixing NuGet dependencies for  Stratis.SmartCon…

### DIFF
--- a/src/Stratis.SmartContracts.Tests.Common/Stratis.SmartContracts.Tests.Common.csproj
+++ b/src/Stratis.SmartContracts.Tests.Common/Stratis.SmartContracts.Tests.Common.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     
-    <Version>2.0.0.0</Version>
+    <Version>2.0.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
…tracts.Tests.Common

Somehow the listed NuGet dependencies don't correspond to what they should be if the package is pushed to NuGet now:

![image](https://user-images.githubusercontent.com/29645989/107320783-78bb3a80-6af5-11eb-83b4-a8849d82ac09.png)

which should be:

```
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <id>Stratis.SmartContracts.Tests.Common</id>
    <version>2.0.0</version>
    <authors>Stratis.SmartContracts.Tests.Common</authors>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <description>Package Description</description>
    <dependencies>
      <group targetFramework=".NETCoreApp3.1">
        <dependency id="Stratis.Features.PoA.IntegrationTests.Common" version="1.0.6.4" exclude="Build,Analyzers" />
        <dependency id="Stratis.Features.SmartContracts" version="1.0.7.1" exclude="Build,Analyzers" />
        <dependency id="Stratis.Features.IntegrationTests.Common" version="1.0.6.4" exclude="Build,Analyzers" />
        <dependency id="Stratis.Core.Tests.Common" version="1.0.6.4" exclude="Build,Analyzers" />
        <dependency id="Stratis.SmartContracts.Networks" version="2.0.1" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
</package>
```