### PR TITLE
[MultiSig] Ensure that input consolidation tx is always built.

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Events/WalletNeedsConsolidation.cs
+++ b/src/Stratis.Features.FederatedPeg/Events/WalletNeedsConsolidation.cs
@@ -6,7 +6,7 @@ namespace Stratis.Features.FederatedPeg.Events
     public class WalletNeedsConsolidation : EventBase
     {
         /// <summary>
-        /// The amount required for the next withdrawal transaction..
+        /// The amount required for the next withdrawal transaction.
         /// </summary>
         public Money Amount { get; }
 

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
@@ -60,7 +60,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
         {
             try
             {
-                this.logger.Debug("BuildDeterministicTransaction depositId(opReturnData)={0}; recipient.ScriptPubKey={1}; recipient.Amount={2}; height={3}", depositId, recipient.ScriptPubKey, recipient.Amount, blockHeight);
+                this.logger.Info("BuildDeterministicTransaction depositId(opReturnData)={0}; recipient.ScriptPubKey={1}; recipient.Amount={2}; height={3}", depositId, recipient.ScriptPubKey, recipient.Amount, blockHeight);
 
                 // Build the multisig transaction template.
                 uint256 opReturnData = depositId;


### PR DESCRIPTION
Currently, the multisig is going into a build input consolidation loop. This is the scenario:

1. An withdrawal tx is built that has more than 50 inputs
2. Input consolidation gets triggered
3. Input consolidation "fails" cause of the threshold amount being reached within the first loop already:

`if (oneRound.Sum(x => x.Transaction.Amount) >= amount + FederatedPegSettings.ConsolidationFee)`

4. A consolidation tx is never built due to the above.
5. The method exits and we go back to point 1.
6. The node is now stuck in a infinite loop of trying to build the consolidation tx.

The fix here is that we always need to build the consolidation tx first and THEN check the threshold amount.

