### PR TITLE
Use BlockTime rather than Time

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinition.cs
@@ -604,9 +604,9 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <summary>Update the block's header information.</summary>
         protected void UpdateBaseHeaders()
         {
+            this.block.Header.Nonce = 0;
             this.block.Header.HashPrevBlock = this.ChainTip.HashBlock;
             this.block.Header.UpdateTime(this.DateTimeProvider.GetTimeOffset(), this.Network, this.ChainTip);
-            this.block.Header.Nonce = 0;
         }
 
         /// <summary>Network specific logic specific as to how the block's header will be set.</summary>

--- a/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/TestPoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/TestPoAMiner.cs
@@ -59,8 +59,7 @@ namespace Stratis.Bitcoin.Features.PoA.IntegrationTests.Common
         {
             for (int i = 0; i < count; i++)
             {
-                this.timeProvider.AdjustedTimeOffset += TimeSpan.FromSeconds(
-                    this.slotsManager.GetRoundLengthSeconds(this.federationManager.GetFederationMembers().Count));
+                this.timeProvider.AdjustedTimeOffset += this.slotsManager.GetRoundLength(this.federationManager.GetFederationMembers().Count);
 
                 uint timeNow = (uint)this.timeProvider.GetAdjustedTimeAsUnixTimestamp();
 

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/HeaderTimeChecksPoARuleTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/Rules/HeaderTimeChecksPoARuleTests.cs
@@ -61,11 +61,11 @@ namespace Stratis.Bitcoin.Features.PoA.Tests.Rules
         public void EnsureTimestampIsNotTooNew()
         {
             long timestamp = new DateTimeProvider().GetUtcNow().ToUnixTimestamp() / this.consensusOptions.TargetSpacingSeconds * this.consensusOptions.TargetSpacingSeconds;
-            DateTimeOffset time = DateTimeOffset.FromUnixTimeSeconds(timestamp);
+            DateTime time = DateTimeOffset.FromUnixTimeSeconds(timestamp).DateTime;
 
             // Pretend we receive the next block right on its timestamp
             var provider = new Mock<IDateTimeProvider>();
-            provider.Setup(x => x.GetAdjustedTimeAsUnixTimestamp()).Returns(timestamp + this.consensusOptions.TargetSpacingSeconds);
+            provider.Setup(x => x.GetAdjustedTime()).Returns(time + TimeSpan.FromSeconds(this.consensusOptions.TargetSpacingSeconds));
 
             this.rulesEngine = new PoAConsensusRuleEngine(this.network, this.loggerFactory, provider.Object, this.ChainIndexer, new NodeDeployments(this.network, this.ChainIndexer),
                 this.consensusSettings, new Checkpoints(this.network, this.consensusSettings), new Mock<ICoinView>().Object, new ChainState(), new InvalidBlockHashStore(provider.Object),

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/HeaderTimeChecksPoARule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/HeaderTimeChecksPoARule.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using System;
+using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Consensus.Rules;
@@ -40,8 +41,8 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             }
 
             // Timestamp shouldn't be more than current time plus max future drift.
-            long maxValidTime = this.Parent.DateTimeProvider.GetAdjustedTimeAsUnixTimestamp() + MaxFutureDriftSeconds;
-            if (chainedHeader.Header.Time > maxValidTime)
+            DateTime maxValidTime = this.Parent.DateTimeProvider.GetAdjustedTime() + TimeSpan.FromSeconds(MaxFutureDriftSeconds);
+            if (chainedHeader.Header.BlockTime > maxValidTime)
             {
                 this.Logger.LogWarning("Peer presented header with timestamp that is too far in to the future. Header was ignored." +
                                        " If you see this message a lot consider checking if your computer's time is correct.");

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/HeaderTimeChecksPoARule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/HeaderTimeChecksPoARule.cs
@@ -33,7 +33,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             ChainedHeader chainedHeader = context.ValidationContext.ChainedHeaderToValidate;
 
             // Timestamp should be greater than timestamp of prev block.
-            if (chainedHeader.Header.Time <= chainedHeader.Previous.Header.Time)
+            if (chainedHeader.Header.BlockTime <= chainedHeader.Previous.Header.BlockTime)
             {
                 this.Logger.LogTrace("(-)[TIME_TOO_OLD]");
                 ConsensusErrors.TimeTooOld.Throw();
@@ -47,13 +47,6 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                                        " If you see this message a lot consider checking if your computer's time is correct.");
                 this.Logger.LogTrace("(-)[TIME_TOO_NEW]");
                 ConsensusErrors.TimeTooNew.Throw();
-            }
-
-            // Timestamp should be divisible by target spacing.
-            if (!this.slotsManager.IsValidTimestamp(chainedHeader.Header.Time))
-            {
-                this.Logger.LogTrace("(-)[INVALID_TIMESTAMP]");
-                PoAConsensusErrors.InvalidHeaderTimestamp.Throw();
             }
         }
     }

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             }
 
             // Look at the last round of blocks to find the previous time that the miner mined.
-            var roundTime = TimeSpan.FromSeconds(this.slotsManager.GetRoundLengthSeconds(federation.Count));
+            var roundTime = this.slotsManager.GetRoundLength(federation.Count);
             int blockCounter = 0;
 
             for (ChainedHeader prevHeader = chainedHeader.Previous; prevHeader.Previous != null; prevHeader = prevHeader.Previous)
@@ -89,10 +89,10 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
                 // Mining slots shift when the federation changes. 
                 // Only raise an error if the federation did not change.
-                if (TimeSpan.FromSeconds(this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader).Count)) != roundTime)
+                if (this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(prevHeader).Count) != roundTime)
                     break;
 
-                if (TimeSpan.FromSeconds(this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader.Previous).Count)) != roundTime)
+                if (this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(prevHeader.Previous).Count) != roundTime)
                     break;
 
                 this.Logger.LogDebug("Block {0} was mined by the same miner '{1}' as {2} blocks ({3})s ago and there was no federation change.", prevHeader.HashBlock, pubKey.ToHex(), blockCounter, header.Time - prevHeader.Header.Time);

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
@@ -72,14 +73,14 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             }
 
             // Look at the last round of blocks to find the previous time that the miner mined.
-            uint roundTime = this.slotsManager.GetRoundLengthSeconds(federation.Count);
+            var roundTime = TimeSpan.FromSeconds(this.slotsManager.GetRoundLengthSeconds(federation.Count));
             int blockCounter = 0;
 
             for (ChainedHeader prevHeader = chainedHeader.Previous; prevHeader.Previous != null; prevHeader = prevHeader.Previous)
             {
                 blockCounter += 1;
 
-                if ((header.Time - prevHeader.Header.Time) >= roundTime)
+                if ((header.BlockTime - prevHeader.Header.BlockTime) >= roundTime)
                     break;
 
                 // If the miner is found again within the same round then throw a consensus error.
@@ -88,10 +89,10 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
                 // Mining slots shift when the federation changes. 
                 // Only raise an error if the federation did not change.
-                if (this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader).Count) != roundTime)
+                if (TimeSpan.FromSeconds(this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader).Count)) != roundTime)
                     break;
 
-                if (this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader.Previous).Count) != roundTime)
+                if (TimeSpan.FromSeconds(this.slotsManager.GetRoundLengthSeconds(this.federationHistory.GetFederationForBlock(prevHeader.Previous).Count)) != roundTime)
                     break;
 
                 this.Logger.LogDebug("Block {0} was mined by the same miner '{1}' as {2} blocks ({3})s ago and there was no federation change.", prevHeader.HashBlock, pubKey.ToHex(), blockCounter, header.Time - prevHeader.Header.Time);

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -79,6 +79,9 @@ namespace Stratis.Bitcoin.Features.PoA
 
         private IFederationMember GetFederationMemberForBlockInternal(ChainedHeader chainedHeader, List<IFederationMember> federation)
         {
+            if (chainedHeader.Height == 0)
+                return federation.Last();
+
             // Try to provide the public key that signed the block.
             try
             {

--- a/src/Stratis.Bitcoin.Features.PoA/SlotsManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/SlotsManager.cs
@@ -20,7 +20,7 @@ namespace Stratis.Bitcoin.Features.PoA
         /// <summary>Determines whether timestamp is valid according to the network rules.</summary>
         bool IsValidTimestamp(uint headerUnixTimestamp);
 
-        uint GetRoundLengthSeconds(int? federationMembersCount = null);
+        TimeSpan GetRoundLength(int? federationMembersCount = null);
     }
 
     public class SlotsManager : ISlotsManager
@@ -51,7 +51,7 @@ namespace Stratis.Bitcoin.Features.PoA
             List<IFederationMember> federationMembers = this.federationManager.GetFederationMembers();
 
             // Round length in seconds.
-            uint roundTime = this.GetRoundLengthSeconds(federationMembers.Count);
+            uint roundTime = (uint)this.GetRoundLength(federationMembers.Count).TotalSeconds;
 
             // Index of a slot that current node can take in each round.
             uint slotIndex = (uint)federationMembers.FindIndex(x => x.PubKey == this.federationManager.CurrentFederationKey.PubKey);
@@ -79,13 +79,13 @@ namespace Stratis.Bitcoin.Features.PoA
             return (headerUnixTimestamp % this.consensusOptions.TargetSpacingSeconds) == 0;
         }
 
-        public uint GetRoundLengthSeconds(int? federationMembersCount = null)
+        public TimeSpan GetRoundLength(int? federationMembersCount)
         {
             federationMembersCount = federationMembersCount ?? this.federationManager.GetFederationMembers().Count;
 
             uint roundLength = (uint)(federationMembersCount * this.consensusOptions.TargetSpacingSeconds);
 
-            return roundLength;
+            return TimeSpan.FromSeconds(roundLength);
         }
     }
 }


### PR DESCRIPTION
Moving to faster block times may mean that `BlockTime` could include fractional seconds in the future. 

Since using `BlockTime` versus `Time` is still logically equivalent we may as well already be using `BlockTime` instead..

So why this PR? The purpose is to make the future PoA v2 PR smaller by addressing trivial (non-logic-changing) updates separately.

There will be future PRs involving mining timestamp (and the use of `BlockTime` instead of `Time`) such as an updated https://github.com/stratisproject/StratisFullNode/pull/310.