### PR TITLE
[Multisig] Pass the calculated fee to the builder

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -1066,7 +1066,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 {
                     TransactionBuilder builder = new TransactionBuilder(this.Wallet.Network).AddCoins(coins);
 
-                    if (builder.Verify(transaction, out TransactionPolicyError[] errors))
+                    if (builder.Verify(transaction, transaction.GetFee(coins.ToArray()), out TransactionPolicyError[] errors))
                         return ValidateTransactionResult.Valid();
 
                     var errorList = new List<string>();


### PR DESCRIPTION
We have a fee issue again whereby partial transaction is getting passed to the mempool cause of the fee. This happens when we try and verify the fee once the partial tx is fully signed but dont pass the actual fee to the verify method.