### PR TITLE
Update Swagger to 6.1.2

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/ConfigureSwaggerOptions.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ConfigureSwaggerOptions.cs
@@ -66,8 +66,6 @@ namespace Stratis.Bitcoin.Features.Api
                     options.IncludeXmlComments(xmlPath);
                 }
             }
-
-            options.DescribeAllEnumsAsStrings();
         }
 
         static OpenApiInfo CreateInfoForApiVersion(ApiVersionDescription description)

--- a/src/Stratis.Bitcoin.Features.Api/Startup.cs
+++ b/src/Stratis.Bitcoin.Features.Api/Startup.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Converters;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Swashbuckle.AspNetCore.SwaggerUI;
 
@@ -77,7 +78,10 @@ namespace Stratis.Bitcoin.Features.Api
                     }
                 })
                 // add serializers for NBitcoin objects
-                .AddNewtonsoftJson(options => Utilities.JsonConverters.Serializer.RegisterFrontConverters(options.SerializerSettings))
+                .AddNewtonsoftJson(options => {
+                    Utilities.JsonConverters.Serializer.RegisterFrontConverters(options.SerializerSettings);
+                    options.SerializerSettings.Converters.Add(new StringEnumConverter());
+                })
                 .AddControllers(this.fullNode.Services.Features, services);
 
             // Enable API versioning.

--- a/src/Stratis.Bitcoin.Features.Api/Startup.cs
+++ b/src/Stratis.Bitcoin.Features.Api/Startup.cs
@@ -80,7 +80,6 @@ namespace Stratis.Bitcoin.Features.Api
                 // add serializers for NBitcoin objects
                 .AddNewtonsoftJson(options => {
                     Utilities.JsonConverters.Serializer.RegisterFrontConverters(options.SerializerSettings);
-                    options.SerializerSettings.Converters.Add(new StringEnumConverter());
                 })
                 .AddControllers(this.fullNode.Services.Features, services);
 

--- a/src/Stratis.Bitcoin.Features.Api/Startup.cs
+++ b/src/Stratis.Bitcoin.Features.Api/Startup.cs
@@ -107,6 +107,7 @@ namespace Stratis.Bitcoin.Features.Api
 
             // Register the Swagger generator. This will use the options we injected just above.
             services.AddSwaggerGen();
+            services.AddSwaggerGenNewtonsoftSupport(); // Use Newtonsoft JSON serializer with swagger. Needs to be placed after AddSwaggerGen()
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
+++ b/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="3.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="3.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0-rc4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.2" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>

--- a/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
+++ b/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="3.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="3.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.1.2" />
     <PackageReference Include="System.Reactive" Version="4.0.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Update to latest version of swagger, necessary for future work to add dynamic contract endpoint.

This version removes Json.NET as the default JSON serializer, so I've added it back in and updated the way that string enum serialization is configured.