### PR TITLE
Include signatures with ContractTxData for calls

### DIFF
--- a/src/Stratis.SmartContracts.CLR/CallDataSerializer.cs
+++ b/src/Stratis.SmartContracts.CLR/CallDataSerializer.cs
@@ -82,7 +82,9 @@ namespace Stratis.SmartContracts.CLR
 
             string methodName = this.primitiveSerializer.Deserialize<string>(decodedParams[0]);
             object[] methodParameters = this.DeserializeMethodParameters(decodedParams[1]);
-            var callData = new ContractTxData(vmVersion, gasPrice, gasLimit, contractAddress, methodName, methodParameters);
+            string[] signatures = (decodedParams.Count > 2) ? this.DeserializeSignatures(decodedParams[2]) : null;
+
+            var callData = new ContractTxData(vmVersion, gasPrice, gasLimit, contractAddress, methodName, methodParameters, signatures);
             return Result.Ok(callData);
         }
 
@@ -130,6 +132,8 @@ namespace Stratis.SmartContracts.CLR
             rlpBytes.Add(this.primitiveSerializer.Serialize(contractTxData.MethodName));
 
             this.AddMethodParams(rlpBytes, contractTxData.MethodParameters);
+            if (contractTxData.Signatures != null)
+                this.AddSignatures(rlpBytes, contractTxData.Signatures);
 
             byte[] encoded = RLP.EncodeList(rlpBytes.Select(RLP.EncodeElement).ToArray());
             

--- a/src/Stratis.SmartContracts.CLR/ContractTxData.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractTxData.cs
@@ -12,7 +12,7 @@ namespace Stratis.SmartContracts.CLR
         /// Creates a ContractTxData object for a method invocation
         /// </summary>
         public ContractTxData(int vmVersion, ulong gasPrice, RuntimeObserver.Gas gasLimit, uint160 contractAddress,
-            string method, object[] methodParameters = null)
+            string method, object[] methodParameters = null, string[] signatures = null)
         {
             this.OpCodeType = (byte) ScOpcodeType.OP_CALLCONTRACT;
             this.VmVersion = vmVersion;
@@ -22,7 +22,7 @@ namespace Stratis.SmartContracts.CLR
             this.MethodName = method;
             this.MethodParameters = methodParameters;
             this.ContractExecutionCode = new byte[0];
-            this.Signatures = null;
+            this.Signatures = signatures;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR is similar to #462 but deals with contract calls.

There is currently no way to "upgrade" contracts transparently. I.e. once e.g. a multisig-membership contract is deployed there is no easy way to fix it if problems or additional requirements are identified. I am thinking we may need something like a "system contract dictionary" system contract that allows internal processes to look up the latest contract addresses of contracts that provide specific functionality. This will make "transparent upgrades" possible and also allow contracts to be black-listed.

**Of course, changing the dictionary would require multiple signatures, similar/same to the signatures required to create system contracts.**