### PR TITLE
[Infra] Clean-up PoSAllowedCodeHashLogic and add SystemContractContainer

### DIFF
--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -205,7 +205,7 @@ namespace NBitcoin
         /// </summary>
         /// <param name="hash">The hash to extract the contract type and version of.</param>
         /// <returns>The contract type and version.</returns>
-        (Type contractType, uint version) GetContractTypeAndVersion(uint256 hash);
+        (string contractType, uint version) GetContractTypeAndVersion(uint256 hash);
     }
 
     public interface IFederations

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -188,14 +188,14 @@ namespace NBitcoin
         /// <summary>
         /// Determines if the contract with the specified hash is active.
         /// </summary>
-        /// <param name="hash">Hash identifying the contract.</param>
+        /// <param name="hash">Pseudo "transaction hash" identifying the contract.</param>
         /// <param name="previousHeader">Previous header of block to check the activation state at.</param>
         /// <param name="deploymentCondition">Function that determines if the contract is active based on previous header and deployment number.</param>
         /// <returns><c>True</c> if the contract is active and <c>false</c> otherwise.</returns>        
         bool IsActive(uint256 hash, ChainedHeader previousHeader, Func<ChainedHeader, int, bool> deploymentCondition);
 
         /// <summary>
-        /// Returns the hashes of all defined contracts, whether active or inactive.
+        /// Returns the pseudo "transaction hashes" of all defined contracts, whether active or inactive.
         /// </summary>
         /// <returns></returns>
         IEnumerable<uint256> ContractHashes();
@@ -203,8 +203,8 @@ namespace NBitcoin
         /// <summary>
         /// Extracts the contract type and version from a contract hash.
         /// </summary>
-        /// <param name="hash">The hash to extract the key id and version of.</param>
-        /// <returns>The key id and version.</returns>
+        /// <param name="hash">The hash to extract the contract type and version of.</param>
+        /// <returns>The contract type and version.</returns>
         (Type contractType, uint version) GetContractTypeAndVersion(uint256 hash);
     }
 

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -198,12 +198,11 @@ namespace NBitcoin
         IEnumerable<uint256> ContractHashes();
 
         /// <summary>
-        /// Retrieves the contract type from the predefined key id to contract type mapping.
+        /// Extracts the contract type and version from a contract hash.
         /// </summary>
-        /// <param name="keyId">Key id to retrieve the contract type for.</param>
-        /// <param name="contractType">Retrieved contract type (if available).</param>
-        /// <returns><c>True</c> if a mapping exists and <c>false</c> otherwise.</returns>
-        bool TryGetContractTypeFromKeyId(KeyId keyId, out Type contractType);
+        /// <param name="hash">The hash to extract the key id and version of.</param>
+        /// <returns>The key id and version.</returns>
+        (Type contractType, uint version) GetContractTypeAndVersion(uint256 hash);
     }
 
     public interface IFederations

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -180,6 +180,32 @@ namespace NBitcoin
         }
     }
 
+    public interface ISystemContractContainer
+    {
+        /// <summary>
+        /// Determines if the contract with the specified hash should be active.
+        /// </summary>
+        /// <param name="hash">Hash identifying the contract.</param>
+        /// <param name="previousHeader">Previous header of block to check the activation state at.</param>
+        /// <param name="deploymentCondition">Function that determines if the contract is active based block and deployment number.</param>
+        /// <returns><c>True</c> if the contract is active and <c>false</c> otherwise.</returns>        
+        bool IsActive(uint256 hash, ChainedHeader previousHeader, Func<ChainedHeader, int, bool> deploymentCondition);
+
+        /// <summary>
+        /// Returns the hashes of all defined contracts, whether active or inactive.
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<uint256> ContractHashes();
+
+        /// <summary>
+        /// Retrieves the contract type from the predefined key id to contract type mapping.
+        /// </summary>
+        /// <param name="keyId">Key id to retrieve the contract type for.</param>
+        /// <param name="contractType">Retrieved contract type (if available).</param>
+        /// <returns><c>True</c> if a mapping exists and <c>false</c> otherwise.</returns>
+        bool TryGetContractTypeFromKeyId(KeyId keyId, out Type contractType);
+    }
+
     public interface IFederations
     {
         /// <summary>
@@ -450,6 +476,8 @@ namespace NBitcoin
         public IStandardScriptsRegistry StandardScriptsRegistry { get; protected set; }
 
         public IFederations Federations { get; protected set; }
+
+        public ISystemContractContainer SystemContractContainer { get; protected set; }
 
         /// <summary>
         /// This is used for reward distribution transactions.

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -198,7 +198,7 @@ namespace NBitcoin
         /// Returns the pseudo "transaction hashes" of all defined contracts, whether active or inactive.
         /// </summary>
         /// <returns></returns>
-        IEnumerable<uint256> ContractHashes();
+        IEnumerable<uint256> GetContractHashes();
 
         /// <summary>
         /// Extracts the contract type and version from a contract hash.

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -187,7 +187,7 @@ namespace NBitcoin
         /// </summary>
         /// <param name="hash">Hash identifying the contract.</param>
         /// <param name="previousHeader">Previous header of block to check the activation state at.</param>
-        /// <param name="deploymentCondition">Function that determines if the contract is active based block and deployment number.</param>
+        /// <param name="deploymentCondition">Function that determines if the contract is active based previous header and deployment number.</param>
         /// <returns><c>True</c> if the contract is active and <c>false</c> otherwise.</returns>        
         bool IsActive(uint256 hash, ChainedHeader previousHeader, Func<ChainedHeader, int, bool> deploymentCondition);
 

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -180,6 +180,9 @@ namespace NBitcoin
         }
     }
 
+    /// <summary>
+    /// Holds the information and logic to determines whether an embedded system contract should be active.
+    /// </summary>
     public interface ISystemContractContainer
     {
         /// <summary>

--- a/src/NBitcoin/Network.cs
+++ b/src/NBitcoin/Network.cs
@@ -186,11 +186,11 @@ namespace NBitcoin
     public interface ISystemContractContainer
     {
         /// <summary>
-        /// Determines if the contract with the specified hash should be active.
+        /// Determines if the contract with the specified hash is active.
         /// </summary>
         /// <param name="hash">Hash identifying the contract.</param>
         /// <param name="previousHeader">Previous header of block to check the activation state at.</param>
-        /// <param name="deploymentCondition">Function that determines if the contract is active based previous header and deployment number.</param>
+        /// <param name="deploymentCondition">Function that determines if the contract is active based on previous header and deployment number.</param>
         /// <returns><c>True</c> if the contract is active and <c>false</c> otherwise.</returns>        
         bool IsActive(uint256 hash, ChainedHeader previousHeader, Func<ChainedHeader, int, bool> deploymentCondition);
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/PoS/SystemContractContainerTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/PoS/SystemContractContainerTests.cs
@@ -56,5 +56,19 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.PoS
             chainedHeader.SetPrivatePropertyValue("Height", 10);
             Assert.True(container.IsActive(hash, chainedHeader, (h, d) => true));
         }
+
+        [Fact]
+        public void CanDereferenceContractTypes()
+        {
+            foreach (Network network in new Network[] { new StraxMain(), new StraxTest(), new StraxRegTest() })
+            {
+                foreach (uint256 hash in network.SystemContractContainer.GetContractHashes())
+                {
+                    (string typeName, uint version) = network.SystemContractContainer.GetContractTypeAndVersion(hash);
+
+                    Assert.NotNull(Type.GetType(typeName));
+                }
+            }
+        }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/PoS/SystemContractContainerTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/PoS/SystemContractContainerTests.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.PoS
             uint256 contractHash = SystemContractContainer.GetPseudoHash(contractId, 1);
             var container = new SystemContractContainer(
                 network,
-                new Dictionary<KeyId, Type> { { contractId, typeof(TestSystemContract) }},
+                new Dictionary<KeyId, string> { { contractId, typeof(TestSystemContract).ToString() }},
                 new Dictionary<uint256, (int start, int? end)[]> { { contractHash, new[] { (1, (int?)10) } } },
                 new Dictionary<uint256, (string, bool)> { { contractHash, ("SystemContracts", true) } });
 
@@ -33,9 +33,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.PoS
 
             Assert.True(SystemContractContainer.IsPseudoHash(hash));
 
-            (Type contractType, uint version) typeAndVersion = container.GetContractTypeAndVersion(hash);
+            (string contractType, uint version) typeAndVersion = container.GetContractTypeAndVersion(hash);
 
-            Assert.Equal(typeof(TestSystemContract), typeAndVersion.contractType);
+            Assert.Equal(typeof(TestSystemContract).ToString(), typeAndVersion.contractType);
             Assert.Equal((uint)1, typeAndVersion.version);
 
             ChainedHeader chainedHeader = new ChainedHeader(0, null, null) { };

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/PoS/SystemContractContainerTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/PoS/SystemContractContainerTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Features.SmartContracts.PoS;
+using Stratis.Bitcoin.Networks;
+using Stratis.Bitcoin.Tests.Common;
+using Xunit;
+
+namespace Stratis.Bitcoin.Features.SmartContracts.Tests.PoS
+{
+    public class TestSystemContract
+    {
+
+    }
+
+    public class SystemContractContainerTests
+    {
+        [Fact]
+        public void CanUseSystemContractContainer()
+        {
+            var network = new StraxMain();
+            KeyId contractId = new Key().PubKey.Hash;
+            var container = new SystemContractContainer(
+                network,
+                new Dictionary<KeyId, Type> { { contractId, typeof(TestSystemContract) }},
+                new Dictionary<uint256, (int start, int? end)[]> { { SystemContractContainer.GetPseudoHash(contractId, 1), new[] { (1, (int?)10) } } },
+                new Dictionary<uint256, (string, bool)> { });
+
+            uint256 hash = container.GetContractHashes().First();
+
+            Assert.True(SystemContractContainer.IsPseudoHash(hash));
+
+            (Type contractType, uint version) typeAndVersion = container.GetContractTypeAndVersion(hash);
+
+            Assert.Equal(typeof(TestSystemContract), typeAndVersion.contractType);
+            Assert.Equal((uint)1, typeAndVersion.version);
+
+            ChainedHeader chainedHeader = new ChainedHeader(0, null, null) { };
+            var mockChainStore = new Mock<IChainStore>();
+            BlockHeader header = network.Consensus.ConsensusFactory.CreateBlockHeader();
+            mockChainStore.Setup(x => x.GetHeader(It.IsAny<ChainedHeader>(), It.IsAny<uint256>())).Returns(header);
+            chainedHeader.SetPrivatePropertyValue("ChainStore", mockChainStore.Object);
+
+            // Active if previous header is at height 9.
+            chainedHeader.SetPrivatePropertyValue("Height", 9);
+            Assert.True(container.IsActive(hash, chainedHeader, (h, d) => true));
+
+            // Inactive if previous header is at height 10.
+            chainedHeader.SetPrivatePropertyValue("Height", 10);
+            Assert.False(container.IsActive(hash, chainedHeader, (h, d) => true));
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Interfaces/IWhitelistedHashChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Interfaces/IWhitelistedHashChecker.cs
@@ -1,0 +1,7 @@
+﻿namespace Stratis.Bitcoin.Features.SmartContracts.Interfaces
+{
+    public interface IWhitelistedHashChecker
+    {
+        bool CheckHashWhitelisted(byte[] hash);
+    }
+}

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/WhitelistedHashChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/WhitelistedHashChecker.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using NBitcoin;
 using Stratis.Bitcoin.Features.PoA.Voting;
+using Stratis.Bitcoin.Features.SmartContracts.Interfaces;
 
 namespace Stratis.Bitcoin.Features.SmartContracts.PoA
 {
@@ -36,10 +37,5 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA
 
             return allowedHashes.Contains(hash256);
         }
-    }
-
-    public interface IWhitelistedHashChecker
-    {
-        bool CheckHashWhitelisted(byte[] hash);
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedContractExtensions.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedContractExtensions.cs
@@ -21,6 +21,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
             services.AddSingleton<IContractCodeHashingStrategy, Keccak256CodeHashingStrategy>();
 
             // Registers an additional contract tx validation consensus rule which checks whether the hash of the contract being deployed is whitelisted.
+            services.AddSingleton<IWhitelistedHashChecker, PoSWhitelistedHashChecker>();
             services.AddSingleton<IContractTransactionFullValidationRule, PoSAllowedCodeHashLogic>();
 
             return options;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
@@ -13,7 +13,8 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
     {
         // TODO: Move these variables to the respective main, test / regtest network classes.
 
-        // Currently white-listed contracts.
+        // History of block ranges over which the contracts was active.
+        // The BIP9 Deployments array is sometimes cleaned up and the information therein has to be transferred here.
         private static Dictionary<uint256, (int start, int? end)[]> contractActivationHistory = new Dictionary<uint256, (int, int?)[]>()
         {
             { uint256.Zero, new (int, int?)[] { (0, 0) } }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
@@ -31,14 +31,17 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
         /// <returns>True if the hash was found in the whitelisted hashes repository.</returns>
         public bool CheckHashWhitelisted(byte[] hashBytes, ChainedHeader previousHeader)
         {
-            if (hashBytes.Length != 32)
-            {
-                // For this implementation, only 32 byte wide hashes are accepted.
-                return false;
-            }
+            return CheckHashWhitelisted(new uint256(hashBytes), previousHeader);
+        }
 
-            var hash = new uint256(hashBytes);
-
+        /// <summary>
+        /// Checks that a supplied hash is present in the whitelisted hashes repository.
+        /// </summary>
+        /// <param name="hash">The hash to check.</param>
+        /// <param name="previousHeader">The block before the block to check.</param>
+        /// <returns>True if the hash was found in the whitelisted hashes repository.</returns>
+        public bool CheckHashWhitelisted(uint256 hash, ChainedHeader previousHeader)
+        {
             return this.network.SystemContractContainer.IsActive(hash, previousHeader, (h, d) => this.nodeDeployments.BIP9.GetState(h, d) == ThresholdState.Active);
         }
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using NBitcoin;
 using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Features.SmartContracts.Interfaces;
@@ -12,33 +9,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
     /// </summary>
     public class PoSWhitelistedHashChecker : IWhitelistedHashChecker
     {
-        // TODO: Move these variables to the respective main, test / regtest network classes.
-
-        private static byte[] pseudoHashSignature = new byte[8] { 0, 0, 0, 0, 0, 0, 0, 0 };
-
-        // Pseudo-hash consisting of 8 "signature", 20 "address" + 4 "version" bytes.
-        private static uint256 PseudoHash(KeyId address, uint version)
-        {
-            byte[] hashBytes = pseudoHashSignature.Concat(address.ToBytes()).Concat(BitConverter.GetBytes(version)).ToArray();
-            return new uint256(hashBytes);
-        }
-
-        // History of block ranges over which contracts were active.
-        // The BIP9 Deployments array is sometimes cleaned up and the information therein has to be transferred here.
-        private static Dictionary<uint256, (int start, int? end)[]> contractActivationHistory = new Dictionary<uint256, (int, int?)[]>()
-        {
-            { PseudoHash(new KeyId(1), 0), new (int, int?)[] { (0, 0) } }
-        };
-
-        // Contracts to white (or black)-list later when the specified BIP 9 goes active.
-        private static Dictionary<uint256, (string, bool)> contractWhitelistingBIP9s = new Dictionary<uint256, (string, bool)>() {
-            { PseudoHash(new KeyId(1), 0), ("SystemContracts", true) }
-        };
-
-        private static Dictionary<uint160, Type> contractTypes = new Dictionary<uint160, Type>() {
-            // { new KeyId(1), typeof(SystemContractDictionary) }
-        };
-
         private readonly Network network;
         private readonly NodeDeployments nodeDeployments;
         private readonly ChainIndexer chainIndexer;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
@@ -58,7 +58,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
             bool isWhiteListed = false;
             if (contractActivationHistory.TryGetValue(hash, out (int start, int? end)[] ranges))
             {
-                if (ranges.Any(r => (previousHeader.Height + 1) <= r.start && (r.end == null || (previousHeader.Height + 1) <= r.end)))
+                if (ranges.Any(r => (previousHeader.Height + 1) >= r.start && (r.end == null || (previousHeader.Height + 1) <= r.end)))
                     isWhiteListed = true;
             }
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using NBitcoin;
+using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Features.SmartContracts.Interfaces;
+
+namespace Stratis.Bitcoin.Features.SmartContracts.PoS
+{
+    /// <summary>
+    /// Checks hashes against a whitelist.
+    /// </summary>
+    public class PoSWhitelistedHashChecker : IWhitelistedHashChecker
+    {
+        // Currently white-listed contracts.
+        private static HashSet<uint256> currentWhiteListedHashes = new HashSet<uint256>()
+        {
+            uint256.Zero
+        };
+
+        // Contracts to white-list later when the specified BIP 9 goes active.
+        private static Dictionary<uint256, string> contractWhitelistingBIP9s = new Dictionary<uint256, string>() {
+            { uint256.Zero, "SystemContracts" }
+        };
+
+        // Contracts to black-list later when the specified BIP 9 goes active.
+        private static Dictionary<uint256, string> contractBlacklistingBIP9s = new Dictionary<uint256, string>() {
+            { uint256.Zero, "SystemContracts" }
+        };
+
+        private readonly Network network;
+        private readonly NodeDeployments nodeDeployments;
+        private readonly ChainIndexer chainIndexer;
+
+        /// <summary>
+        /// Checks for whitelisted contracts on PoS networks.
+        /// </summary>
+        public PoSWhitelistedHashChecker(Network network, NodeDeployments nodeDeployments, ChainIndexer chainIndexer)
+        {
+            this.network = network;
+            this.nodeDeployments = nodeDeployments;
+            this.chainIndexer = chainIndexer;
+        }
+
+        /// <summary>
+        /// Checks that a supplied hash is present in the whitelisted hashes repository.
+        /// </summary>
+        /// <param name="hashBytes">The bytes of the hash to check.</param>
+        /// <param name="previousHeader">The block before the block to check.</param>
+        /// <returns>True if the hash was found in the whitelisted hashes repository.</returns>
+        public bool CheckHashWhitelisted(byte[] hashBytes, ChainedHeader previousHeader)
+        {
+            if (hashBytes.Length != 32)
+            {
+                // For this implementation, only 32 byte wide hashes are accepted.
+                return false;
+            }
+
+            var hash = new uint256(hashBytes);
+
+            bool isWhiteListed = currentWhiteListedHashes.Contains(hash);
+
+            if (!isWhiteListed && contractWhitelistingBIP9s.TryGetValue(hash, out string deploymentName))
+            {
+                // Found.
+            }
+            else if (isWhiteListed && contractBlacklistingBIP9s.TryGetValue(hash, out deploymentName))
+            {
+                // Found.
+            }
+            else
+            {
+                return isWhiteListed;
+            }
+
+            int deployment = this.network.Consensus.BIP9Deployments.FindDeploymentIndexByName(deploymentName);
+            if (deployment < 0)
+                return isWhiteListed;
+
+            if (this.nodeDeployments.BIP9.GetState(previousHeader, deployment) == ThresholdState.Active)
+                isWhiteListed = !isWhiteListed;
+
+            return isWhiteListed;
+        }
+
+        /// <inheritdoc />
+        public bool CheckHashWhitelisted(byte[] hashBytes)
+        {
+            return this.CheckHashWhitelisted(hashBytes, this.chainIndexer.Tip);
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
@@ -62,7 +62,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
             bool isWhiteListed = false;
             if (contractActivationHistory.TryGetValue(hash, out (int start, int? end)[] ranges))
             {
-                if (ranges.Any(r => (previousHeader.Height + 1) <= r.start && (previousHeader.Height + 1) <= r.end))
+                if (ranges.Any(r => (previousHeader.Height + 1) <= r.start && (r.end == null || (previousHeader.Height + 1) <= r.end)))
                     isWhiteListed = true;
             }
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/PoSWhitelistedHashChecker.cs
@@ -13,7 +13,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
     {
         // TODO: Move these variables to the respective main, test / regtest network classes.
 
-        // History of block ranges over which the contracts was active.
+        // History of block ranges over which contracts were active.
         // The BIP9 Deployments array is sometimes cleaned up and the information therein has to be transferred here.
         private static Dictionary<uint256, (int start, int? end)[]> contractActivationHistory = new Dictionary<uint256, (int, int?)[]>()
         {

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/PoSAllowedCodeHashLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/PoSAllowedCodeHashLogic.cs
@@ -11,15 +11,17 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS.Rules
     /// </summary>
     public class PoSAllowedCodeHashLogic : IContractTransactionFullValidationRule
     {
-        private static uint256 dictionaryCodeHash = new uint256("");
+        private static uint256 dictionaryCodeHash = uint256.Zero; // TODO: Replace this with the actual hash.
 
         private readonly Network network;
         private readonly IContractCodeHashingStrategy hashingStrategy;
+        private readonly ISystemContractExecutor systemContractExecutor;
 
-        public PoSAllowedCodeHashLogic(Network network, IContractCodeHashingStrategy hashingStrategy)
+        public PoSAllowedCodeHashLogic(Network network, IContractCodeHashingStrategy hashingStrategy, ISystemContractExecutor systemContractExecutor)
         {
             this.network = network;
             this.hashingStrategy = hashingStrategy;
+            this.systemContractExecutor = systemContractExecutor;
         }
        
         /// <summary>
@@ -39,6 +41,14 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS.Rules
                 return;
 
             // TODO: If the contract is white-listed in the dictionary contract then exit without throwing an error.
+            SystemContractExecutionResult systemContractExecutionResult = Execute(new SystemContractContext()
+            {
+                blockHeight = blockHeight
+                // TODO
+            });
+
+            if ((bool)(systemContractExecutionResult.Result))
+                return;
 
             ThrowInvalidCode();
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/PoSAllowedCodeHashLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/PoSAllowedCodeHashLogic.cs
@@ -11,15 +11,11 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS.Rules
     /// </summary>
     public class PoSAllowedCodeHashLogic : IContractTransactionFullValidationRule
     {
-        private static uint256 dictionaryCodeHash = uint256.Zero; // TODO: Replace this with the actual hash.
-
-        private readonly Network network;
         private readonly IContractCodeHashingStrategy hashingStrategy;
         private readonly IWhitelistedHashChecker whitelistedHashChecker;
 
-        public PoSAllowedCodeHashLogic(Network network, IContractCodeHashingStrategy hashingStrategy, IWhitelistedHashChecker whitelistedHashChecker)
+        public PoSAllowedCodeHashLogic(IContractCodeHashingStrategy hashingStrategy, IWhitelistedHashChecker whitelistedHashChecker)
         {
-            this.network = network;
             this.hashingStrategy = hashingStrategy;
             this.whitelistedHashChecker = whitelistedHashChecker;
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/PoSAllowedCodeHashLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/PoSAllowedCodeHashLogic.cs
@@ -42,7 +42,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS.Rules
             if (!txData.IsCreateContract)
                 return;
 
-            if (!ContractIsWhitelisted(txData))
+            if (ContractIsWhitelisted(txData))
                 return;
 
             ThrowInvalidCode();

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/PoSAllowedCodeHashLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/PoSAllowedCodeHashLogic.cs
@@ -16,14 +16,12 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS.Rules
         private readonly Network network;
         private readonly IContractCodeHashingStrategy hashingStrategy;
         private readonly IWhitelistedHashChecker whitelistedHashChecker;
-        private readonly ISystemContractExecutor systemContractExecutor;
 
-        public PoSAllowedCodeHashLogic(Network network, IContractCodeHashingStrategy hashingStrategy, IWhitelistedHashChecker whitelistedHashChecker, ISystemContractExecutor systemContractExecutor)
+        public PoSAllowedCodeHashLogic(Network network, IContractCodeHashingStrategy hashingStrategy, IWhitelistedHashChecker whitelistedHashChecker)
         {
             this.network = network;
             this.hashingStrategy = hashingStrategy;
             this.whitelistedHashChecker = whitelistedHashChecker;
-            this.systemContractExecutor = systemContractExecutor;
         }
 
         public bool ContractIsWhitelisted(ContractTxData txData)
@@ -45,16 +43,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS.Rules
                 return;
 
             if (!ContractIsWhitelisted(txData))
-                return;
-
-            // TODO: If the contract is white-listed in the dictionary contract then exit without throwing an error.
-            SystemContractExecutionResult systemContractExecutionResult = Execute(new SystemContractContext()
-            {
-                blockHeight = blockHeight
-                // TODO
-            });
-
-            if ((bool)(systemContractExecutionResult.Result))
                 return;
 
             ThrowInvalidCode();

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/PoSAllowedCodeHashLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/Rules/PoSAllowedCodeHashLogic.cs
@@ -38,7 +38,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS.Rules
             if (hashedCode == dictionaryCodeHash)
                 return;
 
-            // TODO: If the contract is white-listed in the dictionary contract the exit without throwing an error.
+            // TODO: If the contract is white-listed in the dictionary contract then exit without throwing an error.
 
             ThrowInvalidCode();
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
@@ -11,8 +11,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
     /// </summary>
     public class SystemContractContainer : ISystemContractContainer
     {
-        // TODO: Move these variables to the respective main, test / regtest network classes.
-
         private static byte[] pseudoHashSignature = new byte[8] { 0, 0, 0, 0, 0, 0, 0, 0 };
 
         private readonly Network network;

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using Stratis.Bitcoin.Utilities;
+
+namespace Stratis.Bitcoin.Features.SmartContracts.PoS
+{
+    /// <summary>
+    /// Holds the information and logic to determines whether a system contract should be active.
+    /// </summary>
+    public class SystemContractContainer : ISystemContractContainer
+    {
+        // TODO: Move these variables to the respective main, test / regtest network classes.
+
+        private static byte[] pseudoHashSignature = new byte[8] { 0, 0, 0, 0, 0, 0, 0, 0 };
+
+        private readonly Network network;
+
+        // History of block ranges over which contracts were active.
+        // The BIP9 Deployments array is sometimes cleaned up and the information therein has to be transferred here.
+        private Dictionary<uint256, (int start, int? end)[]> contractActivationHistory;
+
+        // Contracts to white (or black)-list later when the specified BIP 9 goes active.
+        private Dictionary<uint256, (string, bool)> contractWhitelistingBIP9s;
+
+        // Map key id's to contract types.
+        private Dictionary<KeyId, Type> contractTypes;
+
+        public SystemContractContainer(
+            Network network,
+            Dictionary<KeyId, Type> contractTypes,
+            Dictionary<uint256, (int start, int? end)[]> contractActivationHistory,
+            Dictionary<uint256, (string, bool)> contractWhitelistingBIP9s)
+        {
+            this.network = network;
+            this.contractTypes = contractTypes;
+            this.contractActivationHistory = contractActivationHistory;
+            this.contractWhitelistingBIP9s = contractWhitelistingBIP9s;
+        }
+
+        /// <summary>
+        ///  Pseudo-hash consisting of 8 "signature", 20 "address" + 4 "version" bytes.
+        /// </summary>
+        /// <param name="address"><see cref="KeyId"/> that will be mapped to a contract class.</param>
+        /// <param name="version">Version that will be passed to contract constructor.</param>
+        /// <returns>Pseudo-hash identifying the system contract type and version.</returns>
+        public static uint256 PseudoHash(KeyId address, uint version)
+        {
+            byte[] hashBytes = pseudoHashSignature.Concat(address.ToBytes()).Concat(BitConverter.GetBytes(version)).ToArray();
+            return new uint256(hashBytes);
+        }
+
+        /// <summary>
+        /// Extracts the key id and version from a pseudo-hash.
+        /// </summary>
+        /// <param name="hash">The hash to extract the key id and version of.</param>
+        /// <returns>The key id and version.</returns>
+        public static (KeyId, uint) GetKeyIdAndVersion(uint256 hash)
+        {
+            Guard.Assert(hash.GetLow64() == BitConverter.ToUInt64(pseudoHashSignature));
+
+            var hashBytes = hash.ToBytes();
+
+            var keyIdBytes = new byte[20];
+            Array.Copy(hashBytes, 8, keyIdBytes, 0, 20);
+
+            return (new KeyId(keyIdBytes), BitConverter.ToUInt32(hashBytes, 28));
+        }
+
+        /// <inheritdoc/>
+        public bool TryGetContractTypeFromKeyId(KeyId keyId, out Type contractType)
+        {
+            return this.contractTypes.TryGetValue(keyId, out contractType);
+        }
+
+        /// <inheritdoc/>
+        public bool IsActive(uint256 hash, ChainedHeader previousHeader, Func<ChainedHeader, int, bool> deploymentCondition)
+        {
+            bool isActive = false;
+            if (this.contractActivationHistory.TryGetValue(hash, out (int start, int? end)[] ranges))
+            {
+                if (ranges.Any(r => (previousHeader.Height + 1) >= r.start && (r.end == null || (previousHeader.Height + 1) <= r.end)))
+                    isActive = true;
+            }
+
+            if (!isActive && this.contractWhitelistingBIP9s.TryGetValue(hash, out (string deploymentName, bool whiteList) action))
+            {
+                int deployment = this.network.Consensus.BIP9Deployments.FindDeploymentIndexByName(action.deploymentName);
+                if (deployment < 0)
+                    return isActive;
+
+                if (deploymentCondition(previousHeader, deployment))
+                    isActive = action.whiteList;
+            }
+
+            return isActive;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<uint256> ContractHashes()
+        {
+            return this.contractActivationHistory.Keys.Concat(this.contractWhitelistingBIP9s.Keys).Distinct();
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
@@ -45,7 +45,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
         /// <param name="contractTypeId"><see cref="KeyId"/> that will be mapped to a contract class.</param>
         /// <param name="version">Version that will be passed to contract constructor.</param>
         /// <returns>Pseudo-hash identifying the system contract type and version.</returns>
-        public static uint256 PseudoHash(KeyId contractTypeId, uint version)
+        public static uint256 GetPseudoHash(KeyId contractTypeId, uint version)
         {
             byte[] hashBytes = pseudoHashSignature.Concat(contractTypeId.ToBytes()).Concat(BitConverter.GetBytes(version)).ToArray();
             return new uint256(hashBytes);

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
@@ -52,13 +52,23 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
         }
 
         /// <summary>
+        /// Determines whether the hash is a "pseudo hash".
+        /// </summary>
+        /// <param name="hash">Hash to evaluate.</param>
+        /// <returns><c>True</c> if its a pseudo-hash and <c>flase</c> otherwise.</returns>
+        public static bool IsPseudoHash(uint256 hash)
+        {
+            return hash.GetLow64() == BitConverter.ToUInt64(pseudoHashSignature);
+        }
+
+        /// <summary>
         /// Extracts the key id and version from a pseudo-hash.
         /// </summary>
         /// <param name="hash">The hash to extract the key id and version of.</param>
         /// <returns>The key id and version.</returns>
-        public static (KeyId, uint) GetKeyIdAndVersion(uint256 hash)
+        public static (KeyId keyId, uint version) GetKeyIdAndVersion(uint256 hash)
         {
-            Guard.Assert(hash.GetLow64() == BitConverter.ToUInt64(pseudoHashSignature));
+            Guard.Assert(IsPseudoHash(hash));
 
             var hashBytes = hash.ToBytes();
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
@@ -23,11 +23,11 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
         private Dictionary<uint256, (string, bool)> contractWhitelistingBIP9s;
 
         // Map key id's to contract types.
-        private Dictionary<KeyId, Type> contractTypes;
+        private Dictionary<KeyId, string> contractTypes;
 
         public SystemContractContainer(
             Network network,
-            Dictionary<KeyId, Type> contractTypes,
+            Dictionary<KeyId, string> contractTypes,
             Dictionary<uint256, (int start, int? end)[]> contractActivationHistory,
             Dictionary<uint256, (string, bool)> contractWhitelistingBIP9s)
         {
@@ -64,7 +64,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
         /// </summary>
         /// <param name="hash">The hash to extract the key id and version of.</param>
         /// <returns>The key id and version.</returns>
-        public (Type contractType, uint version) GetContractTypeAndVersion(uint256 hash)
+        public (string contractType, uint version) GetContractTypeAndVersion(uint256 hash)
         {
             Guard.Assert(IsPseudoHash(hash));
 

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
@@ -7,7 +7,7 @@ using Stratis.Bitcoin.Utilities;
 namespace Stratis.Bitcoin.Features.SmartContracts.PoS
 {
     /// <summary>
-    /// Holds the information and logic to determines whether a system contract should be active.
+    /// Holds the information and logic to determines whether an embedded system contract should be active.
     /// </summary>
     public class SystemContractContainer : ISystemContractContainer
     {

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
@@ -40,14 +40,14 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
         }
 
         /// <summary>
-        ///  Pseudo-hash consisting of 8 "signature", 20 "address" + 4 "version" bytes.
+        ///  Pseudo-hash consisting of 8 "signature", 20 "contractTypeId" + 4 "version" bytes.
         /// </summary>
-        /// <param name="address"><see cref="KeyId"/> that will be mapped to a contract class.</param>
+        /// <param name="contractTypeId"><see cref="KeyId"/> that will be mapped to a contract class.</param>
         /// <param name="version">Version that will be passed to contract constructor.</param>
         /// <returns>Pseudo-hash identifying the system contract type and version.</returns>
-        public static uint256 PseudoHash(KeyId address, uint version)
+        public static uint256 PseudoHash(KeyId contractTypeId, uint version)
         {
-            byte[] hashBytes = pseudoHashSignature.Concat(address.ToBytes()).Concat(BitConverter.GetBytes(version)).ToArray();
+            byte[] hashBytes = pseudoHashSignature.Concat(contractTypeId.ToBytes()).Concat(BitConverter.GetBytes(version)).ToArray();
             return new uint256(hashBytes);
         }
 
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
         /// </summary>
         /// <param name="hash">The hash to extract the key id and version of.</param>
         /// <returns>The key id and version.</returns>
-        public static (KeyId keyId, uint version) GetKeyIdAndVersion(uint256 hash)
+        public (Type contractType, uint version) GetContractTypeAndVersion(uint256 hash)
         {
             Guard.Assert(IsPseudoHash(hash));
 
@@ -75,13 +75,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
             var keyIdBytes = new byte[20];
             Array.Copy(hashBytes, 8, keyIdBytes, 0, 20);
 
-            return (new KeyId(keyIdBytes), BitConverter.ToUInt32(hashBytes, 28));
-        }
-
-        /// <inheritdoc/>
-        public bool TryGetContractTypeFromKeyId(KeyId keyId, out Type contractType)
-        {
-            return this.contractTypes.TryGetValue(keyId, out contractType);
+            return (this.contractTypes[new KeyId(keyIdBytes)], BitConverter.ToUInt32(hashBytes, 28));
         }
 
         /// <inheritdoc/>

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoS/SystemContractContainer.cs
@@ -100,7 +100,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoS
         }
 
         /// <inheritdoc/>
-        public IEnumerable<uint256> ContractHashes()
+        public IEnumerable<uint256> GetContractHashes()
         {
             return this.contractActivationHistory.Keys.Concat(this.contractWhitelistingBIP9s.Keys).Distinct();
         }

--- a/src/Stratis.Bitcoin.Networks/StraxMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StraxMain.cs
@@ -40,7 +40,7 @@ namespace Stratis.Bitcoin.Networks
             
             this.SystemContractContainer = new SystemContractContainer(
                 this,
-                new Dictionary<KeyId, Type> { },
+                new Dictionary<KeyId, string> { },
                 new Dictionary<uint256, (int start, int? end)[]> { },
                 new Dictionary<uint256, (string, bool)> { });
 

--- a/src/Stratis.Bitcoin.Networks/StraxMain.cs
+++ b/src/Stratis.Bitcoin.Networks/StraxMain.cs
@@ -37,6 +37,12 @@ namespace Stratis.Bitcoin.Networks
             this.CirrusRewardDummyAddress = "CPqxvnzfXngDi75xBJKqi4e6YrFsinrJka"; // Cirrus main address
             this.RewardClaimerBatchActivationHeight = 119_200; // Tuesday, 12 January 2021 9:00:00 AM (Estimated)
             this.RewardClaimerBlockInterval = 100;
+            
+            this.SystemContractContainer = new SystemContractContainer(
+                this,
+                new Dictionary<KeyId, Type> { },
+                new Dictionary<uint256, (int start, int? end)[]> { },
+                new Dictionary<uint256, (string, bool)> { });
 
             // To successfully process the OP_FEDERATION opcode the federations should be known.
             this.Federations = new Federations();

--- a/src/Stratis.Bitcoin.Networks/StraxRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StraxRegTest.cs
@@ -81,6 +81,12 @@ namespace Stratis.Bitcoin.Networks
                 [StraxBIP9Deployments.SystemContracts] = new BIP9DeploymentsParameters("SystemContracts", 3, DateTime.Parse("2021-02-25 06:20:00 GMT"), DateTime.Parse("2031-02-20 00:00:00 GMT"), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
+            this.SystemContractContainer = new SystemContractContainer(
+                this,
+                new Dictionary<KeyId, Type> { },
+                new Dictionary<uint256, (int start, int? end)[]> { },
+                new Dictionary<uint256, (string, bool)> { });
+
             // To successfully process the OP_FEDERATION opcode the federations should be known.
             this.Federations = new Federations();
 

--- a/src/Stratis.Bitcoin.Networks/StraxRegTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StraxRegTest.cs
@@ -83,7 +83,7 @@ namespace Stratis.Bitcoin.Networks
 
             this.SystemContractContainer = new SystemContractContainer(
                 this,
-                new Dictionary<KeyId, Type> { },
+                new Dictionary<KeyId, string> { },
                 new Dictionary<uint256, (int start, int? end)[]> { },
                 new Dictionary<uint256, (string, bool)> { });
 

--- a/src/Stratis.Bitcoin.Networks/StraxTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StraxTest.cs
@@ -80,7 +80,7 @@ namespace Stratis.Bitcoin.Networks
 
             this.SystemContractContainer = new SystemContractContainer(
                 this,
-                new Dictionary<KeyId, Type> { },
+                new Dictionary<KeyId, string> { },
                 new Dictionary<uint256, (int start, int? end)[]> { },
                 new Dictionary<uint256, (string, bool)> { });
 

--- a/src/Stratis.Bitcoin.Networks/StraxTest.cs
+++ b/src/Stratis.Bitcoin.Networks/StraxTest.cs
@@ -78,6 +78,12 @@ namespace Stratis.Bitcoin.Networks
                 [StraxBIP9Deployments.SystemContracts] = new BIP9DeploymentsParameters("SystemContracts", 3, DateTime.Parse("2021-02-25 06:20:00 GMT"), DateTime.Parse("2031-02-20 00:00:00 GMT"), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
+            this.SystemContractContainer = new SystemContractContainer(
+                this,
+                new Dictionary<KeyId, Type> { },
+                new Dictionary<uint256, (int start, int? end)[]> { },
+                new Dictionary<uint256, (string, bool)> { });
+
             // To successfully process the OP_FEDERATION opcode the federations should be known.
             this.Federations = new Federations();
 

--- a/src/Stratis.SmartContracts.CLR.Tests/CallDataSerializerTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/CallDataSerializerTests.cs
@@ -30,7 +30,7 @@ namespace Stratis.SmartContracts.CLR.Tests
                 }"
             );
 
-            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, contractExecutionCode, signatures: new[] { Convert.ToBase64String(new byte[] { 1, 2, 3 }), Convert.ToBase64String(new byte[] { 7, 8, 9 }) });
+            var contractTxData = new ContractTxData(1, 1, (RuntimeObserver.Gas)5000, contractExecutionCode);
             var callDataResult = this.Serializer.Deserialize(this.Serializer.Serialize(contractTxData));
             var callData = callDataResult.Value;
 
@@ -40,8 +40,6 @@ namespace Stratis.SmartContracts.CLR.Tests
             Assert.Equal<byte[]>(contractExecutionCode, callData.ContractExecutionCode);
             Assert.Equal((RuntimeObserver.Gas)1, callData.GasPrice);
             Assert.Equal((RuntimeObserver.Gas)5000, callData.GasLimit);
-            Assert.Equal(new byte[] { 1, 2, 3 }, Convert.FromBase64String(callData.Signatures[0]));
-            Assert.Equal(new byte[] { 7, 8, 9 }, Convert.FromBase64String(callData.Signatures[1]));
         }
 
         [Fact]

--- a/src/Stratis.SmartContracts.CLR/CallDataSerializer.cs
+++ b/src/Stratis.SmartContracts.CLR/CallDataSerializer.cs
@@ -63,9 +63,8 @@ namespace Stratis.SmartContracts.CLR
 
             var contractExecutionCode = this.primitiveSerializer.Deserialize<byte[]>(decodedParams[0]);
             object[] methodParameters = this.DeserializeMethodParameters(decodedParams[1]);
-            string[] signatures = (decodedParams.Count > 2) ? this.DeserializeSignatures(decodedParams[2]) : null;
 
-            var callData = new ContractTxData(vmVersion, gasPrice, gasLimit, contractExecutionCode, methodParameters, signatures);
+            var callData = new ContractTxData(vmVersion, gasPrice, gasLimit, contractExecutionCode, methodParameters);
             return Result.Ok(callData);
         }
 
@@ -81,9 +80,8 @@ namespace Stratis.SmartContracts.CLR
 
             string methodName = this.primitiveSerializer.Deserialize<string>(decodedParams[0]);
             object[] methodParameters = this.DeserializeMethodParameters(decodedParams[1]);
-            string[] signatures = (decodedParams.Count > 2) ? this.DeserializeSignatures(decodedParams[2]) : null;
 
-            var callData = new ContractTxData(vmVersion, gasPrice, gasLimit, contractAddress, methodName, methodParameters, signatures);
+            var callData = new ContractTxData(vmVersion, gasPrice, gasLimit, contractAddress, methodName, methodParameters);
             return Result.Ok(callData);
         }
 
@@ -108,8 +106,6 @@ namespace Stratis.SmartContracts.CLR
             rlpBytes.Add(contractTxData.ContractExecutionCode);
             
             this.AddMethodParams(rlpBytes, contractTxData.MethodParameters);
-            if (contractTxData.Signatures != null)
-                this.AddSignatures(rlpBytes, contractTxData.Signatures);
             
             byte[] encoded = RLP.EncodeList(rlpBytes.Select(RLP.EncodeElement).ToArray());
             
@@ -129,8 +125,6 @@ namespace Stratis.SmartContracts.CLR
             rlpBytes.Add(this.primitiveSerializer.Serialize(contractTxData.MethodName));
 
             this.AddMethodParams(rlpBytes, contractTxData.MethodParameters);
-            if (contractTxData.Signatures != null)
-                this.AddSignatures(rlpBytes, contractTxData.Signatures);
 
             byte[] encoded = RLP.EncodeList(rlpBytes.Select(RLP.EncodeElement).ToArray());
             
@@ -168,18 +162,6 @@ namespace Stratis.SmartContracts.CLR
             }
         }
 
-        /// <summary>
-        /// Adds the passed signatures to the passed list of byte arrays.
-        /// </summary>
-        /// <param name="rlpBytes">The list of byte arrays to add the signatures to.</param>
-        /// <param name="signatures">The signatures as a base 64 encoded byte array. See <see cref="SerializeSignatures(string[])"/></param>
-        protected void AddSignatures(List<byte[]> rlpBytes, string[] signatures)
-        {
-            Guard.NotNull(signatures, nameof(signatures));
-
-            rlpBytes.Add(this.SerializeSignatures(signatures));
-        }
-
         protected static bool IsCallContract(byte type)
         {
             return type == (byte)ScOpcodeType.OP_CALLCONTRACT;
@@ -198,57 +180,6 @@ namespace Stratis.SmartContracts.CLR
                 methodParameters = this.methodParamSerializer.Deserialize(methodParametersRaw);
 
             return methodParameters;
-        }
-
-        /// <summary>
-        /// Serializes the signatures.
-        /// </summary>
-        /// <param name="signatures">Signatures passed as an array of base 64 encoded byte arrays.</param>
-        /// <returns>A byte array containing the decoded signatures, where each signature is prefixed by its length.</returns>
-        protected byte[] SerializeSignatures(string[] signatures)
-        {
-            byte[][] signaturesRaw = new byte[signatures.Length][];
-            int totalBytes = 0;
-            for (int i = 0; i < signatures.Length; i++)
-            {
-                signaturesRaw[i] = Convert.FromBase64String(signatures[i]);
-                totalBytes += signaturesRaw[i].Length + 1;
-            }
-
-            var res = new byte[totalBytes];
-            totalBytes = 0;
-            for (int i = 0; i < signatures.Length; i++)
-            {
-                res[totalBytes] = (byte)signaturesRaw[i].Length;
-                signaturesRaw[i].CopyTo(res, totalBytes + 1);
-                totalBytes += signaturesRaw[i].Length + 1;
-            }
-
-            return res;
-        }
-
-        /// <summary>
-        /// Deserializes signatures.
-        /// </summary>
-        /// <param name="signaturesRaw">A byte array containing the decoded signatures, where each signature is prefixed by its length.</param>
-        /// <returns>Signatures as an array of base 64 encoded byte arrays.</returns>
-        protected string[] DeserializeSignatures(byte[] signaturesRaw)
-        {
-            if (signaturesRaw == null || signaturesRaw.Length == 0)
-                return new string[0];
-
-            var signatures = new List<string>();
-
-            for (int i = 0; i < signaturesRaw.Length; i++)
-            {
-                int length = signaturesRaw[i];
-                var buffer = new byte[length];
-                Array.Copy(signaturesRaw, i + 1, buffer, 0, length);
-                i += length;
-                signatures.Add(Convert.ToBase64String(buffer));
-            }
-
-            return signatures.ToArray();
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/ContractTxData.cs
+++ b/src/Stratis.SmartContracts.CLR/ContractTxData.cs
@@ -11,7 +11,7 @@ namespace Stratis.SmartContracts.CLR
         /// Creates a ContractTxData object for a method invocation
         /// </summary>
         public ContractTxData(int vmVersion, ulong gasPrice, RuntimeObserver.Gas gasLimit, uint160 contractAddress,
-            string method, object[] methodParameters = null, string[] signatures = null)
+            string method, object[] methodParameters = null)
         {
             this.OpCodeType = (byte) ScOpcodeType.OP_CALLCONTRACT;
             this.VmVersion = vmVersion;
@@ -21,14 +21,12 @@ namespace Stratis.SmartContracts.CLR
             this.MethodName = method;
             this.MethodParameters = methodParameters;
             this.ContractExecutionCode = new byte[0];
-            this.Signatures = signatures;
         }
 
         /// <summary>
         /// Creates a ContractTxData for contract creation
         /// </summary>
-        public ContractTxData(int vmVersion, ulong gasPrice, RuntimeObserver.Gas gasLimit, byte[] code,
-            object[] methodParameters = null, string[] signatures = null)
+        public ContractTxData(int vmVersion, ulong gasPrice, RuntimeObserver.Gas gasLimit, byte[] code, object[] methodParameters = null)
         {
             this.OpCodeType = (byte)ScOpcodeType.OP_CREATECONTRACT;
             this.VmVersion = vmVersion;
@@ -38,7 +36,6 @@ namespace Stratis.SmartContracts.CLR
             this.MethodName = "";
             this.MethodParameters = methodParameters;
             this.ContractAddress = uint160.Zero;
-            this.Signatures = signatures;
         }
 
         /// <summary>The method name of the contract that will be executed.</summary>
@@ -64,9 +61,6 @@ namespace Stratis.SmartContracts.CLR
 
         /// <summary>The contract code that will be executed.</summary>
         public byte[] ContractExecutionCode { get; }
-
-        /// <summary>The signatures (if any) passed as an array of base 64 encoded byte arrays - as returned by <see cref="Key.SignMessage"/>.</summary>
-        public string[] Signatures { get; }
 
         /// <summary>The maximum cost (in satoshi) the contract can spend.</summary>
         public ulong GasCostBudget


### PR DESCRIPTION
Removes signature field and references from `ContractTxData`.

Adds SystemContractContainer:
```
    public interface ISystemContractContainer
    {
        /// <summary>
        /// Determines if the contract with the specified hash is active.
        /// </summary>
        /// <param name="hash">Pseudo "transaction hash" identifying the contract.</param>
        /// <param name="previousHeader">Previous header of block to check the activation state at.</param>
        /// <param name="deploymentCondition">Function that determines if the contract is active based on previous header and deployment number.</param>
        /// <returns><c>True</c> if the contract is active and <c>false</c> otherwise.</returns>        
        bool IsActive(uint256 hash, ChainedHeader previousHeader, Func<ChainedHeader, int, bool> deploymentCondition);
        
        /// <summary>
        /// Returns the pseudo transaction-hashes of all defined contracts, whether active or inactive.
        /// </summary>
        /// <returns></returns>
        IEnumerable<uint256> ContractHashes();
        
        /// <summary>
        /// Extracts the contract type and version from a contract hash.
        /// </summary>
        /// <param name="hash">The hash to extract the contract type and version of.</param>
        /// <returns>The contract type and version.</returns>
        (Type contractType, uint version) GetContractTypeAndVersion(uint256 hash);
    }
```

Version should be passed to system contract constructor. Each network class defines its embedded contracts as follows:
```
            // Specifies that class SystemContractDictionary will go active when the "SystemContracts" deployment goes active.
            this.SystemContractContainer = new SystemContractContainer(
                this, /* Network class */
                new Dictionary<KeyId, Type> { { 1, typeof(SystemContractDictionary) } }, /* Maps classes to contract type identifiers (gets encoded in the hash) */
                new Dictionary<uint256, (int start, int? end)[]> { }, /* Retains contract legacy despite any BIP 9 deployments array clean-up */
                new Dictionary<uint256, (string, bool)> { { SystemContractContainer.GetPseudoHash(1, 0 /* version */), ("SystemContracts" /* BIP9 */, true) } });
```

@rowandh , Note that the `PoSWhitelistedHashChecker` utilizes the above class in its `CheckHashWhitelisted` method. This would be the appropriate method to use when checking the "executability" of system contracts.