### PR TITLE
[Infra] Modify signaturure verification method

### DIFF
--- a/src/Stratis.SmartContracts.CLR/SCL/ECRecover.cs
+++ b/src/Stratis.SmartContracts.CLR/SCL/ECRecover.cs
@@ -44,7 +44,7 @@ namespace Stratis.SCL.Crypto
         /// <param name="addresses">The addresses returned are intersected with these addresses.</param>
         /// <param name="verifiedAddresses">The list of addresses that produced the signatures and constrained to the list provided in <paramref name="addresses"/>.</param>
         /// <returns>The boolean value returned only indicates whether the operation could be performed. The number of verified addresses should still be checked.</returns>
-        public static bool TryGetVerifiedSignatures(string[] signatures, string message, Address[] addresses, out Address[] verifiedAddresses)
+        public static bool TryGetVerifiedSignatures(string[] signatures, byte[] message, Address[] addresses, out Address[] verifiedAddresses)
         {
             if (addresses == null)
             {
@@ -52,9 +52,22 @@ namespace Stratis.SCL.Crypto
                 return false;
             }
 
-            verifiedAddresses = VerifySignatures(signatures, System.Text.Encoding.ASCII.GetBytes(message), addresses);
+            verifiedAddresses = VerifySignatures(signatures, message, addresses);
 
             return verifiedAddresses != null;
+        }
+
+        /// <summary>
+        /// Takes a message and signatures and recovers the list of addresses that produced the signatures.
+        /// </summary>
+        /// <param name="signatures">The list of signatures of the message.</param>
+        /// <param name="message">The message that was signed.</param>
+        /// <param name="addresses">The addresses returned are intersected with these addresses.</param>
+        /// <param name="verifiedAddresses">The list of addresses that produced the signatures and constrained to the list provided in <paramref name="addresses"/>.</param>
+        /// <returns>The boolean value returned only indicates whether the operation could be performed. The number of verified addresses should still be checked.</returns>
+        public static bool TryGetVerifiedSignatures(string[] signatures, string message, Address[] addresses, out Address[] verifiedAddresses)
+        {
+            return TryGetVerifiedSignatures(signatures, System.Text.Encoding.ASCII.GetBytes(message), addresses, out verifiedAddresses);
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/SCL/ECRecover.cs
+++ b/src/Stratis.SmartContracts.CLR/SCL/ECRecover.cs
@@ -16,7 +16,7 @@ namespace Stratis.SCL.Crypto
         /// <param name="message">The message that was signed.</param>
         /// <param name="addresses">The addresses returned are intersected with these addresses (if not <c>null</c>).</param>
         /// <returns>The list of addresses that produced the signatures and constrained to the list provided in <paramref name="addresses"/>.</returns>
-        public static Address[] GetVerifiedSignatures(string[] signatures, byte[] message, Address[] addresses)
+        private static Address[] VerifySignatures(string[] signatures, byte[] message, Address[] addresses)
         {
             try
             { 
@@ -41,11 +41,20 @@ namespace Stratis.SCL.Crypto
         /// </summary>
         /// <param name="signatures">The list of signatures of the message.</param>
         /// <param name="message">The message that was signed.</param>
-        /// <param name="addresses">The addresses returned are intersected with these addresses (if not <c>null</c>).</param>
-        /// <returns>The list of addresses that produced the signatures and constrained to the list provided in <paramref name="addresses"/>.</returns>
-        public static Address[] GetVerifiedSignatures(string[] signatures, string message, Address[] addresses)
+        /// <param name="addresses">The addresses returned are intersected with these addresses.</param>
+        /// <param name="verifiedAddresses">The list of addresses that produced the signatures and constrained to the list provided in <paramref name="addresses"/>.</param>
+        /// <returns>The boolean value returned only indicates whether the operation could be performed. The number of verified addresses should still be checked.</returns>
+        public static bool TryGetVerifiedSignatures(string[] signatures, string message, Address[] addresses, out Address[] verifiedAddresses)
         {
-            return GetVerifiedSignatures(signatures, System.Text.Encoding.ASCII.GetBytes(message), addresses);
+            if (addresses == null)
+            {
+                verifiedAddresses = null;
+                return false;
+            }
+
+            verifiedAddresses = VerifySignatures(signatures, System.Text.Encoding.ASCII.GetBytes(message), addresses);
+
+            return verifiedAddresses != null;
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/SCL/ECRecover.cs
+++ b/src/Stratis.SmartContracts.CLR/SCL/ECRecover.cs
@@ -9,7 +9,14 @@ namespace Stratis.SCL.Crypto
 {
     public static class ECRecover
     {
-        private static Address[] VerifySignatures(string[] signatures, byte[] message, Address[] addresses)
+        /// <summary>
+        /// Takes a message and signatures and recovers the list of addresses that produced the signatures.
+        /// </summary>
+        /// <param name="signatures">The list of signatures of the message.</param>
+        /// <param name="message">The message that was signed.</param>
+        /// <param name="addresses">The addresses returned are intersected with these addresses (if not <c>null</c>).</param>
+        /// <returns>The list of addresses that produced the signatures and constrained to the list provided in <paramref name="addresses"/>.</returns>
+        public static Address[] GetVerifiedSignatures(string[] signatures, byte[] message, Address[] addresses)
         {
             try
             { 
@@ -34,20 +41,11 @@ namespace Stratis.SCL.Crypto
         /// </summary>
         /// <param name="signatures">The list of signatures of the message.</param>
         /// <param name="message">The message that was signed.</param>
-        /// <param name="addresses">The addresses returned are intersected with these addresses.</param>
-        /// <param name="verifiedAddresses">The list of addresses that produced the signatures and constrained to the list provided in <paramref name="addresses"/>.</param>
-        /// <returns>The boolean value returned only indicates whether the operation could be performed. The number of verified addresses should still be checked.</returns>
-        public static bool TryVerifySignatures(string[] signatures, byte[] message, Address[] addresses, out Address[] verifiedAddresses)
+        /// <param name="addresses">The addresses returned are intersected with these addresses (if not <c>null</c>).</param>
+        /// <returns>The list of addresses that produced the signatures and constrained to the list provided in <paramref name="addresses"/>.</returns>
+        public static Address[] GetVerifiedSignatures(string[] signatures, string message, Address[] addresses)
         {
-            if (addresses == null)
-            {
-                verifiedAddresses = null;
-                return false;
-            }      
-
-            verifiedAddresses = VerifySignatures(signatures, message, addresses);
-
-            return verifiedAddresses != null;
+            return GetVerifiedSignatures(signatures, System.Text.Encoding.ASCII.GetBytes(message), addresses);
         }
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/29645989/115100811-8a501100-9f82-11eb-9835-c8c1c329826c.png)

@rowandh , besides the points @YakupIpek is making regarding "expected behaviour" there is also the issue of converting the challenge to bytes, which probably can't / shouldn't be done within the contract. As such we should have the option of either passing the challenge/message as bytes or as a string.

Regarding Yakup's points. I thought the same and assumed it was only my opinion, however having this confirmed makes me think most users may feel this way.