### PR TITLE
Add delete chainstate endpoint

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/NodeController.cs
+++ b/src/Stratis.Bitcoin.Features.Api/NodeController.cs
@@ -664,6 +664,19 @@ namespace Stratis.Bitcoin.Features.Api
         }
 
         /// <summary>
+        /// Schedules data folder storing chain state in the <see cref="DataFolder"/> for deletion on the next graceful shutdown.
+        /// </summary>
+        /// <returns></returns>
+        [HttpDelete]
+        [Route("datafolder/chain")]
+        public IActionResult DeleteChain()
+        {
+            this.nodeSettings.DataFolder.ScheduleChainDeletion();
+
+            return Ok();
+        }
+
+        /// <summary>
         /// Retrieves a transaction block given a valid hash.
         /// This function is used by other methods in this class and not explicitly by RPC/API.
         /// </summary>

--- a/src/Stratis.Bitcoin/Configuration/DataFolder.cs
+++ b/src/Stratis.Bitcoin/Configuration/DataFolder.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Linq;
 using System.Net;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
@@ -103,5 +104,37 @@ namespace Stratis.Bitcoin.Configuration
 
         /// <summary>Path to the folder for <see cref="ProvenBlockHeader"/> items database files.</summary>
         public string ProvenBlockHeaderPath { get; set; }
+
+        /// <summary></summary>
+        public bool ScheduledChainDeletion { get; private set; }
+
+        /// <summary>
+        /// Schedule the data folders storing chain state for deletion on the next graceful shutdown.
+        /// </summary>
+        public void ScheduleChainDeletion()
+        {
+            this.ScheduledChainDeletion = true;
+        }
+
+        /// <summary>
+        /// Deletes all directories that may be problematic for syncing. Will not delete a directory if it contains any files with a *.db extension.
+        /// This should not be called while the node is running.
+        /// </summary>
+        public void DeleteChainDirectories()
+        {
+            var dirsForDeletion = new string[] { BlockPath, ChainPath, CoindbPath, KeyValueRepositoryPath, SmartContractStatePath, ProvenBlockHeaderPath };
+
+            foreach (var dir in dirsForDeletion.Select(dir => new DirectoryInfo(dir)))
+            {
+                if (!dir.Exists)
+                    continue;
+
+                // Ignore any directories that contain suspected wallets.
+                if (dir.EnumerateFiles("*.db").Any())
+                    continue;
+
+                dir.Delete(true);
+            }
+        }
     }
 }

--- a/src/Stratis.Bitcoin/Configuration/DataFolder.cs
+++ b/src/Stratis.Bitcoin/Configuration/DataFolder.cs
@@ -105,7 +105,7 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>Path to the folder for <see cref="ProvenBlockHeader"/> items database files.</summary>
         public string ProvenBlockHeaderPath { get; set; }
 
-        /// <summary></summary>
+        /// <summary>True if the chain state directories are scheduled for deletion on the next graceful shutdown.</summary>
         public bool ScheduledChainDeletion { get; private set; }
 
         /// <summary>

--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -326,6 +326,12 @@ namespace Stratis.Bitcoin
             if (this.nodeRunningLock != null)
                 this.nodeRunningLock.UnlockNodeFolder();
 
+            if (this.DataFolder.ScheduledChainDeletion)
+            {
+                this.logger.LogInformation("Deleting chain state data directories.");
+                this.DataFolder.DeleteChainDirectories();
+            }
+
             this.State = FullNodeState.Disposed;
         }
     }


### PR DESCRIPTION
Adds the ability to schedule the chain state folders for deletion upon graceful shutdown. This is currently used as a solution to common syncing problems.