### PR TITLE
Prevent changing published packages w/o bumping local version

### DIFF
--- a/src/NBitcoin/NBitcoin.csproj
+++ b/src/NBitcoin/NBitcoin.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <Version>4.0.0.79</Version>
+    <Version>4.0.0.80</Version>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
+++ b/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Stratis.Bitcoin.Features.Api</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>Stratis.Features.Api</PackageId>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>

--- a/src/Stratis.Bitcoin.Features.BlockStore/Stratis.Bitcoin.Features.BlockStore.csproj
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Stratis.Bitcoin.Features.BlockStore.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.ColdStaking/Stratis.Bitcoin.Features.ColdStaking.csproj
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/Stratis.Bitcoin.Features.ColdStaking.csproj
@@ -7,7 +7,7 @@
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<Version>1.0.7.0</Version>
+		<Version>1.0.7.2</Version>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 		<Authors>Stratis Group Ltd.</Authors>
 	</PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.Consensus/Stratis.Bitcoin.Features.Consensus.csproj
+++ b/src/Stratis.Bitcoin.Features.Consensus/Stratis.Bitcoin.Features.Consensus.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.MemoryPool/Stratis.Bitcoin.Features.MemoryPool.csproj
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/Stratis.Bitcoin.Features.MemoryPool.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <OutputTypeEx>library</OutputTypeEx>
     <Authors>Stratis Group Ltd.</Authors>

--- a/src/Stratis.Bitcoin.Features.Miner/Stratis.Bitcoin.Features.Miner.csproj
+++ b/src/Stratis.Bitcoin.Features.Miner/Stratis.Bitcoin.Features.Miner.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.Notifications/Stratis.Bitcoin.Features.Notifications.csproj
+++ b/src/Stratis.Bitcoin.Features.Notifications/Stratis.Bitcoin.Features.Notifications.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common.csproj
+++ b/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common.csproj
@@ -13,7 +13,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.6.4</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Product />
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.PoA/Stratis.Bitcoin.Features.PoA.csproj
+++ b/src/Stratis.Bitcoin.Features.PoA/Stratis.Bitcoin.Features.PoA.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.RPC/Stratis.Bitcoin.Features.RPC.csproj
+++ b/src/Stratis.Bitcoin.Features.RPC/Stratis.Bitcoin.Features.RPC.csproj
@@ -14,7 +14,7 @@
 		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
 		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
 		<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-		<Version>1.0.7.0</Version>
+		<Version>1.0.7.2</Version>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 		<Authors>Stratis Group Ltd.</Authors>
 	</PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Stratis.Bitcoin.Features.SmartContracts.csproj
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Stratis.Bitcoin.Features.SmartContracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>    
-    <Version>1.0.7.1</Version>
+    <Version>1.0.7.2</Version>
     <Authors>Stratis Group Ltd.</Authors>
     <PackageId>Stratis.Features.SmartContracts</PackageId>
     <Product>Stratis.Features.SmartContracts</Product>

--- a/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
+++ b/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.8.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
+++ b/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.8.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Stratis.Bitcoin.IntegrationTests.Common.csproj
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Stratis.Bitcoin.IntegrationTests.Common.csproj
@@ -13,7 +13,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.7</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Product />
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Networks/Stratis.Bitcoin.Networks.csproj
+++ b/src/Stratis.Bitcoin.Networks/Stratis.Bitcoin.Networks.csproj
@@ -16,7 +16,7 @@
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <AssemblyVersion>1.0.7.0</AssemblyVersion>
     <FileVersion>1.0.7.0</FileVersion>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Tests.Common/Stratis.Bitcoin.Tests.Common.csproj
+++ b/src/Stratis.Bitcoin.Tests.Common/Stratis.Bitcoin.Tests.Common.csproj
@@ -13,7 +13,7 @@
 		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
 		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
 		<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-		<Version>1.0.7</Version>
+		<Version>1.0.7.2</Version>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
 
                 string projectFolder = Path.GetDirectoryName(project.AbsolutePath);
                 string targetName = $"{name.ToLower()}.{version}-nuget.symbols";
-                string targetFolder = Path.Combine(projectFolder, $"bin{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}");
+                string targetFolder = Path.Combine(projectFolder, "bin", "Release");
                 string targetPath = Path.Combine(targetFolder, targetName);
                 if (!Directory.Exists(targetPath))
                 {

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -129,12 +129,11 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
 
                         XmlDocument doc3 = projectFiles[includeFullPath];
                         string name3 = doc3.SelectSingleNode("Project/PropertyGroup/PackageId")?.InnerText;
-                        string version3 = doc3.SelectSingleNode("Project/PropertyGroup/Version")?.InnerText;
 
                         XmlNode depNode = doc2.SelectSingleNode($"//*[name()='dependency' and @id='{name3}']");
                         string cmpVersion = depNode.Attributes["version"].Value;
 
-                        if (cmpVersion != version3)
+                        if (cmpVersion != referencedVersions[includeFullPath])
                         {
                             versionsMatch = false;
                             break;
@@ -146,6 +145,7 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
                 }
 
                 modifiedPackages.Add(project.ProjectName);
+                referencedVersions[projectFolder] = "mismatch";
             }
 
             Assert.Empty(modifiedPackages);

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Xml;
+using Microsoft.Build.Construction;
+using Xunit;
+
+namespace Stratis.Bitcoin.Tests.PackagesAndVersions
+{
+    public class PackagesAndVersionsTests
+    {
+        [Fact]
+        public void EnsureVersionsBumpedWhenChangingPublishedPackages()
+        {
+            // 1) Read solution file and get all projects with package information.
+            // 2) Retrieve the package from NuGet if not retrieved already
+            // 3) Build the package from source if not built already.
+            // 4) If the assemblies DLLs are different (and same version) then this is an error.
+
+            var modifiedPackages = new List<string>();
+
+            string sourceFolder = AppDomain.CurrentDomain.BaseDirectory;
+            for (int i = 0; i < 5; i++)
+                sourceFolder = Directory.GetParent(sourceFolder).ToString();
+
+            string solutionFilePath = Directory.EnumerateFiles(sourceFolder, "*.sln").First();
+            SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
+            HashSet<string> extra = new HashSet<string>() { "NBitcoin", "FodyNlogAdapter" };
+
+            foreach (ProjectInSolution project in solutionFile.ProjectsByGuid.Values)
+            {
+                if (!project.ProjectName.StartsWith("Stratis.") && !extra.Contains(project.ProjectName))
+                    continue;
+
+                // Read project file.
+                XmlDocument doc = new XmlDocument();
+                doc.Load(project.AbsolutePath);
+                string name = doc.SelectSingleNode("Project/PropertyGroup/PackageId")?.InnerText;
+                if (name == null)
+                    continue;
+
+                string version = doc.SelectSingleNode("Project/PropertyGroup/Version")?.InnerText;
+                if (version == null)
+                    continue;
+
+                if (version.EndsWith(".0"))
+                    version = version.Substring(0, version.Length - 2);
+
+                string projectFolder = Path.GetDirectoryName(project.AbsolutePath);
+                string targetName = $"{name.ToLower()}.{version}-nuget.symbols";
+                string targetFolder = Path.Combine(projectFolder, $"bin{Path.DirectorySeparatorChar}Release{Path.DirectorySeparatorChar}");
+                string targetPath = Path.Combine(targetFolder, targetName);
+                if (!Directory.Exists(targetPath))
+                {
+                    string targetFile = Path.Combine(projectFolder, $"{targetPath}.nupkg");
+                    if (!File.Exists(targetFile))
+                    {
+                        string url = $"https://www.nuget.org/api/v2/package/{name}/{version}";
+                        // Only if its on NuGet too.
+                        using (var client = new WebClient())
+                        {
+                            try
+                            {
+                                client.DownloadFile(url, targetFile);
+                            }
+                            catch (Exception)
+                            {
+                                if (File.Exists(targetFile))
+                                    File.Delete(targetFile);
+
+                                continue;
+                            }
+                        }
+                    }
+
+                    ZipFile.ExtractToDirectory(targetFile, targetPath);
+                }
+
+                // Compare source with files from NuGet.
+                string packageSource = Path.Combine(targetPath, "src", project.ProjectName);
+                if (Directory.Exists(packageSource) && DirectoryEquals(packageSource, projectFolder))
+                    continue;
+
+                modifiedPackages.Add(project.ProjectName);
+            }
+
+            Assert.Empty(modifiedPackages);
+        }
+
+        static bool DirectoryEquals(string directory1, string directory2)
+        {
+            foreach (string fileName1 in Directory.EnumerateFiles(directory1))
+            {
+                string fileName2 = Path.Combine(directory2, Path.GetFileName(fileName1));
+                if (!FileEquals(fileName1, fileName2))
+                    return false;
+            }
+
+            foreach (string subFolder in Directory.EnumerateDirectories(directory1))
+            {
+                string directoryName = Path.GetFileName(subFolder);
+                if (!DirectoryEquals(subFolder, Path.Combine(directory2, directoryName)))
+                    return false;
+            }
+
+            return true;
+        }
+
+        static bool FileEquals(string fileName1, string fileName2)
+        {
+            try
+            {
+                IEnumerable<string> source = File.ReadLines(fileName2);
+
+                foreach (string line in File.ReadLines(fileName1))
+                {
+                    if (source.Take(1).FirstOrDefault() != line)
+                        return false;
+
+                    source = source.Skip(1);
+                    continue;
+                }
+
+                return source.Take(1).FirstOrDefault() == null;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -17,8 +17,7 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
         {
             // 1) Read solution file and get all projects with package information.
             // 2) Retrieve the package from NuGet if not retrieved already
-            // 3) Build the package from source if not built already.
-            // 4) If the assemblies DLLs are different (and same version) then this is an error.
+            // 3) If the source code is different and same version then this is an error.
 
             var modifiedPackages = new List<string>();
 

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -29,14 +29,23 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
             SolutionFile solutionFile = SolutionFile.Parse(solutionFilePath);
             HashSet<string> extra = new HashSet<string>() { "NBitcoin", "FodyNlogAdapter" };
 
-            foreach (ProjectInSolution project in solutionFile.ProjectsByGuid.Values)
+            var projectsByPath = solutionFile.ProjectsByGuid
+                .Where(p => p.Value.ProjectName.StartsWith("Stratis.") || extra.Contains(p.Value.ProjectName))
+                .ToDictionary(p => p.Value.AbsolutePath, p => p.Value);
+            var projectFiles = projectsByPath.ToDictionary(p => p.Key, p => { XmlDocument doc = new XmlDocument(); doc.Load(p.Key); return doc; });
+            var referencedVersions = projectFiles.ToDictionary(p => p.Key, p => p.Value.SelectSingleNode("Project/PropertyGroup/Version")?.InnerText);
+            var projectsToCheck = new List<string>(projectsByPath.Keys);
+
+            while (projectsToCheck.Count > 0)
             {
-                if (!project.ProjectName.StartsWith("Stratis.") && !extra.Contains(project.ProjectName))
-                    continue;
+                string projectFolder = projectsToCheck.First();
+                projectsToCheck.RemoveAt(0);
+
+                ProjectInSolution project = projectsByPath[projectFolder];
 
                 // Read project file.
-                XmlDocument doc = new XmlDocument();
-                doc.Load(project.AbsolutePath);
+                XmlDocument doc = projectFiles[projectFolder];
+
                 string name = doc.SelectSingleNode("Project/PropertyGroup/PackageId")?.InnerText;
                 if (name == null)
                     continue;
@@ -48,13 +57,34 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
                 if (version.EndsWith(".0"))
                     version = version.Substring(0, version.Length - 2);
 
-                string projectFolder = Path.GetDirectoryName(project.AbsolutePath);
+                // Check the referenced projects first.
+                var references = new List<string>();
+                foreach (XmlNode x in doc.SelectNodes("/Project/ItemGroup/ProjectReference"))
+                {
+                    string includePath = x.Attributes["Include"].Value;
+                    string referencedProject = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectFolder), includePath));
+
+                    if (projectsToCheck.Contains(referencedProject))
+                    {
+                        references.Add(referencedProject);
+                        projectsToCheck.Remove(referencedProject);
+                    }
+                }
+
+                if (references.Count > 0)
+                {
+                    projectsToCheck.InsertRange(0, references);
+                    projectsToCheck.Add(projectFolder);
+                    continue;
+                }
+
                 string targetName = $"{name.ToLower()}.{version}-nuget.symbols";
-                string targetFolder = Path.Combine(projectFolder, "bin", "Release");
+                string targetFolder = Path.Combine(Path.GetDirectoryName(projectFolder), "bin", "Release");
                 string targetPath = Path.Combine(targetFolder, targetName);
                 if (!Directory.Exists(targetPath))
                 {
-                    Directory.CreateDirectory(targetFolder);
+                    if (!Directory.Exists(targetFolder))
+                        Directory.CreateDirectory(targetFolder);
 
                     string targetFile = Path.Combine(projectFolder, $"{targetPath}.nupkg");
                     if (!File.Exists(targetFile))
@@ -82,10 +112,9 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
 
                 // Compare source with files from NuGet.
                 string packageSource = Path.Combine(targetPath, "src", project.ProjectName);
-                if (Directory.Exists(packageSource) && DirectoryEquals(packageSource, projectFolder))
+                if (Directory.Exists(packageSource) && DirectoryEquals(packageSource, Path.GetDirectoryName(projectFolder)))
                 {
-                    // Even though the project file may be unchanged the references could be referring
-                    // to different versions.
+                    // Even though the project file may be unchanged the references could be referring to different versions.
 
                     // Load the NUSPEC file from the package.
                     string nuspecFile = Path.Combine(targetPath, $"{name}.nuspec");
@@ -96,9 +125,9 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
                     foreach (XmlNode x in doc.SelectNodes("/Project/ItemGroup/ProjectReference"))
                     {
                         string includePath = x.Attributes["Include"].Value;
+                        string includeFullPath = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(projectFolder), includePath));
 
-                        XmlDocument doc3 = new XmlDocument();
-                        doc3.Load(Path.Combine(projectFolder, includePath));
+                        XmlDocument doc3 = projectFiles[includeFullPath];
                         string name3 = doc3.SelectSingleNode("Project/PropertyGroup/PackageId")?.InnerText;
                         string version3 = doc3.SelectSingleNode("Project/PropertyGroup/Version")?.InnerText;
 

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -54,6 +54,8 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
                 string targetPath = Path.Combine(targetFolder, targetName);
                 if (!Directory.Exists(targetPath))
                 {
+                    Directory.CreateDirectory(targetFolder);
+
                     string targetFile = Path.Combine(projectFolder, $"{targetPath}.nupkg");
                     if (!File.Exists(targetFile))
                     {

--- a/src/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests.csproj
+++ b/src/Stratis.Bitcoin.Tests/Stratis.Bitcoin.Tests.csproj
@@ -28,6 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="DBreeze" Version="1.89.0" />
+    <PackageReference Include="Microsoft.Build" Version="16.8.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <CodeAnalysisRuleSet>..\Stratis.ruleset</CodeAnalysisRuleSet>
     <Authors>Stratis Group Ltd.</Authors>

--- a/src/Stratis.Features.SQLiteWalletRepository/Stratis.Features.SQLiteWalletRepository.csproj
+++ b/src/Stratis.Features.SQLiteWalletRepository/Stratis.Features.SQLiteWalletRepository.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.0.7.0</Version>
+    <Version>1.0.7.2</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>


### PR DESCRIPTION
This test case compares the source of published NuGet packages against local source. 

If the source is different but the version is the same then the test fails.

This is going to make it easier to know if a module has changed and will require publishing by simply looking at the versions.