### PR TITLE
Make AllowedCodeHashLogic rule reusable and pass block height

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts/Interfaces/IContractTransactionValidationRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Interfaces/IContractTransactionValidationRule.cs
@@ -18,6 +18,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
         /// </summary>
         /// <param name="txData">The included transaction data.</param>
         /// <param name="suppliedBudget">The total amount sent as the protocol fee.</param>
-        void CheckContractTransaction(ContractTxData txData, Money suppliedBudget);
+        /// <param name="blockHeight">The block height (as permissions change with block height).</param>
+        void CheckContractTransaction(ContractTxData txData, Money suppliedBudget, int blockHeight = 0);
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/AllowedCodeHashLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/AllowedCodeHashLogic.cs
@@ -20,7 +20,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA.Rules
             this.hashingStrategy = hashingStrategy;
         }
 
-        public void CheckContractTransaction(ContractTxData txData, Money suppliedBudget)
+        public void CheckContractTransaction(ContractTxData txData, Money suppliedBudget, int blockHeight = 0)
         {
             if (!txData.IsCreateContract)
                 return;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/ReflectionExecutor/Consensus/Rules/SmartContractFormatLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/ReflectionExecutor/Consensus/Rules/SmartContractFormatLogic.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.ReflectionExecutor.Consensus.R
 
         public const ulong GasPriceMaximum = 10_000;
 
-        public void CheckContractTransaction(ContractTxData txData, Money suppliedBudget)
+        public void CheckContractTransaction(ContractTxData txData, Money suppliedBudget, int blockHeight = 0)
         {
             Check(txData, suppliedBudget);
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/ContractTransactionChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/ContractTransactionChecker.cs
@@ -32,7 +32,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
 
             foreach (Transaction transaction in block.Transactions)
             {
-                this.CheckTransaction(transaction, contractTransactionValidationRules, context.ValidationContext.ChainedHeaderToValidate.Height);
+                this.CheckTransaction(transaction, contractTransactionValidationRules, context.ValidationContext.ChainedHeaderToValidate?.Height ?? 0);
             }
 
             return Task.CompletedTask;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/ContractTransactionChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/ContractTransactionChecker.cs
@@ -32,7 +32,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
 
             foreach (Transaction transaction in block.Transactions)
             {
-                this.CheckTransaction(transaction, contractTransactionValidationRules);
+                this.CheckTransaction(transaction, contractTransactionValidationRules, context.ValidationContext.ChainedHeaderToValidate.Height);
             }
 
             return Task.CompletedTask;
@@ -52,7 +52,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
             return txData;
         }
 
-        private void CheckTransaction(Transaction transaction, IEnumerable<IContractTransactionValidationRule> rules)
+        private void CheckTransaction(Transaction transaction, IEnumerable<IContractTransactionValidationRule> rules, int blockHeight)
         {
             TxOut scTxOut = transaction.TryGetSmartContractTxOut();
 
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
 
             foreach (IContractTransactionValidationRule rule in rules)
             {
-                rule.CheckContractTransaction(txData, null);
+                rule.CheckContractTransaction(txData, null, blockHeight);
             }
         }
     }

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -12,7 +12,6 @@ using Stratis.Bitcoin.Features.PoA.Policies;
 using Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules;
 using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
-using Stratis.Bitcoin.Features.SmartContracts.PoA.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
 

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -12,7 +12,6 @@ using Stratis.Bitcoin.Features.PoA.Policies;
 using Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules;
 using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
-using Stratis.Bitcoin.Features.SmartContracts.PoA.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
 

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -12,7 +12,6 @@ using Stratis.Bitcoin.Features.PoA.Policies;
 using Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules;
 using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
-using Stratis.Bitcoin.Features.SmartContracts.PoA.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
 

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -11,7 +11,6 @@ using Stratis.Bitcoin.Features.PoA.Policies;
 using Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules;
 using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
-using Stratis.Bitcoin.Features.SmartContracts.PoA.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
 

--- a/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
@@ -11,7 +11,6 @@ using Stratis.Bitcoin.Features.PoA.Policies;
 using Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules;
 using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
-using Stratis.Bitcoin.Features.SmartContracts.PoA.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
 

--- a/src/Stratis.SmartContracts.Networks/SmartContractsPoAWhitelistRegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsPoAWhitelistRegTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using NBitcoin;
 using Stratis.Bitcoin.Features.MemoryPool.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
-using Stratis.Bitcoin.Features.SmartContracts.PoA.MempoolRules;
 
 namespace Stratis.SmartContracts.Networks
 {

--- a/src/Stratis.SmartContracts.Networks/SmartContractsRegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsRegTest.cs
@@ -8,7 +8,6 @@ using Stratis.Bitcoin.Features.MemoryPool.Rules;
 using Stratis.Bitcoin.Features.PoA.Policies;
 using Stratis.Bitcoin.Features.SmartContracts;
 using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
-using Stratis.Bitcoin.Features.SmartContracts.PoA.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoW;
 using Stratis.Bitcoin.Features.SmartContracts.PoW.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;

--- a/src/Stratis.SmartContracts.Tests.Common/MockChain/PoAMockChainFixture.cs
+++ b/src/Stratis.SmartContracts.Tests.Common/MockChain/PoAMockChainFixture.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using NBitcoin;
-using Stratis.Bitcoin.Features.SmartContracts.PoA.MempoolRules;
+using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.IntegrationTests.Common.EnvironmentMockUpHelpers;
 using Stratis.SmartContracts.Networks;
 


### PR DESCRIPTION
Contract permissions can vary with block height and as such we need to pass the block height to this rule. The PoA whitelist checker should probably be using this information too but that is out-of-scope for this PR.

This is a backwards compatible change required by system contracts.