### PR TITLE
Fix Locking Issues in DevMode

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -422,6 +422,7 @@ namespace Stratis.Bitcoin.Features.PoA
             int pubKeyTakeCharacters = 5;
             int hitCount = 0;
 
+            // If the node is in DevMode just use the genesis members via the federation manager.
             List<IFederationMember> modifiedFederation;
             if (this.nodeSettings.DevMode)
                 modifiedFederation = this.federationManager.GetFederationMembers();

--- a/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAMiner.cs
@@ -422,7 +422,11 @@ namespace Stratis.Bitcoin.Features.PoA
             int pubKeyTakeCharacters = 5;
             int hitCount = 0;
 
-            List<IFederationMember> modifiedFederation = this.votingManager?.GetModifiedFederation(currentHeader) ?? this.federationManager.GetFederationMembers();
+            List<IFederationMember> modifiedFederation;
+            if (this.nodeSettings.DevMode)
+                modifiedFederation = this.federationManager.GetFederationMembers();
+            else
+                modifiedFederation = this.votingManager?.GetModifiedFederation(currentHeader) ?? this.federationManager.GetFederationMembers();
 
             int maxDepth = modifiedFederation.Count;
 
@@ -451,7 +455,10 @@ namespace Stratis.Bitcoin.Features.PoA
                     currentHeader = currentHeader.Previous;
                     hitCount++;
 
-                    modifiedFederation = this.votingManager?.GetModifiedFederation(currentHeader) ?? this.federationManager.GetFederationMembers();
+                    if (this.nodeSettings.DevMode)
+                        modifiedFederation = this.federationManager.GetFederationMembers();
+                    else
+                        modifiedFederation = this.votingManager?.GetModifiedFederation(currentHeader) ?? this.federationManager.GetFederationMembers();
                 }
                 else
                 {

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -647,14 +647,16 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         {
             log.AppendLine(">> Voting & Poll Data");
 
-            lock (this.locker)
-            {
-                log.AppendLine("Member Polls".PadRight(LoggingConfiguration.ColumnLength) + $": Pending: {GetPendingPolls().MemberPolls().Count} Approved: {GetApprovedPolls().MemberPolls().Count} Executed : {GetExecutedPolls().MemberPolls().Count}");
-                log.AppendLine("Whitelist Polls".PadRight(LoggingConfiguration.ColumnLength) + $": Pending: {GetPendingPolls().WhitelistPolls().Count} Approved: {GetApprovedPolls().WhitelistPolls().Count} Executed : {GetExecutedPolls().WhitelistPolls().Count}");
-                log.AppendLine("Scheduled Votes".PadRight(LoggingConfiguration.ColumnLength) + ": " + this.scheduledVotingData.Count);
-                log.AppendLine("Scheduled votes will be added to the next block this node mines.");
-                log.AppendLine();
-            }
+            // Use the polls list directly as opposed to the locked versions of them for console reporting.
+            List<Poll> pendingPolls = this.polls.Where(x => x.IsPending).ToList();
+            List<Poll> approvedPolls = this.polls.Where(x => !x.IsPending).ToList();
+            List<Poll> executedPolls = this.polls.Where(x => x.IsExecuted).ToList();
+
+            log.AppendLine("Member Polls".PadRight(LoggingConfiguration.ColumnLength) + $": Pending: {pendingPolls.MemberPolls().Count} Approved: {approvedPolls.MemberPolls().Count} Executed : {executedPolls.MemberPolls().Count}");
+            log.AppendLine("Whitelist Polls".PadRight(LoggingConfiguration.ColumnLength) + $": Pending: {pendingPolls.WhitelistPolls().Count} Approved: {approvedPolls.WhitelistPolls().Count} Executed : {executedPolls.WhitelistPolls().Count}");
+            log.AppendLine("Scheduled Votes".PadRight(LoggingConfiguration.ColumnLength) + ": " + this.scheduledVotingData.Count);
+            log.AppendLine("Scheduled votes will be added to the next block this node mines.");
+            log.AppendLine();
         }
 
         [NoTrace]

--- a/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
+++ b/src/Stratis.Bitcoin/Connection/ConnectionManager.cs
@@ -316,7 +316,6 @@ namespace Stratis.Bitcoin.Connection
 
             int inbound = this.ConnectedPeers.Count(x => x.Inbound);
 
-            builder.AppendLine();
             builder.AppendLine($">> Connections (In:{inbound}) (Out:{this.ConnectedPeers.Count() - inbound})");
             builder.AppendLine("Data Transfer".PadRight(LoggingConfiguration.ColumnLength, ' ') + $": Received: {totalRead.BytesToMegaBytes()} MB Sent: {totalWritten.BytesToMegaBytes()} MB");
 


### PR DESCRIPTION
When the node is in `devmode` we don't need to getthe modified federation for component stats as there will only ever be one node mining (in the federation).