### PR TITLE
Reduce RegTest miner confirmation window

### DIFF
--- a/src/NBitcoin.Tests/NetworkTests.cs
+++ b/src/NBitcoin.Tests/NetworkTests.cs
@@ -522,7 +522,7 @@ namespace NBitcoin.Tests
             Assert.Equal(TimeSpan.FromSeconds(45), network.Consensus.TargetSpacing);
             Assert.True(network.Consensus.PowAllowMinDifficultyBlocks);
             Assert.True(network.Consensus.PowNoRetargeting);
-            Assert.Equal(2016, network.Consensus.MinerConfirmationWindow);
+            Assert.Equal(144, network.Consensus.MinerConfirmationWindow);
             Assert.Equal(12500, network.Consensus.LastPOWBlock);
             Assert.True(network.Consensus.IsProofOfStake);
             Assert.Equal(1, network.Consensus.CoinType);

--- a/src/Stratis.Bitcoin.Networks/StraxRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StraxRegTest.cs
@@ -112,7 +112,7 @@ namespace Stratis.Bitcoin.Networks
                 buriedDeployments: buriedDeployments,
                 bip9Deployments: bip9Deployments,
                 bip34Hash: null,
-                minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing
+                minerConfirmationWindow: 144, // nPowTargetTimespan / nPowTargetSpacing
                 maxReorgLength: 500,
                 defaultAssumeValid: null, // turn off assumevalid for regtest.
                 maxMoney: long.MaxValue,


### PR DESCRIPTION
The aim of this PR is to reduce the time to it takes to test BIP9 activations by reducing the size of the miner confirmation window from 2016 to 144.

This PR is being split off from PR #450 to reduce the size of that PR.