### PR TITLE
[MultiSig] Exclude dust from input selection in the MS wallet.

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/Wallet/MultiSigTransactionsTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Wallet/MultiSigTransactionsTests.cs
@@ -85,9 +85,11 @@ namespace Stratis.Features.FederatedPeg.Tests.Wallet
                 if (!hasSpendingDetails)
                     return null;
 
-                return new SpendingDetails() {
-                    WithdrawalDetails = hasWithdrawalDetails ? new WithdrawalDetails() {
-                         MatchingDepositId = spendingDepositId
+                return new SpendingDetails()
+                {
+                    WithdrawalDetails = hasWithdrawalDetails ? new WithdrawalDetails()
+                    {
+                        MatchingDepositId = spendingDepositId
                     } : null,
                     BlockHeight = spendingBlockHeight(),
                     TransactionId = spendingTransactionId
@@ -107,6 +109,7 @@ namespace Stratis.Features.FederatedPeg.Tests.Wallet
             var transactionData = new TransactionData()
             {
                 Id = transactionId,
+                Amount = Money.Coins(1),
                 Index = transactionIndex,
                 BlockHeight = blockHeight(),
                 SpendingDetails = spendingDetails()

--- a/src/Stratis.Features.FederatedPeg/FederatedPegSettings.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegSettings.cs
@@ -15,6 +15,9 @@ namespace Stratis.Features.FederatedPeg
     /// <inheritdoc />
     public sealed class FederatedPegSettings : IFederatedPegSettings
     {
+        /// <summary>The amount to filter dust inputs by.</summary>
+        public const decimal DustThreshold = 0.001m;
+
         public const string WalletSyncFromHeightParam = "walletsyncfromheight";
 
         public const string RedeemScriptParam = "redeemscript";
@@ -69,8 +72,6 @@ namespace Stratis.Features.FederatedPeg
             Guard.NotNull(nodeSettings, nameof(nodeSettings));
 
             TextFileConfiguration configReader = nodeSettings.ConfigReader;
-
-            this.DustThreshold = Money.Coins(0.001m);
 
             this.IsMainChain = configReader.GetOrDefault("mainchain", false);
             if (!this.IsMainChain && !configReader.GetOrDefault("sidechain", false))
@@ -144,9 +145,6 @@ namespace Stratis.Features.FederatedPeg
             this.MaximumPartialTransactionThreshold = configReader.GetOrDefault(MaximumPartialTransactionsParam, CrossChainTransferStore.MaximumPartialTransactions);
             this.WalletSyncFromHeight = configReader.GetOrDefault(WalletSyncFromHeightParam, 0);
         }
-
-        /// <inheritdoc/>
-        public Money DustThreshold { get; }
 
         /// <inheritdoc/>
         public bool IsMainChain { get; }

--- a/src/Stratis.Features.FederatedPeg/FederatedPegSettings.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegSettings.cs
@@ -70,6 +70,8 @@ namespace Stratis.Features.FederatedPeg
 
             TextFileConfiguration configReader = nodeSettings.ConfigReader;
 
+            this.DustThreshold = Money.Coins(0.001m);
+
             this.IsMainChain = configReader.GetOrDefault("mainchain", false);
             if (!this.IsMainChain && !configReader.GetOrDefault("sidechain", false))
                 throw new ConfigurationException("Either -mainchain or -sidechain must be specified");
@@ -142,6 +144,9 @@ namespace Stratis.Features.FederatedPeg
             this.MaximumPartialTransactionThreshold = configReader.GetOrDefault(MaximumPartialTransactionsParam, CrossChainTransferStore.MaximumPartialTransactions);
             this.WalletSyncFromHeight = configReader.GetOrDefault(WalletSyncFromHeightParam, 0);
         }
+
+        /// <inheritdoc/>
+        public Money DustThreshold { get; }
 
         /// <inheritdoc/>
         public bool IsMainChain { get; }

--- a/src/Stratis.Features.FederatedPeg/InputConsolidation/InputConsolidator.cs
+++ b/src/Stratis.Features.FederatedPeg/InputConsolidation/InputConsolidator.cs
@@ -165,6 +165,7 @@ namespace Stratis.Features.FederatedPeg.InputConsolidation
         /// <summary>
         /// Builds a list of consolidation transactions that will need to pass before the next withdrawal transaction can come through.
         /// </summary>
+        /// <returns>A list of consolidation transactions.</returns>
         public List<ConsolidationTransaction> CreateRequiredConsolidationTransactions(Money amount)
         {
             // TODO: This method doesn't need to be public.
@@ -172,9 +173,7 @@ namespace Stratis.Features.FederatedPeg.InputConsolidation
             lock (this.txLock)
             {
                 // Get all of the inputs
-                List<UnspentOutputReference> unspentOutputs = this.walletManager
-                    .GetSpendableTransactionsInWallet(WithdrawalTransactionBuilder.MinConfirmations)
-                    .Where(x => x.Transaction.Amount > Money.Coins(0.001m)).ToList();
+                List<UnspentOutputReference> unspentOutputs = this.walletManager.GetSpendableTransactionsInWallet(WithdrawalTransactionBuilder.MinConfirmations).ToList();
 
                 // We shouldn't be consolidating transactions if we have less than 50 UTXOs to spend.
                 if (unspentOutputs.Count < FederatedPegSettings.MaxInputs)

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederatedPegSettings.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederatedPegSettings.cs
@@ -10,6 +10,11 @@ namespace Stratis.Features.FederatedPeg.Interfaces
     public interface IFederatedPegSettings
     {
         /// <summary>
+        /// The amount to filter dust inputs by.
+        /// </summary>
+        public Money DustThreshold { get; }
+
+        /// <summary>
         /// Indicates whether this is the main chain. Set if the "-mainchain" switch was used.
         /// </summary>
         bool IsMainChain { get; }

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederatedPegSettings.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederatedPegSettings.cs
@@ -10,11 +10,6 @@ namespace Stratis.Features.FederatedPeg.Interfaces
     public interface IFederatedPegSettings
     {
         /// <summary>
-        /// The amount to filter dust inputs by.
-        /// </summary>
-        public Money DustThreshold { get; }
-
-        /// <summary>
         /// Indicates whether this is the main chain. Set if the "-mainchain" switch was used.
         /// </summary>
         bool IsMainChain { get; }

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
@@ -44,6 +44,7 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// <summary>
         /// Lists all spendable transactions from all accounts in the wallet.
         /// </summary>
+        /// <param name="confirmations">The minimum confirmations to filter by.</param>
         /// <returns>A collection of spendable outputs</returns>
         IEnumerable<UnspentOutputReference> GetSpendableTransactionsInWallet(int confirmations = 0);
 

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -117,7 +117,9 @@ namespace Stratis.Features.FederatedPeg.Wallet
         /// </summary>
         private Dictionary<OutPoint, TransactionData> outpointLookup => this.Wallet.MultiSigAddress.Transactions.GetOutpointLookup();
 
-        // Gateway settings picked up from the node config.
+        /// <summary>
+        /// Gateway settings picked up from the node config.
+        /// </summary>
         private readonly IFederatedPegSettings federatedPegSettings;
 
         public FederationWalletManager(
@@ -322,16 +324,12 @@ namespace Stratis.Features.FederatedPeg.Wallet
         {
             lock (this.lockObject)
             {
-
                 if (this.Wallet == null)
                 {
                     return Enumerable.Empty<UnspentOutputReference>();
                 }
 
-                UnspentOutputReference[] res;
-                res = this.GetSpendableTransactions(this.chainIndexer.Tip.Height, confirmations).ToArray();
-
-                return res;
+                return this.GetSpendableTransactions(this.chainIndexer.Tip.Height, confirmations).ToArray();
             }
         }
 
@@ -1047,7 +1045,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
 
                 // Verify that there are no earlier unspent UTXOs.
                 var comparer = Comparer<TransactionData>.Create(DeterministicCoinOrdering.CompareTransactionData);
-                TransactionData earliestUnspent = this.Wallet.MultiSigAddress.Transactions.GetUnspentTransactions().Where(x => x.Amount > Money.Coins(0.001m)).FirstOrDefault();
+                TransactionData earliestUnspent = this.Wallet.MultiSigAddress.Transactions.GetUnspentTransactions().FirstOrDefault();
                 if (earliestUnspent != null)
                 {
                     TransactionData oldestInput = transaction.Inputs

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletTransactionHandler.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletTransactionHandler.cs
@@ -218,7 +218,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
         /// <returns>The coins and unspent outputs that will be used.</returns>
         public static (List<Coin>, List<UnspentOutputReference>) DetermineCoins(IFederationWalletManager walletManager, Network network, TransactionBuildContext context, IFederatedPegSettings settings)
         {
-            List<UnspentOutputReference> unspentOutputs = walletManager.GetSpendableTransactionsInWallet(context.MinConfirmations).Where(x => x.Transaction.Amount > Money.Coins(0.001m)).ToList();
+            List<UnspentOutputReference> unspentOutputs = walletManager.GetSpendableTransactionsInWallet(context.MinConfirmations).ToList();
 
             // Get total spendable balance in the account.
             long balance = unspentOutputs.Sum(t => t.Transaction.Amount);

--- a/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
@@ -303,7 +303,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 IList<TransactionData> result = this.spendableTransactionList.Keys;
 
                 if (filterDustTransactions)
-                    result = result.Where(x => x.Amount > Money.Coins(0.001m)).ToArray();
+                    result = result.Where(x => x.Amount > Money.Coins(FederatedPegSettings.DustThreshold)).ToArray();
 
                 return result.ToArray();
             }

--- a/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
@@ -293,13 +293,19 @@ namespace Stratis.Features.FederatedPeg.Wallet
         /// <summary>
         /// List all spendable transactions in a multisig address.
         /// </summary>
+        /// <param name="filterDustTransactions">Filter spendable inputs below <see cref="FederatedPegSettings.DustThreshold"/>.</param>
         /// <returns>Returns all the unspent <see cref="TransactionData"/> objects.</returns>
         [NoTrace]
-        public TransactionData[] GetUnspentTransactions()
+        public TransactionData[] GetUnspentTransactions(bool filterDustTransactions = true)
         {
             lock (this.lockObject)
             {
-                return this.spendableTransactionList.Keys.ToArray();
+                IList<TransactionData> result = this.spendableTransactionList.Keys;
+
+                if (filterDustTransactions)
+                    result = result.Where(x => x.Amount > Money.Coins(0.001m)).ToArray();
+
+                return result.ToArray();
             }
         }
 


### PR DESCRIPTION
If we are filtering dust UTXOs from the withdrawal builder we need to also filter them when validating the transaction.

Not doing so fails the logic which checks if earliest unspent UTXO  was used.