### PR TITLE
[Infra] Enable ScriptDestinationReader override

### DIFF
--- a/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingFeature.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/ColdStakingFeature.cs
@@ -253,6 +253,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking
                     services.AddSingleton<IWalletService, ColdStakingWalletService>();
 
                     services.AddSingleton<ScriptAddressReader>();
+                    services.AddSingleton<ScriptDestinationReader, ColdStakingDestinationReader>();
                     services.Replace(new ServiceDescriptor(typeof(IScriptAddressReader), typeof(ColdStakingDestinationReader), ServiceLifetime.Singleton));
                 });
             });

--- a/src/Stratis.Bitcoin.Features.SmartContracts/SmartContractScriptAddressReader.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/SmartContractScriptAddressReader.cs
@@ -1,26 +1,58 @@
-﻿using CSharpFunctionalExtensions;
+﻿using System.Collections.Generic;
+using CSharpFunctionalExtensions;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Interfaces;
 using Stratis.SmartContracts.CLR;
-using Stratis.SmartContracts.Core;
 
 namespace Stratis.Bitcoin.Features.SmartContracts
 {
     /// <summary>
     /// Smart contract specific logic to get the contract address from the <see cref="ContractTxData"/>.
     /// </summary>
-    public sealed class SmartContractScriptAddressReader : IScriptAddressReader
+    public sealed class SmartContractScriptAddressReader : IScriptDestinationReader
     {
         private readonly IScriptAddressReader baseAddressReader;
         private readonly ICallDataSerializer callDataSerializer;
 
         public SmartContractScriptAddressReader(
-            ScriptAddressReader addressReader,
-            ICallDataSerializer callDataSerializer)
+            ICallDataSerializer callDataSerializer,
+            ScriptAddressReader scriptAddressReader,
+            ScriptDestinationReader scriptDestinationReader = null)
         {
-            this.baseAddressReader = addressReader;
+            this.baseAddressReader = scriptDestinationReader ?? (IScriptAddressReader)scriptAddressReader;
             this.callDataSerializer = callDataSerializer;
+        }
+
+        public IEnumerable<TxDestination> GetDestinationFromScriptPubKey(Network network, Script script)
+        {
+            if (script.IsSmartContractCreate() || script.IsSmartContractCall())
+            {
+                Result<ContractTxData> result = this.callDataSerializer.Deserialize(script.ToBytes());
+                if (result.Value.ContractAddress != null)
+                {
+                    string address = result.Value.ContractAddress.ToAddress().ToString();
+                    TxDestination destination = ScriptDestinationReader.GetDestinationForAddress(address, network);
+                    if (destination != null)
+                        yield return destination;
+                }
+            }
+            else
+            {
+                if (this.baseAddressReader is IScriptDestinationReader destinationReader)
+                {
+                    foreach (TxDestination destination in destinationReader.GetDestinationFromScriptPubKey(network, script))
+                        if (destination != null)
+                            yield return destination;
+                }
+                else
+                {
+                    TxDestination destination = ScriptDestinationReader.GetDestinationForAddress(this.baseAddressReader.GetAddressFromScriptPubKey(network, script), network);
+                    if (destination != null)
+                        yield return destination;
+                }
+            }
         }
 
         public string GetAddressFromScriptPubKey(Network network, Script script)

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/ScriptDestinationReader.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/ScriptDestinationReader.cs
@@ -11,7 +11,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         IEnumerable<TxDestination> GetDestinationFromScriptPubKey(Network network, Script script);
     }
 
-    public class ScriptDestinationReader : IScriptAddressReader
+    public abstract class ScriptDestinationReader : IScriptDestinationReader
     {
         private readonly IScriptAddressReader scriptAddressReader;
 

--- a/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/External/ITransactionsToLists.cs
@@ -58,7 +58,7 @@ namespace Stratis.Features.SQLiteWalletRepository.External
                             yield return new KeyId(txDestination.ToBytes());
                         break;
                     default:
-                        if (this.scriptAddressReader is ScriptDestinationReader scriptDestinationReader)
+                        if (this.scriptAddressReader is IScriptDestinationReader scriptDestinationReader)
                         {
                             foreach (TxDestination destination in scriptDestinationReader.GetDestinationFromScriptPubKey(this.network, redeemScript))
                             {


### PR DESCRIPTION
Currently the `SmartContractScriptAddressReader` is able to replace the `IScriptAddressReader` service.
However, once SmartContracts are used on networks that support **cold staking** the `SmartContractScriptAddressReader` should also be able to replace the `IScriptDestinationReader` service. This PR extends the `SmartContractScriptAddressReader` to achieve that.