### PR TITLE
Add ability to include signatures with ContractTxData

### DIFF
--- a/src/Stratis.CirrusMinerD/Properties/launchSettings.json
+++ b/src/Stratis.CirrusMinerD/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Stratis.CirrusMinerD": {
+      "commandName": "Project",
+      "commandLineArgs": "-sidechain"
+    }
+  }
+}

--- a/src/Stratis.CirrusMinerD/Properties/launchSettings.json
+++ b/src/Stratis.CirrusMinerD/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "Stratis.CirrusMinerD": {
-      "commandName": "Project",
-      "commandLineArgs": "-sidechain"
-    }
-  }
-}

--- a/src/Stratis.SmartContracts.CLR.Tests/CallDataSerializerTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/CallDataSerializerTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text;
 using Stratis.SmartContracts.CLR.Serialization;
 using Stratis.SmartContracts.Core;
@@ -29,7 +30,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 }"
             );
 
-            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, contractExecutionCode);
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, contractExecutionCode, signatures: new[] { Convert.ToBase64String(new byte[] { 1, 2, 3 }), Convert.ToBase64String(new byte[] { 7, 8, 9 }) });
             var callDataResult = this.Serializer.Deserialize(this.Serializer.Serialize(contractTxData));
             var callData = callDataResult.Value;
 
@@ -39,6 +40,8 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.Equal<byte[]>(contractExecutionCode, callData.ContractExecutionCode);
             Assert.Equal((RuntimeObserver.Gas)1, callData.GasPrice);
             Assert.Equal((RuntimeObserver.Gas)5000, callData.GasLimit);
+            Assert.Equal(new byte[] { 1, 2, 3 }, Convert.FromBase64String(callData.Signatures[0]));
+            Assert.Equal(new byte[] { 7, 8, 9 }, Convert.FromBase64String(callData.Signatures[1]));
         }
 
         [Fact]

--- a/src/Stratis.SmartContracts.CLR/CallDataSerializer.cs
+++ b/src/Stratis.SmartContracts.CLR/CallDataSerializer.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using CSharpFunctionalExtensions;
 using NBitcoin;
 using Nethereum.RLP;
+using Stratis.Bitcoin.Utilities;
 using Stratis.SmartContracts.CLR.Serialization;
 using Stratis.SmartContracts.Core;
 using TracerAttributes;
@@ -166,16 +167,16 @@ namespace Stratis.SmartContracts.CLR
             }
         }
 
+        /// <summary>
+        /// Adds the passed signatures to the passed list of byte arrays.
+        /// </summary>
+        /// <param name="rlpBytes">The list of byte arrays to add the signatures to.</param>
+        /// <param name="signatures">The signatures as a base 64 encoded byte array. See <see cref="SerializeSignatures(string[])"/></param>
         protected void AddSignatures(List<byte[]> rlpBytes, string[] signatures)
         {
-            if (signatures != null && signatures.Any())
-            {
-                rlpBytes.Add(this.SerializeSignatures(signatures));
-            }
-            else if (signatures != null)
-            {
-                rlpBytes.Add(new byte[0]);
-            }
+            Guard.NotNull(signatures, nameof(signatures));
+
+            rlpBytes.Add(this.SerializeSignatures(signatures));
         }
 
         protected static bool IsCallContract(byte type)
@@ -198,6 +199,11 @@ namespace Stratis.SmartContracts.CLR
             return methodParameters;
         }
 
+        /// <summary>
+        /// Serializes the signatures.
+        /// </summary>
+        /// <param name="signatures">Signatures passed as an array of base 64 encoded byte arrays.</param>
+        /// <returns>A byte array containing the decoded signatures, where each signature is prefixed by its length.</returns>
         protected byte[] SerializeSignatures(string[] signatures)
         {
             byte[][] signaturesRaw = new byte[signatures.Length][];
@@ -220,6 +226,11 @@ namespace Stratis.SmartContracts.CLR
             return res;
         }
 
+        /// <summary>
+        /// Deserializes signatures.
+        /// </summary>
+        /// <param name="signaturesRaw">A byte array containing the decoded signatures, where each signature is prefixed by its length.</param>
+        /// <returns>Signatures as an array of base 64 encoded byte arrays.</returns>
         protected string[] DeserializeSignatures(byte[] signaturesRaw)
         {
             if (signaturesRaw == null || signaturesRaw.Length == 0)

--- a/src/Stratis.SmartContracts.CLR/ContractTxData.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractTxData.cs
@@ -29,7 +29,7 @@ namespace Stratis.SmartContracts.CLR
         /// Creates a ContractTxData for contract creation
         /// </summary>
         public ContractTxData(int vmVersion, ulong gasPrice, RuntimeObserver.Gas gasLimit, byte[] code,
-            object[] methodParameters = null, byte[][] signatures = null)
+            object[] methodParameters = null, string[] signatures = null)
         {
             this.OpCodeType = (byte)ScOpcodeType.OP_CREATECONTRACT;
             this.VmVersion = vmVersion;
@@ -67,7 +67,7 @@ namespace Stratis.SmartContracts.CLR
         public byte[] ContractExecutionCode { get; }
 
         /// <summary>The signatures (if any).</summary>
-        public byte[][] Signatures { get; }
+        public string[] Signatures { get; }
 
         /// <summary>The maximum cost (in satoshi) the contract can spend.</summary>
         public ulong GasCostBudget

--- a/src/Stratis.SmartContracts.CLR/ContractTxData.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractTxData.cs
@@ -22,13 +22,14 @@ namespace Stratis.SmartContracts.CLR
             this.MethodName = method;
             this.MethodParameters = methodParameters;
             this.ContractExecutionCode = new byte[0];
+            this.Signatures = null;
         }
 
         /// <summary>
         /// Creates a ContractTxData for contract creation
         /// </summary>
         public ContractTxData(int vmVersion, ulong gasPrice, RuntimeObserver.Gas gasLimit, byte[] code,
-            object[] methodParameters = null)
+            object[] methodParameters = null, byte[][] signatures = null)
         {
             this.OpCodeType = (byte)ScOpcodeType.OP_CREATECONTRACT;
             this.VmVersion = vmVersion;
@@ -38,6 +39,7 @@ namespace Stratis.SmartContracts.CLR
             this.MethodName = "";
             this.MethodParameters = methodParameters;
             this.ContractAddress = uint160.Zero;
+            this.Signatures = signatures;
         }
 
         /// <summary>The method name of the contract that will be executed.</summary>
@@ -63,6 +65,9 @@ namespace Stratis.SmartContracts.CLR
 
         /// <summary>The contract code that will be executed.</summary>
         public byte[] ContractExecutionCode { get; }
+
+        /// <summary>The signatures (if any).</summary>
+        public byte[][] Signatures { get; }
 
         /// <summary>The maximum cost (in satoshi) the contract can spend.</summary>
         public ulong GasCostBudget

--- a/src/Stratis.SmartContracts.CLR/ContractTxData.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractTxData.cs
@@ -66,7 +66,7 @@ namespace Stratis.SmartContracts.CLR
         /// <summary>The contract code that will be executed.</summary>
         public byte[] ContractExecutionCode { get; }
 
-        /// <summary>The signatures (if any).</summary>
+        /// <summary>The signatures (if any) passed as an array of base 64 encoded byte arrays - as returned by <see cref="Key.SignMessage"/>.</summary>
         public string[] Signatures { get; }
 
         /// <summary>The maximum cost (in satoshi) the contract can spend.</summary>


### PR DESCRIPTION
This change makes it possible to include signatures into the transaction that creates a SC. This will allow us to write a rule to confirm that system contracts have been signed by the required signatories before being adopted by the nodes. 

See https://app.clickup.com/t/34wnfe.

This is a backwards compatible change required by system contracts.