### PR TITLE
[Base] Add dispose last flag

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiFeature.cs
@@ -47,6 +47,7 @@ namespace Stratis.Bitcoin.Features.Api
             this.certificateStore = certificateStore;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
 
+            this.DisposeLast = true;
             this.InitializeBeforeBase = true;
         }
 

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureCollectionTest.cs
@@ -34,6 +34,9 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         private class FeatureCollectionFullNodeFeature : IFullNodeFeature
         {
             /// <inheritdoc />
+            public bool DisposeLast { get; set; }
+
+            /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
 
             public FeatureInitializationState State { get; set; }

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeatureRegistrationTest.cs
@@ -105,6 +105,9 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
 
         private class FeatureRegistrationFullNodeFeature : IFullNodeFeature
         {
+            /// <inheritdoc />
+            public bool DisposeLast { get; set; }
+
             public bool InitializeBeforeBase { get; set; }
 
             public FeatureInitializationState State { get; set; }

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesDependencyCheckingTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesDependencyCheckingTest.cs
@@ -22,6 +22,9 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         private class FeatureBase : IFullNodeFeature
         {
             /// <inheritdoc />
+            public bool DisposeLast { get; set; }
+
+            /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
 
             public FeatureInitializationState State { get; set; }

--- a/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/Feature/FeaturesExtensionsTest.cs
@@ -20,6 +20,9 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         private class FeatureA : IFullNodeFeature
         {
             /// <inheritdoc />
+            public bool DisposeLast { get; set; }
+
+            /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
 
             public FeatureInitializationState State { get; set; }
@@ -61,6 +64,9 @@ namespace Stratis.Bitcoin.Tests.Builder.Feature
         /// </summary>
         private class FeatureB : IFullNodeFeature
         {
+            /// <inheritdoc />
+            public bool DisposeLast { get; set; }
+
             /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
 

--- a/src/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Builder/FullNodeServiceProviderTest.cs
@@ -57,6 +57,9 @@ namespace Stratis.Bitcoin.Tests.Builder
         private class TestFeatureStub : IFullNodeFeature
         {
             /// <inheritdoc />
+            public bool DisposeLast { get; set; }
+
+            /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
 
             public FeatureInitializationState State { get; set; }
@@ -95,6 +98,9 @@ namespace Stratis.Bitcoin.Tests.Builder
 
         private class TestFeatureStub2 : IFullNodeFeature
         {
+            /// <inheritdoc />
+            public bool DisposeLast { get; set; }
+
             /// <inheritdoc />
             public bool InitializeBeforeBase { get; set; }
 

--- a/src/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
+++ b/src/Stratis.Bitcoin/Builder/Feature/FullNodeFeature.cs
@@ -19,6 +19,11 @@ namespace Stratis.Bitcoin.Builder.Feature
     public interface IFullNodeFeature : IDisposable
     {
         /// <summary>
+        /// Instructs the <see cref="FullNodeFeatureExecutor"/> to order and dispose this feature last.
+        /// </summary>
+        bool DisposeLast { get; set; }
+
+        /// <summary>
         /// Instructs the <see cref="FullNodeFeatureExecutor"/> to start this feature before the <see cref="Base.BaseFeature"/>.
         /// </summary>
         bool InitializeBeforeBase { get; set; }
@@ -58,6 +63,9 @@ namespace Stratis.Bitcoin.Builder.Feature
     public abstract class FullNodeFeature : IFullNodeFeature
     {
         private const float InitializationWaitSeconds = 1.0f;
+
+        /// <inheritdoc />
+        public bool DisposeLast { get; set; }
 
         /// <inheritdoc />
         public bool InitializeBeforeBase { get; set; }

--- a/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -113,7 +113,8 @@ namespace Stratis.Bitcoin.Builder
             if (disposing)
             {
                 // When the node is shutting down, we need to dispose all features, so we don't break on exception.
-                foreach (IFullNodeFeature feature in this.fullNode.Services.Features.Reverse())
+                var r = this.fullNode.Services.Features.Reverse().OrderBy(f => f.DisposeLast);
+                foreach (IFullNodeFeature feature in this.fullNode.Services.Features.Reverse().OrderBy(f => f.DisposeLast))
                 {
                     try
                     {

--- a/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
+++ b/src/Stratis.Bitcoin/Builder/FullNodeFeatureExecutor.cs
@@ -113,7 +113,6 @@ namespace Stratis.Bitcoin.Builder
             if (disposing)
             {
                 // When the node is shutting down, we need to dispose all features, so we don't break on exception.
-                var r = this.fullNode.Services.Features.Reverse().OrderBy(f => f.DisposeLast);
                 foreach (IFullNodeFeature feature in this.fullNode.Services.Features.Reverse().OrderBy(f => f.DisposeLast))
                 {
                     try


### PR DESCRIPTION
This is so that we can, for instance, dispose the API last.

The UI client will then be able to call the API right up until the last feature is disposed.