### PR TITLE
Add methods for bloom filter compression

### DIFF
--- a/src/NBitcoin.Tests/bloom_tests.cs
+++ b/src/NBitcoin.Tests/bloom_tests.cs
@@ -397,5 +397,28 @@ namespace NBitcoin.Tests
             Assert.True(!filter.Contains(new OutPoint(uint256.Parse("0x147caa76786596590baa4e98f5d9f48b86c7765e489f7a6ff3360fe5c674360b"), 0)));
             Assert.True(!filter.Contains((new OutPoint(uint256.Parse("0x02981fa052f0481dbc5868f4fc2166035a10f27a03cfd2de67326471df5bc041"), 0))));
         }
+
+        [Fact]
+        [Trait("Core", "Core")]
+        public void CanCompressAndDecompressBloomFilters()
+        {
+            Random r = new Random(0);
+            for (int i = 0; i < 10000; i++)
+            {
+                var bloom = new Bloom();
+                int repeats = 1 << r.Next(10);
+                for (int j = 0; j < repeats; j++)
+                {
+                    var bytes = new byte[2 + r.Next(10)];
+                    r.NextBytes(bytes);
+                    bloom.Add(bytes);
+                }
+
+                byte[] compressed = bloom.GetCompressedBloom();
+                Bloom bloomRecovered = Bloom.GetDecompressedBloom(compressed);
+
+                Assert.Equal(bloom.ToBytes(), bloomRecovered.ToBytes());
+            }
+        }
     }
 }

--- a/src/NBitcoin/NBitcoin.csproj
+++ b/src/NBitcoin/NBitcoin.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <Version>4.0.0.80</Version>
+    <Version>4.0.0.81</Version>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
The purpose of this PR is to reduce the serialized size of the bloom filter used by the `PosBlockHeader`. Since the bloom filter is basically a bit map of 2048 bits contained in 256 bytes it is quite possible that many of those bytes may be `0`. This compression scheme reduces the number of `0` bytes by storing the number of `0` bytes instead of the bytes themselves. As an example 256 `0` bytes would be encoded as `1 255 0`  - where 1 is the total compressed length - 1, followed by 255 zeros and finally one more zero. The general pattern is `<compressed length - 1> [<number of zeros> <explicit byte>] x n where n > 0`. The last explicit byte is added only if required. If the compressed length exceeds 255 then the bloom filter is not compressed when serialized, which is flagged by `255` in the first byte. A `0` in the first byte is not possible and is reserved for future use.

This is a backwards compatible change required by system contract and does not affect legacy bloom filters.

This PR is being split off from PR #450 to reduce the size of that PR.