### PR TITLE
Remove CirrusTest Checkpoints

### DIFF
--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -214,8 +214,7 @@ namespace Stratis.Sidechains.Networks
                 { 1600000, new CheckpointInfo(new uint256("0x696cd64ec08b67ed3a3ec1e3add77c0e8203d8d6c0bb7df96dd9508dda4ba67e")) },
                 { 1700000, new CheckpointInfo(new uint256("0xf42564107701d81e847e5dc6bd95da6bf32cb54e762d84118a7764349b414e68")) },
                 { 1800000, new CheckpointInfo(new uint256("0x57a3119de52cf43b66d6e805a644c20fdee63557038cd68c429d47b21d111084")) },
-                { 1950000, new CheckpointInfo(new uint256("0xf64b399a0c22cb0641c2aee63c60ced5bc65992ed08ddcec6f061e8bfb3b6b70")) },
-                { 2150000, new CheckpointInfo(new uint256("0x7bcb5e1df4b7ee287cc59a534183af263a8bd19ffe11f818c565af33008ed2aa")) }
+                { 1900000, new CheckpointInfo(new uint256("0xd413f3aed50f4a1a4580e7c506223a605e222849da9649ca6d43ad7aac5c5af5")) },
             };
 
             this.DNSSeeds = new List<DNSSeedData>


### PR DESCRIPTION
We are rewinding the CirrusTest network so we need to remove the latest checkpoints