### PR TITLE
Fix SignalR connectioninfo naming consistency

### DIFF
--- a/src/Stratis.Bitcoin.Features.SignalR/Controllers/SignalRController.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/Controllers/SignalRController.cs
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.Features.SignalR.Controllers
         /// <summary>
         /// Returns SignalR Connection Info.
         /// </summary>
-        /// <returns>Returns SignalR Connection Info as Json {SignalRUri,SignalPort}</returns>
+        /// <returns>Returns SignalR Connection Info as Json {SignalRUri,SignalRPort}</returns>
         /// <response code="200">Returns connection info</response>
         [Route("getConnectionInfo")]
         [HttpGet]
@@ -32,7 +32,7 @@ namespace Stratis.Bitcoin.Features.SignalR.Controllers
             return this.Json(new
             {
                 this.signalRSettings.SignalRUri,
-                this.signalRSettings.SignalPort
+                this.signalRSettings.SignalRPort
             });
         }
     }

--- a/src/Stratis.Bitcoin.Features.SignalR/SignalRSettings.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/SignalRSettings.cs
@@ -22,7 +22,7 @@ namespace Stratis.Bitcoin.Features.SignalR
         public Uri SignalRUri { get; set; }
 
         /// <summary>Port of node's Signal interface.</summary>
-        public int SignalPort { get; set; }
+        public int SignalRPort { get; set; }
 
         public SignalRSettings(NodeSettings nodeSettings)
         {
@@ -42,12 +42,12 @@ namespace Stratis.Bitcoin.Features.SignalR
             if (uri.IsDefaultPort)
             {
                 this.SignalRUri = new Uri($"{host}:{port}");
-                this.SignalPort = port;
+                this.SignalRPort = port;
             }
             else
             {
                 this.SignalRUri = uri;
-                this.SignalPort = uri.Port;
+                this.SignalRPort = uri.Port;
             }
         }
 


### PR DESCRIPTION
See issue #475 for details. 
- StraxUI expects SignalRPort json field from getconnectioninfo, but receives SignalPort.
- Adds naming consistency for SignalR connection info (SignalRURI and SignalRPort versus SignalRURI and SignalPort)
