### PR TITLE
Fix WatchOnly transaction query performance

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletFeature.cs
@@ -100,6 +100,8 @@ namespace Stratis.Bitcoin.Features.Wallet
                 log.AppendLine("Wallet Height".PadRight(LoggingConfiguration.ColumnLength) + $": {this.walletManager.WalletTipHeight}".PadRight(10) + $"(Hash: {this.walletManager.WalletTipHash})");
             else
                 log.AppendLine("Wallet Height".PadRight(LoggingConfiguration.ColumnLength) + ": No Wallet");
+
+            log.AppendLine();
         }
 
         private void AddComponentStats(StringBuilder log)


### PR DESCRIPTION
The issue here was the fact we were still querying over the whole transaction set for WatchOnly accounts. 

If we specify a transaction Id in the query, the query should always pass the transaction id to the SQL query