### PR TITLE
Support null BIP9 parameters

### DIFF
--- a/src/NBitcoin/BIP9DeploymentsArray.cs
+++ b/src/NBitcoin/BIP9DeploymentsArray.cs
@@ -81,7 +81,7 @@
             name = name.ToLower();
 
             for (int deployment = 0; deployment < this.parameters.Length; deployment++)
-                if (this.parameters[deployment].Name == name)
+                if (this.parameters[deployment]?.Name == name)
                     return deployment;
 
             return -1;


### PR DESCRIPTION
Some tests may set these to `null`.