### PR TITLE
[Cirrus Polls] Improve voting repo sync and add tip to idle kicker

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/TestPoAMiner.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/TestPoAMiner.cs
@@ -37,6 +37,7 @@ namespace Stratis.Bitcoin.Features.PoA.IntegrationTests.Common
             IConnectionManager connectionManager,
             PoABlockHeaderValidator poaHeaderValidator,
             IFederationManager federationManager,
+            IFederationHistory federationHistory,
             IIntegrityValidator integrityValidator,
             IWalletManager walletManager,
             INodeStats nodeStats,
@@ -46,7 +47,7 @@ namespace Stratis.Bitcoin.Features.PoA.IntegrationTests.Common
             IIdleFederationMembersKicker idleFederationMembersKicker,
             NodeSettings nodeSettings)
             : base(consensusManager, dateTimeProvider, network, nodeLifetime, loggerFactory, ibdState, blockDefinition, slotsManager,
-                connectionManager, poaHeaderValidator, federationManager, integrityValidator, walletManager, nodeStats, votingManager, poAMinerSettings, asyncProvider, idleFederationMembersKicker, nodeSettings)
+                connectionManager, poaHeaderValidator, federationManager, federationHistory, integrityValidator, walletManager, nodeStats, votingManager, poAMinerSettings, asyncProvider, idleFederationMembersKicker, nodeSettings)
         {
             this.timeProvider = dateTimeProvider as EditableTimeProvider;
 

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -140,7 +140,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             });
 
             federationHistory
-                .Setup(x => x.GetFederationMemberForTimestamp(It.IsAny<uint>(), It.IsAny<PoAConsensusOptions>()))
+                .Setup(x => x.GetFederationMemberForTimestamp(It.IsAny<uint>(), It.IsAny<PoAConsensusOptions>(), It.IsAny<List<IFederationMember>>()))
                 .Returns<uint, PoAConsensusOptions>((headerUnixTimestamp, poAConsensusOptions) =>
                 {
                     List<IFederationMember> federationMembers = poAConsensusOptions.GenesisFederationMembers;

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -127,13 +127,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
                 List<IFederationMember> members = ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;
                 return members[chainedHeader.Height % members.Count];
             });
-            /*
-            federationHistory.Setup(x => x.GetFederationMemberForBlock(It.IsAny<ChainedHeader>(), It.IsAny<List<IFederationMember>>())).Returns<ChainedHeader, List<IFederationMember>>((chainedHeader, members) =>
-            {
-                members = members ?? ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;
-                return members[chainedHeader.Height % members.Count];
-            });
-            */
+
             federationHistory.Setup(x => x.GetFederationForBlock(It.IsAny<ChainedHeader>())).Returns<ChainedHeader>((chainedHeader) =>
             {
                 return ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -133,23 +133,6 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
                 return ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;
             });
 
-            federationHistory
-                .Setup(x => x.GetFederationMemberForTimestamp(It.IsAny<uint>(), It.IsAny<PoAConsensusOptions>(), It.IsAny<List<IFederationMember>>()))
-                .Returns<uint, PoAConsensusOptions, List<IFederationMember>>((headerUnixTimestamp, poAConsensusOptions, federation) =>
-                {
-                    List<IFederationMember> federationMembers = federation ?? poAConsensusOptions.GenesisFederationMembers;
-
-                    uint roundTime = (uint)(federationMembers.Count * poAConsensusOptions.TargetSpacingSeconds);
-
-                    // Time when current round started.
-                    uint roundStartTimestamp = (headerUnixTimestamp / roundTime) * roundTime;
-
-                    // Slot number in current round.
-                    int currentSlotNumber = (int)((headerUnixTimestamp - roundStartTimestamp) / poAConsensusOptions.TargetSpacingSeconds);
-
-                    return federationMembers[currentSlotNumber];
-                });
-
             votingManager.Initialize(federationHistory.Object);
             fullNode.Setup(x => x.NodeService<VotingManager>(It.IsAny<bool>())).Returns(votingManager);
             federationManager.Initialize();

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -141,9 +141,9 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
 
             federationHistory
                 .Setup(x => x.GetFederationMemberForTimestamp(It.IsAny<uint>(), It.IsAny<PoAConsensusOptions>(), It.IsAny<List<IFederationMember>>()))
-                .Returns<uint, PoAConsensusOptions>((headerUnixTimestamp, poAConsensusOptions) =>
+                .Returns<uint, PoAConsensusOptions, List<IFederationMember>>((headerUnixTimestamp, poAConsensusOptions, federation) =>
                 {
-                    List<IFederationMember> federationMembers = poAConsensusOptions.GenesisFederationMembers;
+                    List<IFederationMember> federationMembers = federation ?? poAConsensusOptions.GenesisFederationMembers;
 
                     uint roundTime = (uint)(federationMembers.Count * poAConsensusOptions.TargetSpacingSeconds);
 

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -127,13 +127,13 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
                 List<IFederationMember> members = ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;
                 return members[chainedHeader.Height % members.Count];
             });
-
+            /*
             federationHistory.Setup(x => x.GetFederationMemberForBlock(It.IsAny<ChainedHeader>(), It.IsAny<List<IFederationMember>>())).Returns<ChainedHeader, List<IFederationMember>>((chainedHeader, members) =>
             {
                 members = members ?? ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;
                 return members[chainedHeader.Height % members.Count];
             });
-
+            */
             federationHistory.Setup(x => x.GetFederationForBlock(It.IsAny<ChainedHeader>())).Returns<ChainedHeader>((chainedHeader) =>
             {
                 return ((PoAConsensusOptions)network.Consensus.Options).GenesisFederationMembers;

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -49,8 +49,6 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
             var header = chainedHeader.Header as PoABlockHeader;
 
-            List<IFederationMember> federation = this.federationHistory.GetFederationForBlock(chainedHeader);
-
             PubKey pubKey = this.federationHistory.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate)?.PubKey;
 
             if (pubKey == null || !this.validator.VerifySignature(pubKey, header))
@@ -72,7 +70,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             }
 
             // Look at the last round of blocks to find the previous time that the miner mined.
-            var roundTime = this.slotsManager.GetRoundLength(federation.Count);
+            var roundTime = this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(chainedHeader).Count);
             int blockCounter = 0;
 
             for (ChainedHeader prevHeader = chainedHeader.Previous; prevHeader.Previous != null; prevHeader = prevHeader.Previous)

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
@@ -28,10 +26,6 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
         private Network network;
 
-        // Tracks mining activity and federation size for one round's worth of blocks.
-        private List<(PubKey pubKey, int federationSize, DateTimeOffset blockTime)> activity;
-        private ChainedHeader activityTip;
-
         /// <inheritdoc />
         public override void Initialize()
         {
@@ -45,8 +39,6 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             this.validator = engine.PoaHeaderValidator;
             this.chainState = engine.ChainState;
             this.network = this.Parent.Network;
-            this.activity = new List<(PubKey pubKey, int federationSize, DateTimeOffset blockTime)>();
-            this.activityTip = null;
 
             this.maxReorg = this.network.Consensus.MaxReorgLength;
         }
@@ -59,7 +51,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
             List<IFederationMember> federation = this.federationHistory.GetFederationForBlock(chainedHeader);
 
-            PubKey pubKey = this.federationHistory.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate/*, federation*/)?.PubKey;
+            PubKey pubKey = this.federationHistory.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate)?.PubKey;
 
             if (pubKey == null || !this.validator.VerifySignature(pubKey, header))
             {
@@ -83,45 +75,26 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             var roundTime = this.slotsManager.GetRoundLength(federation.Count);
             int blockCounter = 0;
 
-            var headers = chainedHeader.Previous
-                .EnumerateToGenesis()
-                .TakeWhile(h => (header.BlockTime - h.Header.BlockTime) >= roundTime && !(this.activityTip?.HashBlock == h.HashBlock))
-                .Reverse()
-                .ToArray();
-
-
-            if (headers.FirstOrDefault()?.Previous?.HashBlock != this.activityTip?.HashBlock)
-                this.activity.Clear();
-
-            (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> _)[] federations) = this.federationHistory.GetFederationMembersForBlocks(headers);
-
-            this.activity.AddRange(Enumerable.Range(0, miners.Length)
-                .Select(i => (miners[i].PubKey, federations[i].members.Count, headers[i].Header.BlockTime)));
-
-            this.activityTip = chainedHeader.Previous;
-
-            for (int i = this.activity.Count - 1; i >= 0; i--)
+            for (ChainedHeader prevHeader = chainedHeader.Previous; prevHeader.Previous != null; prevHeader = prevHeader.Previous)
             {
                 blockCounter += 1;
 
-                (PubKey miner, int federationSize, DateTimeOffset blockTime) = this.activity[i];
-
-                if ((header.BlockTime - blockTime) >= roundTime)
+                if ((header.BlockTime - prevHeader.Header.BlockTime) >= roundTime)
                     break;
 
                 // If the miner is found again within the same round then throw a consensus error.
-                if (miner != pubKey)
+                if (this.federationHistory.GetFederationMemberForBlock(prevHeader)?.PubKey != pubKey)
                     continue;
 
                 // Mining slots shift when the federation changes. 
                 // Only raise an error if the federation did not change.
-                if (federationSize != federation.Count)
+                if (this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(prevHeader).Count) != roundTime)
                     break;
 
-                if (this.activity[i - 1].federationSize != federation.Count)
+                if (this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(prevHeader.Previous).Count) != roundTime)
                     break;
 
-                this.Logger.LogDebug("Block was mined by the same miner '{0}' as {1} blocks ({2})s ago and there was no federation change.", pubKey.ToHex(), blockCounter, (header.BlockTime - blockTime).TotalSeconds);
+                this.Logger.LogDebug("Block {0} was mined by the same miner '{1}' as {2} blocks ({3})s ago and there was no federation change.", prevHeader.HashBlock, pubKey.ToHex(), blockCounter, header.Time - prevHeader.Header.Time);
                 this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
                 ConsensusErrors.BlockTimestampTooEarly.Throw();
             }

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -110,14 +110,6 @@ namespace Stratis.Bitcoin.Features.PoA
             }
         }
 
-        private int GetVotingManagerV2ActivationHeight()
-        {
-            if (this.network.Consensus.Options is PoAConsensusOptions poaConsensusOptions)
-                return (poaConsensusOptions.VotingManagerV2ActivationHeight == 0) ? int.MaxValue : poaConsensusOptions.VotingManagerV2ActivationHeight;
-
-            return 0;
-        }
-
         private (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) GetFederationMembersForBlocks(ChainedHeader[] chainedHeaders)
         {
             (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations;
@@ -132,7 +124,7 @@ namespace Stratis.Bitcoin.Features.PoA
             PoABlockHeader[] headers = chainedHeaders.Select(h => (PoABlockHeader)h.Header).ToArray();
 
             // Reading chainedHeader's "Header" does not play well with asynchronocity so we will load the block times here.
-            int votingManagerV2ActivationHeight = GetVotingManagerV2ActivationHeight();
+            int votingManagerV2ActivationHeight = (this.network.Consensus.Options as PoAConsensusOptions).VotingManagerV2ActivationHeight;
 
             Parallel.For(0, chainedHeaders.Length, i => miners[i] = GetFederationMemberForBlock(headers[i], federations[i].members, chainedHeaders[i].Height >= votingManagerV2ActivationHeight));
 

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -39,6 +39,11 @@ namespace Stratis.Bitcoin.Features.PoA
         /// </summary>
         /// <returns>A list of public keys and the times at which they were active.</returns>
         ConcurrentDictionary<IFederationMember, uint> GetFederationMembersByLastActiveTime();
+
+        /// <summary>
+        /// Initializes this component.
+        /// </summary>
+        void Initialize();
     }
 
     /// <summary>
@@ -70,6 +75,11 @@ namespace Stratis.Bitcoin.Features.PoA
             this.lastActiveTimeByPubKey = new ConcurrentDictionary<PubKey, List<uint>>();
             this.federationHistory = new SortedDictionary<uint, (List<IFederationMember>, IFederationMember)>();
             this.lastActiveTip = null;
+        }
+
+        public void Initialize()
+        {
+            GetFederationForBlock(this.chainIndexer.Tip);
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -255,9 +255,12 @@ namespace Stratis.Bitcoin.Features.PoA
 
             var federationMemberActivationTime = ((PoAConsensusOptions)this.network.Consensus.Options).FederationMemberActivationTime ?? 0;
 
+            uint maxInactiveTime = ((PoAConsensusOptions)this.network.Consensus.Options).FederationMemberMaxIdleTimeSeconds;
+            uint blockTime = blockHeader.Header.Time;
+
             ChainedHeader[] headers = blockHeader
                 .EnumerateToGenesis()
-                .TakeWhile(h => h.HashBlock != this.lastActiveTip?.HashBlock && h.Header.Time >= federationMemberActivationTime)
+                .TakeWhile(h => h.HashBlock != this.lastActiveTip?.HashBlock && (h.Header.Time + maxInactiveTime) >= blockTime && h.Header.Time >= federationMemberActivationTime)
                 .Reverse().ToArray();
 
             if (headers.Length != 0)

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -31,7 +31,7 @@ namespace Stratis.Bitcoin.Features.PoA
         /// and then the signature in <see cref="PoABlockHeader.BlockSignature"/>.</summary>
         /// <param name="chainedHeaders">Identifies the blocks and timestamps.</param>
         /// <returns>The federation member or <c>null</c> if the member could not be determined, as well as the federations.</returns>
-        (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) GetFederationMembersForBlocks(ChainedHeader[] chainedHeaders, bool forceV2 = false);
+        (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) GetFederationMembersForBlocks(ChainedHeader[] chainedHeaders);
 
         /// <summary>Gets the federation for a specified block.</summary>
         /// <param name="chainedHeader">Identifies the block and timestamp.</param>
@@ -101,7 +101,7 @@ namespace Stratis.Bitcoin.Features.PoA
         }
 
         /// <inheritdoc />
-        public (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) GetFederationMembersForBlocks(ChainedHeader[] chainedHeaders, bool forceV2 = false)
+        public (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) GetFederationMembersForBlocks(ChainedHeader[] chainedHeaders)
         {
             (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations = this.votingManager.GetModifiedFederations(chainedHeaders).ToArray();
             IFederationMember[] miners = new IFederationMember[chainedHeaders.Length];
@@ -110,7 +110,7 @@ namespace Stratis.Bitcoin.Features.PoA
             // Reading chainedHeader's "Header" does not play well with asynchronocity so we will load the block times here.
             int votingManagerV2ActivationHeight = GetVotingManagerV2ActivationHeight();
 
-            Parallel.For(0, chainedHeaders.Length, i => miners[i] = GetFederationMemberForBlock(headers[i], federations[i].members, forceV2 || chainedHeaders[i].Height >= votingManagerV2ActivationHeight));
+            Parallel.For(0, chainedHeaders.Length, i => miners[i] = GetFederationMemberForBlock(headers[i], federations[i].members, chainedHeaders[i].Height >= votingManagerV2ActivationHeight));
 
             if (chainedHeaders.FirstOrDefault()?.Height == 0)
                 miners[0] = federations[0].members.Last();

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using NBitcoin;
 using NBitcoin.Crypto;
 using Stratis.Bitcoin.Features.PoA.Voting;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.PoA
 {
@@ -17,21 +18,6 @@ namespace Stratis.Bitcoin.Features.PoA
         /// <returns>The federation member or <c>null</c> if the member could not be determined.</returns>
         /// <exception cref="ConsensusErrorException">In case timestamp is invalid.</exception>
         IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader);
-
-        /// <summary>Gets the miner for a specified block by first looking at a cache 
-        /// and then the signature in <see cref="PoABlockHeader.BlockSignature"/>.</summary>
-        /// <param name="chainedHeader">Identifies the block and timestamp.</param>
-        /// <param name="federation">The federation members at the block height.</param>
-        /// <returns>The federation member or <c>null</c> if the member could not be determined.</returns>
-        IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader, List<IFederationMember> federation);
-
-        IFederationMember GetFederationMemberForBlock(PoABlockHeader blockHeader, List<IFederationMember> federation, bool votingManagerV2);
-
-        /// <summary>Gets the miner (and federation) for the specified blocks by first looking at a cache 
-        /// and then the signature in <see cref="PoABlockHeader.BlockSignature"/>.</summary>
-        /// <param name="chainedHeaders">Identifies the blocks and timestamps.</param>
-        /// <returns>The federation member or <c>null</c> if the member could not be determined, as well as the federations.</returns>
-        (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) GetFederationMembersForBlocks(ChainedHeader[] chainedHeaders);
 
         /// <summary>Gets the federation for a specified block.</summary>
         /// <param name="chainedHeader">Identifies the block and timestamp.</param>
@@ -45,10 +31,19 @@ namespace Stratis.Bitcoin.Features.PoA
         IFederationMember GetFederationMemberForTimestamp(uint headerUnixTimestamp, PoAConsensusOptions poAConsensusOptions, List<IFederationMember> federationMembers = null);
 
         /// <summary>
-        /// Determines the height from which the voting manager v2 is active.
+        /// Determines when a federation member was last active. This includes mining or joining.
         /// </summary>
-        /// <returns>The height from which the voting manager v2 is active.</returns>
-        int GetVotingManagerV2ActivationHeight();
+        /// <param name="federationMember">Member to check activity of.</param>
+        /// <param name="blockHeader">Block at which to check for past activity.</param>
+        /// <param name="lastActiveTime">Time at which member was last active.</param>
+        /// <returns><c>True</c> if the information is available and <c>false</c> otherwise.</returns>
+        bool GetLastActiveTime(IFederationMember federationMember, ChainedHeader blockHeader, out uint lastActiveTime);
+
+        /// <summary>
+        /// Determines when the current federation members were last active. This includes mining or joining.
+        /// </summary>
+        /// <returns>A list of public keys and the times at which they were active.</returns>
+        ConcurrentDictionary<IFederationMember, uint> GetFederationMembersByLastActiveTime();
     }
 
     /// <summary>
@@ -60,30 +55,62 @@ namespace Stratis.Bitcoin.Features.PoA
     {
         private readonly IFederationManager federationManager;
         private readonly VotingManager votingManager;
+        private readonly ChainIndexer chainIndexer;
         private readonly Network network;
         private readonly ConcurrentDictionary<uint256, PubKey[]> candidatesByBlockHash;
+        private readonly object lockObject;
 
-        public FederationHistory(IFederationManager federationManager, Network network, VotingManager votingManager = null)
+        private SortedDictionary<uint, (List<IFederationMember>, IFederationMember)> federationHistory;
+        private ConcurrentDictionary<PubKey, List<uint>> lastActiveTimeByPubKey;
+        private ChainedHeader lastActiveTip;
+
+        public FederationHistory(IFederationManager federationManager, Network network, VotingManager votingManager = null, ChainIndexer chainIndexer = null)
         {
             this.federationManager = federationManager;
             this.votingManager = votingManager;
+            this.chainIndexer = chainIndexer;
             this.network = network;
             this.candidatesByBlockHash = new ConcurrentDictionary<uint256, PubKey[]>();
+            this.lockObject = new object();
+            this.lastActiveTimeByPubKey = new ConcurrentDictionary<PubKey, List<uint>>();
+            this.federationHistory = new SortedDictionary<uint, (List<IFederationMember>, IFederationMember)>();
+            this.lastActiveTip = null;
         }
 
         /// <inheritdoc />
         public List<IFederationMember> GetFederationForBlock(ChainedHeader chainedHeader)
         {
-            return (this.votingManager == null) ? this.federationManager.GetFederationMembers() : this.votingManager.GetModifiedFederation(chainedHeader);
+            lock (this.lockObject)
+            {
+                this.UpdateTip(chainedHeader);
+
+                if (this.federationHistory.TryGetValue(chainedHeader.Header.Time, out (List<IFederationMember> modifiedFederation, IFederationMember miner) item))
+                    return item.modifiedFederation;
+
+                return (this.votingManager == null) ? this.federationManager.GetFederationMembers() : this.votingManager.GetModifiedFederation(chainedHeader);
+            }
         }
 
         /// <inheritdoc />
         public IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader)
         {
-            return GetFederationMemberForBlock(chainedHeader, this.GetFederationForBlock(chainedHeader));
+            lock (this.lockObject)
+            {
+                this.UpdateTip(chainedHeader);
+
+                if (this.federationHistory.TryGetValue(chainedHeader.Header.Time, out (List<IFederationMember> modifiedFederation, IFederationMember miner) item))
+                    return item.miner;
+
+                List<IFederationMember> federation = (this.votingManager == null) ? this.federationManager.GetFederationMembers() : this.votingManager.GetModifiedFederation(chainedHeader);
+
+                if (chainedHeader.Height == 0)
+                    return federation.Last();
+
+                return GetFederationMemberForBlock(chainedHeader.Header as PoABlockHeader, federation, chainedHeader.Height >= this.GetVotingManagerV2ActivationHeight());
+            }
         }
 
-        public int GetVotingManagerV2ActivationHeight()
+        private int GetVotingManagerV2ActivationHeight()
         {
             if (this.network.Consensus.Options is PoAConsensusOptions poaConsensusOptions)
                 return (poaConsensusOptions.VotingManagerV2ActivationHeight == 0) ? int.MaxValue : poaConsensusOptions.VotingManagerV2ActivationHeight;
@@ -91,17 +118,7 @@ namespace Stratis.Bitcoin.Features.PoA
             return 0;
         }
 
-        /// <inheritdoc />
-        public IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader, List<IFederationMember> federation)
-        {
-            if (chainedHeader.Height == 0)
-                return federation.Last();
-
-            return GetFederationMemberForBlock(chainedHeader.Header as PoABlockHeader, federation, chainedHeader.Height >= this.GetVotingManagerV2ActivationHeight());
-        }
-
-        /// <inheritdoc />
-        public (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) GetFederationMembersForBlocks(ChainedHeader[] chainedHeaders)
+        private (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) GetFederationMembersForBlocks(ChainedHeader[] chainedHeaders)
         {
             (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations = this.votingManager.GetModifiedFederations(chainedHeaders).ToArray();
             IFederationMember[] miners = new IFederationMember[chainedHeaders.Length];
@@ -118,7 +135,7 @@ namespace Stratis.Bitcoin.Features.PoA
             return (miners, federations);
         }
 
-        public IFederationMember GetFederationMemberForBlock(PoABlockHeader blockHeader, List<IFederationMember> federation, bool votingManagerV2)
+        private IFederationMember GetFederationMemberForBlock(PoABlockHeader blockHeader, List<IFederationMember> federation, bool votingManagerV2)
         {
             if (!votingManagerV2)
                 return GetFederationMemberForTimestamp(blockHeader.Time, this.network.Consensus.Options as PoAConsensusOptions, federation);
@@ -172,6 +189,152 @@ namespace Stratis.Bitcoin.Features.PoA
         {
             uint roundLength = (uint)(federationMembersCount * poAConsensusOptions.TargetSpacingSeconds);
             return roundLength;
+        }
+
+        /// <inheritdoc />
+        public ConcurrentDictionary<IFederationMember, uint> GetFederationMembersByLastActiveTime()
+        {
+            lock (this.lockObject)
+            {
+                ChainedHeader tip = this.lastActiveTip ?? this.chainIndexer.GetHeader(0);
+
+                List<IFederationMember> federationMembers = this.GetFederationForBlock(tip);
+
+                return new ConcurrentDictionary<IFederationMember, uint>(federationMembers
+                    .Select(m => (m, (this.GetLastActiveTime(m, tip, out uint lastActiveTime) && lastActiveTime != default) ? lastActiveTime : this.network.GenesisTime))
+                    .ToDictionary(x => x.m, x => x.Item2));
+            }
+        }
+
+        private void DiscardActivityAboveTime(uint discardAboveTime)
+        {
+            var remove = new List<PubKey>();
+
+            foreach ((PubKey pubKey, List<uint> activity) in this.lastActiveTimeByPubKey)
+            {
+                int pos = BinarySearch.BinaryFindFirst(x => activity[x] > discardAboveTime, 0, activity.Count);
+                if (pos >= 0)
+                {
+                    if (pos == 0)
+                        remove.Add(pubKey);
+                    else
+                        activity.RemoveRange(pos, activity.Count - pos);
+                }
+            }
+
+            foreach (PubKey pubKey in remove)
+                this.lastActiveTimeByPubKey.Remove(pubKey, out _);
+
+            int pos2 = BinarySearch.BinaryFindFirst(x => this.federationHistory.ElementAt(x).Key > discardAboveTime, 0, this.federationHistory.Values.Count);
+            if (pos2 > 0)
+                this.federationHistory = new SortedDictionary<uint, (List<IFederationMember>, IFederationMember)>(this.federationHistory.Skip(pos2).ToDictionary(x => x.Key, x => x.Value));
+        }
+
+        private void UpdateTip(ChainedHeader blockHeader)
+        {
+            // TODO: Add cleanup of older blocks.
+
+            if (this.lastActiveTip != null)
+            {
+                if (blockHeader == this.lastActiveTip)
+                    return;
+
+                ChainedHeader fork = this.lastActiveTip.FindFork(blockHeader);
+
+                // If the current chain includes the block then do nothing.
+                if (fork == blockHeader)
+                    return;
+
+                // If the fork shows blocks that are not in common then discard those blocks.
+                if (fork != this.lastActiveTip)
+                {
+                    DiscardActivityAboveTime(fork.Header.Time);
+                    this.lastActiveTip = fork;
+                }
+            }
+
+            var federationMemberActivationTime = ((PoAConsensusOptions)this.network.Consensus.Options).FederationMemberActivationTime ?? 0;
+
+            ChainedHeader[] headers = blockHeader
+                .EnumerateToGenesis()
+                .TakeWhile(h => h.HashBlock != this.lastActiveTip?.HashBlock && h.Header.Time >= federationMemberActivationTime)
+                .Reverse().ToArray();
+
+            if (headers.Length != 0)
+            {
+                (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) = this.GetFederationMembersForBlocks(headers);
+
+                for (int i = 0; i < headers.Length; i++)
+                {
+                    ChainedHeader header = headers[i];
+
+                    uint headerTime = header.Header.Time;
+
+                    this.federationHistory[headerTime] = (federations[i].members, miners[i]);
+
+                    if (miners[i] != null)
+                    {
+                        if (!this.lastActiveTimeByPubKey.TryGetValue(miners[i].PubKey, out List<uint> minerActivity))
+                        {
+                            minerActivity = new List<uint>();
+                            this.lastActiveTimeByPubKey[miners[i].PubKey] = minerActivity;
+                        }
+
+                        if (minerActivity.LastOrDefault() != headerTime)
+                            minerActivity.Add(headerTime);
+                    }
+
+                    foreach (IFederationMember member in federations[i].whoJoined)
+                    {
+                        if (!this.lastActiveTimeByPubKey.TryGetValue(member.PubKey, out List<uint> joinActivity))
+                        {
+                            joinActivity = new List<uint>();
+                            this.lastActiveTimeByPubKey[member.PubKey] = joinActivity;
+                        }
+
+                        if (joinActivity.LastOrDefault() != headerTime)
+                            joinActivity.Add(headerTime);
+                    }
+                }
+            }
+
+            this.lastActiveTip = blockHeader;
+        }
+
+        /// <inheritdoc />
+        public bool GetLastActiveTime(IFederationMember federationMember, ChainedHeader blockHeader, out uint lastActiveTime)
+        {
+            lock (this.lockObject)
+            {
+                UpdateTip(blockHeader);
+
+                if (this.lastActiveTimeByPubKey.TryGetValue(federationMember.PubKey, out List<uint> activity))
+                {
+                    uint blockTime = blockHeader.Header.Time;
+
+                    lastActiveTime = activity.Last();
+                    if (activity.Last() <= blockTime)
+                        return true;
+
+                    int pos = BinarySearch.BinaryFindFirst(i => activity[i] > blockTime, 0, activity.Count);
+
+                    if (pos > 0)
+                    {
+                        lastActiveTime = activity[pos - 1];
+                        return true;
+                    }
+                }
+
+                if (((PoAConsensusOptions)this.network.Consensus.Options).GenesisFederationMembers.Any(m => m.PubKey == federationMember.PubKey))
+                {
+                    lastActiveTime = default;
+                    return true;
+                }
+
+                // This should never happen.
+                lastActiveTime = default;
+                return false;
+            }
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using NBitcoin;
 using NBitcoin.Crypto;
 using Stratis.Bitcoin.Features.PoA.Voting;
@@ -16,12 +18,20 @@ namespace Stratis.Bitcoin.Features.PoA
         /// <exception cref="ConsensusErrorException">In case timestamp is invalid.</exception>
         IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader);
 
-        /// <summary>Gets the federation member for a specified block by first looking at a cache 
+        /// <summary>Gets the miner for a specified block by first looking at a cache 
         /// and then the signature in <see cref="PoABlockHeader.BlockSignature"/>.</summary>
         /// <param name="chainedHeader">Identifies the block and timestamp.</param>
         /// <param name="federation">The federation members at the block height.</param>
         /// <returns>The federation member or <c>null</c> if the member could not be determined.</returns>
         IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader, List<IFederationMember> federation);
+
+        IFederationMember GetFederationMemberForBlock(PoABlockHeader blockHeader, List<IFederationMember> federation, bool votingManagerV2);
+
+        /// <summary>Gets the miner (and federation) for the specified blocks by first looking at a cache 
+        /// and then the signature in <see cref="PoABlockHeader.BlockSignature"/>.</summary>
+        /// <param name="chainedHeaders">Identifies the blocks and timestamps.</param>
+        /// <returns>The federation member or <c>null</c> if the member could not be determined, as well as the federations.</returns>
+        (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) GetFederationMembersForBlocks(ChainedHeader[] chainedHeaders, bool forceV2 = false);
 
         /// <summary>Gets the federation for a specified block.</summary>
         /// <param name="chainedHeader">Identifies the block and timestamp.</param>
@@ -32,7 +42,13 @@ namespace Stratis.Bitcoin.Features.PoA
         /// See <see cref="PoAConsensusOptions.VotingManagerV2ActivationHeight"/>
         /// </summary>
         /// <returns>The federation member or <c>null</c> if the member could not be determined.</returns>
-        IFederationMember GetFederationMemberForTimestamp(uint headerUnixTimestamp, PoAConsensusOptions poAConsensusOptions);
+        IFederationMember GetFederationMemberForTimestamp(uint headerUnixTimestamp, PoAConsensusOptions poAConsensusOptions, List<IFederationMember> federationMembers = null);
+
+        /// <summary>
+        /// Determines the height from which the voting manager v2 is active.
+        /// </summary>
+        /// <returns>The height from which the voting manager v2 is active.</returns>
+        int GetVotingManagerV2ActivationHeight();
     }
 
     /// <summary>
@@ -44,13 +60,15 @@ namespace Stratis.Bitcoin.Features.PoA
     {
         private readonly IFederationManager federationManager;
         private readonly VotingManager votingManager;
-        private readonly Dictionary<uint256, IFederationMember> minersByBlockHash;
+        private readonly Network network;
+        private readonly ConcurrentDictionary<uint256, PubKey[]> candidatesByBlockHash;
 
-        public FederationHistory(IFederationManager federationManager, VotingManager votingManager = null)
+        public FederationHistory(IFederationManager federationManager, Network network, VotingManager votingManager = null)
         {
             this.federationManager = federationManager;
             this.votingManager = votingManager;
-            this.minersByBlockHash = new Dictionary<uint256, IFederationMember>();
+            this.network = network;
+            this.candidatesByBlockHash = new ConcurrentDictionary<uint256, PubKey[]>();
         }
 
         /// <inheritdoc />
@@ -62,57 +80,82 @@ namespace Stratis.Bitcoin.Features.PoA
         /// <inheritdoc />
         public IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader)
         {
-            if (this.minersByBlockHash.TryGetValue(chainedHeader.HashBlock, out IFederationMember federationMember))
-                return federationMember;
+            return GetFederationMemberForBlock(chainedHeader, this.GetFederationForBlock(chainedHeader));
+        }
 
-            return GetFederationMemberForBlockInternal(chainedHeader, this.GetFederationForBlock(chainedHeader));
+        public int GetVotingManagerV2ActivationHeight()
+        {
+            if (this.network.Consensus.Options is PoAConsensusOptions poaConsensusOptions)
+                return (poaConsensusOptions.VotingManagerV2ActivationHeight == 0) ? int.MaxValue : poaConsensusOptions.VotingManagerV2ActivationHeight;
+
+            return 0;
         }
 
         /// <inheritdoc />
         public IFederationMember GetFederationMemberForBlock(ChainedHeader chainedHeader, List<IFederationMember> federation)
         {
-            if (this.minersByBlockHash.TryGetValue(chainedHeader.HashBlock, out IFederationMember federationMember))
-                return federationMember;
-
-            return GetFederationMemberForBlockInternal(chainedHeader, federation);
-        }
-
-        private IFederationMember GetFederationMemberForBlockInternal(ChainedHeader chainedHeader, List<IFederationMember> federation)
-        {
             if (chainedHeader.Height == 0)
                 return federation.Last();
 
-            // Try to provide the public key that signed the block.
-            try
-            {
-                var header = chainedHeader.Header as PoABlockHeader;
+            return GetFederationMemberForBlock(chainedHeader.Header as PoABlockHeader, federation, chainedHeader.Height >= this.GetVotingManagerV2ActivationHeight());
+        }
 
-                var signature = ECDSASignature.FromDER(header.BlockSignature.Signature);
-                for (int recId = 0; recId < 4; recId++)
+        /// <inheritdoc />
+        public (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) GetFederationMembersForBlocks(ChainedHeader[] chainedHeaders, bool forceV2 = false)
+        {
+            (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations = this.votingManager.GetModifiedFederations(chainedHeaders).ToArray();
+            IFederationMember[] miners = new IFederationMember[chainedHeaders.Length];
+            PoABlockHeader[] headers = chainedHeaders.Select(h => (PoABlockHeader)h.Header).ToArray();
+
+            // Reading chainedHeader's "Header" does not play well with asynchronocity so we will load the block times here.
+            int votingManagerV2ActivationHeight = GetVotingManagerV2ActivationHeight();
+
+            Parallel.For(0, chainedHeaders.Length, i => miners[i] = GetFederationMemberForBlock(headers[i], federations[i].members, forceV2 || chainedHeaders[i].Height >= votingManagerV2ActivationHeight));
+
+            if (chainedHeaders.FirstOrDefault()?.Height == 0)
+                miners[0] = federations[0].members.Last();
+
+            return (miners, federations);
+        }
+
+        public IFederationMember GetFederationMemberForBlock(PoABlockHeader blockHeader, List<IFederationMember> federation, bool votingManagerV2)
+        {
+            if (!votingManagerV2)
+                return GetFederationMemberForTimestamp(blockHeader.Time, this.network.Consensus.Options as PoAConsensusOptions, federation);
+
+            uint256 blockHash = blockHeader.GetHash();
+
+            if (!this.candidatesByBlockHash.TryGetValue(blockHash, out PubKey[] pubKeys))
+            {
+                pubKeys = new PubKey[4];
+
+                try
                 {
-                    PubKey pubKeyForSig = PubKey.RecoverFromSignature(recId, signature, header.GetHash(), true);
-                    if (pubKeyForSig == null)
-                        break;
-
-                    IFederationMember federationMember = federation.FirstOrDefault(m => m.PubKey == pubKeyForSig);
-                    if (federationMember != null)
-                    {
-                        this.minersByBlockHash[chainedHeader.HashBlock] = federationMember;
-                        return federationMember;
-                    }
+                    var signature = ECDSASignature.FromDER(blockHeader.BlockSignature.Signature);
+                    for (int recId = 0; recId < pubKeys.Length; recId++)
+                        pubKeys[recId] = PubKey.RecoverFromSignature(recId, signature, blockHash, true);
                 }
+                catch (Exception)
+                {
+                }
+
+                this.candidatesByBlockHash[blockHash] = pubKeys;
             }
-            catch (Exception)
-            {
+
+            foreach (PubKey pubKeyForSig in pubKeys)
+            { 
+                IFederationMember federationMember = federation.FirstOrDefault(m => m.PubKey == pubKeyForSig);
+                if (federationMember != null)
+                    return federationMember;
             }
 
             return null;
         }
 
         /// <inheritdoc />
-        public IFederationMember GetFederationMemberForTimestamp(uint headerUnixTimestamp, PoAConsensusOptions poAConsensusOptions)
+        public IFederationMember GetFederationMemberForTimestamp(uint headerUnixTimestamp, PoAConsensusOptions poAConsensusOptions, List<IFederationMember> federationMembers = null)
         {
-            List<IFederationMember> federationMembers = this.federationManager.GetFederationMembers();
+            federationMembers = federationMembers ?? this.federationManager.GetFederationMembers();
 
             uint roundTime = this.GetRoundLengthSeconds(poAConsensusOptions, federationMembers.Count);
 

--- a/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationManager.cs
@@ -341,6 +341,11 @@ namespace Stratis.Bitcoin.Features.PoA
         public int? GetMultisigMinersApplicabilityHeight()
         {
             IConsensusManager consensusManager = this.fullNode.NodeService<IConsensusManager>();
+
+            // Not always passed in tests.
+            if (consensusManager == null)
+                return 0;
+
             ChainedHeader fork = (this.lastBlockChecked == null) ? null : consensusManager.Tip.FindFork(this.lastBlockChecked);
 
             if (this.multisigMinersApplicabilityHeight != null && fork?.HashBlock == this.lastBlockChecked?.HashBlock)

--- a/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
@@ -136,6 +136,8 @@ namespace Stratis.Bitcoin.Features.PoA
             if (rebuildFederationHeight)
                 this.reconstructFederationService.Reconstruct();
 
+            this.federationHistory.Initialize();
+
             // If the node is started in devmode, its role must be of miner in order to mine.
             // If devmode is not specified, initialize mining as per normal.
             if (this.nodeSettings.DevMode == null || this.nodeSettings.DevMode == DevModeNodeRole.Miner)

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
@@ -86,7 +86,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     PubKey = this.federationManager.CurrentFederationKey.PubKey.ToHex()
                 };
 
-                KeyValuePair<PubKey, uint> lastActive = this.idleFederationMembersKicker.GetFederationMembersByLastActiveTime().FirstOrDefault(x => x.Key == this.federationManager.CurrentFederationKey.PubKey);
+                KeyValuePair<IFederationMember, uint> lastActive = this.idleFederationMembersKicker.GetFederationMembersByLastActiveTime().FirstOrDefault(x => x.Key.PubKey == this.federationManager.CurrentFederationKey.PubKey);
                 if (lastActive.Key != null)
                 {
                     federationMemberModel.LastActiveTime = new DateTime(1970, 1, 1, 0, 0, 0).AddSeconds(lastActive.Value);
@@ -154,15 +154,15 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 var federationMemberModels = new List<FederationMemberModel>();
 
                 // Get their last active times.
-                ConcurrentDictionary<PubKey, uint> activeTimes = this.idleFederationMembersKicker.GetFederationMembersByLastActiveTime();
+                ConcurrentDictionary<IFederationMember, uint> activeTimes = this.idleFederationMembersKicker.GetFederationMembersByLastActiveTime();
                 foreach (IFederationMember federationMember in federationMembers)
                 {
                     federationMemberModels.Add(new FederationMemberModel()
                     {
                         PubKey = federationMember.PubKey.ToHex(),
                         CollateralAmount = (federationMember as CollateralFederationMember).CollateralAmount.ToUnit(MoneyUnit.BTC),
-                        LastActiveTime = new DateTime(1970, 1, 1, 0, 0, 0).AddSeconds(activeTimes.FirstOrDefault(a => a.Key == federationMember.PubKey).Value),
-                        PeriodOfInActivity = DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0).AddSeconds(activeTimes.FirstOrDefault(a => a.Key == federationMember.PubKey).Value)
+                        LastActiveTime = new DateTime(1970, 1, 1, 0, 0, 0).AddSeconds(activeTimes.FirstOrDefault(a => a.Key.PubKey == federationMember.PubKey).Value),
+                        PeriodOfInActivity = DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0).AddSeconds(activeTimes.FirstOrDefault(a => a.Key.PubKey == federationMember.PubKey).Value)
                     });
                 }
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
@@ -18,6 +18,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         private readonly ChainIndexer chainIndexer;
         private readonly IFederationManager federationManager;
         private readonly IIdleFederationMembersKicker idleFederationMembersKicker;
+        private readonly IFederationHistory federationHistory;
         private readonly ILogger logger;
         private readonly Network network;
         private readonly ReconstructFederationService reconstructFederationService;
@@ -29,11 +30,13 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             VotingManager votingManager,
             Network network,
             IIdleFederationMembersKicker idleFederationMembersKicker,
+            IFederationHistory federationHistory,
             ReconstructFederationService reconstructFederationService)
         {
             this.chainIndexer = chainIndexer;
             this.federationManager = federationManager;
             this.idleFederationMembersKicker = idleFederationMembersKicker;
+            this.federationHistory = federationHistory;
             this.network = network;
             this.reconstructFederationService = reconstructFederationService;
             this.votingManager = votingManager;
@@ -86,7 +89,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     PubKey = this.federationManager.CurrentFederationKey.PubKey.ToHex()
                 };
 
-                KeyValuePair<IFederationMember, uint> lastActive = this.idleFederationMembersKicker.GetFederationMembersByLastActiveTime().FirstOrDefault(x => x.Key.PubKey == this.federationManager.CurrentFederationKey.PubKey);
+                KeyValuePair<IFederationMember, uint> lastActive = this.federationHistory.GetFederationMembersByLastActiveTime().FirstOrDefault(x => x.Key.PubKey == this.federationManager.CurrentFederationKey.PubKey);
                 if (lastActive.Key != null)
                 {
                     federationMemberModel.LastActiveTime = new DateTime(1970, 1, 1, 0, 0, 0).AddSeconds(lastActive.Value);
@@ -154,7 +157,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 var federationMemberModels = new List<FederationMemberModel>();
 
                 // Get their last active times.
-                ConcurrentDictionary<IFederationMember, uint> activeTimes = this.idleFederationMembersKicker.GetFederationMembersByLastActiveTime();
+                ConcurrentDictionary<IFederationMember, uint> activeTimes = this.federationHistory.GetFederationMembersByLastActiveTime();
                 foreach (IFederationMember federationMember in federationMembers)
                 {
                     federationMemberModels.Add(new FederationMemberModel()

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -159,7 +159,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
             if (headers.Length != 0)
             {
-                (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) = this.federationHistory.GetFederationMembersForBlocks(headers, false);
+                (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) = this.federationHistory.GetFederationMembersForBlocks(headers);
 
                 for (int i = 0; i < headers.Length; i++)
                 {

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -393,6 +393,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 dataToSave.Add(pair.Key.ToHex(), pair.Value);
 
             this.keyValueRepository.SaveValueJson(fedMembersByLastActiveTimeKey, dataToSave);
+            this.keyValueRepository.SaveValueJson(lastActiveTipKey, new HashHeightPair(this.lastActiveTip));
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -344,14 +344,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                 List<IFederationMember> modifiedFederation = this.federationHistory.GetFederationForBlock(this.lastActiveTip);
 
-                /*
-                PubKey pubKey = this.federationHistory.GetFederationMemberForBlock(consensusTip, modifiedFederation).PubKey;
-                this.fedPubKeysByLastActiveTime.AddOrReplace(pubKey, consensusTip.Header.Time);
-                this.fedPubKeysByLastActiveTime1.AddOrReplace(pubKey, consensusTip);
-
-                this.SaveMembersByLastActiveTime();
-                */
-
                 // Check if any fed member was idle for too long. Use the timestamp of the mined block.
                 foreach (KeyValuePair<PubKey, uint> fedMemberToActiveTime in this.GetFederationMembersByLastActiveTime())
                 {

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -57,6 +57,12 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         /// Saves the current state.
         /// </summary>
         void SaveMembersByLastActiveTime();
+
+        /// <summary>
+        /// Updates idle information up to the specified block.
+        /// </summary>
+        /// <param name="blockHeader">The block to update idle information up to.</param>
+        void UpdateTip(ChainedHeader blockHeader);
     }
 
     /// <summary>

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -31,8 +31,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         /// Initializes this component.
         /// </summary>
         void Initialize();
-
-        bool SaveStatePeriodically { get; set; }
     }
 
     /// <summary>
@@ -41,15 +39,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
     /// </summary>
     public class IdleFederationMembersKicker : IIdleFederationMembersKicker
     {
-        private readonly IKeyValueRepository keyValueRepository;
-
-        private readonly IConsensusManager consensusManager;
-
-        private readonly IAsyncProvider asyncProvider;
-
         private readonly Network network;
-
-        private readonly IFederationManager federationManager;
 
         private readonly VotingManager votingManager;
 
@@ -63,16 +53,10 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
         private readonly object lockObject;
 
-        public bool SaveStatePeriodically { get; set; }
-
         public IdleFederationMembersKicker(Network network, IKeyValueRepository keyValueRepository, IConsensusManager consensusManager, IAsyncProvider asyncProvider,
             IFederationManager federationManager, VotingManager votingManager, IFederationHistory federationHistory, ILoggerFactory loggerFactory)
         {
             this.network = network;
-            this.keyValueRepository = keyValueRepository;
-            this.consensusManager = consensusManager;
-            this.asyncProvider = asyncProvider;
-            this.federationManager = federationManager;
             this.votingManager = votingManager;
             this.federationHistory = federationHistory;
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.AsyncWork;
@@ -14,20 +10,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 {
     public interface IIdleFederationMembersKicker : IDisposable
     {
-        /// <summary>
-        /// Determines when a federation member was last active. This includes mining or joining.
-        /// </summary>
-        /// <param name="federationMember">Member to check activity of.</param>
-        /// <param name="blockHeader">Block at which to check for past activity.</param>
-        /// <param name="lastActiveTime">Time at which member was last active.</param>
-        /// <returns><c>True</c> if the information is available and <c>false</c> otherwise.</returns>
-        bool GetLastActiveTime(IFederationMember federationMember, ChainedHeader blockHeader, out uint lastActiveTime);
-
-        /// <summary>
-        /// Determines when the current federation members were last active. This includes mining or joining.
-        /// </summary>
-        /// <returns>A list of public keys and the times at which they were active.</returns>
-        ConcurrentDictionary<IFederationMember, uint> GetFederationMembersByLastActiveTime();
 
         /// <summary>
         /// Determines if a federation member should be kicked.
@@ -49,11 +31,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         /// Initializes this component.
         /// </summary>
         void Initialize();
-
-        /// <summary> 
-        /// Clears the recorded member activity before a re-sync.
-        /// </summary>
-        void ResetFederationMemberLastActiveTime();
 
         bool SaveStatePeriodically { get; set; }
     }
@@ -80,34 +57,21 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
         private readonly ILogger logger;
 
-        private readonly ChainIndexer chainIndexer;
-
         private readonly uint federationMemberMaxIdleTimeSeconds;
 
         private readonly PoAConsensusFactory consensusFactory;
 
-        private IAsyncLoop asyncLoop;
-
-        private readonly INodeLifetime nodeLifetime;
-
         private readonly object lockObject;
-
-        public ConcurrentDictionary<PubKey, List<uint>> lastActiveTimes;
-        public ChainedHeader lastActiveTip;
 
         public bool SaveStatePeriodically { get; set; }
 
-        private const string fedMembersByLastActiveTimeKey = "fedMembersByLastActiveTime";
-        private const string lastActiveTipKey = "lastActiveTip";
-
-        public IdleFederationMembersKicker(Network network, IKeyValueRepository keyValueRepository, IConsensusManager consensusManager, IAsyncProvider asyncProvider, INodeLifetime nodeLifetime,
-            IFederationManager federationManager, VotingManager votingManager, IFederationHistory federationHistory, ILoggerFactory loggerFactory, ChainIndexer chainIndexer)
+        public IdleFederationMembersKicker(Network network, IKeyValueRepository keyValueRepository, IConsensusManager consensusManager, IAsyncProvider asyncProvider,
+            IFederationManager federationManager, VotingManager votingManager, IFederationHistory federationHistory, ILoggerFactory loggerFactory)
         {
             this.network = network;
             this.keyValueRepository = keyValueRepository;
             this.consensusManager = consensusManager;
             this.asyncProvider = asyncProvider;
-            this.nodeLifetime = nodeLifetime;
             this.federationManager = federationManager;
             this.votingManager = votingManager;
             this.federationHistory = federationHistory;
@@ -115,222 +79,12 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             this.consensusFactory = this.network.Consensus.ConsensusFactory as PoAConsensusFactory;
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
             this.federationMemberMaxIdleTimeSeconds = ((PoAConsensusOptions)network.Consensus.Options).FederationMemberMaxIdleTimeSeconds;
-            this.chainIndexer = chainIndexer;
             this.lockObject = new object();
         }
 
         /// <inheritdoc />
         public void Initialize()
         {
-            lock (this.lockObject)
-            {
-                ResetFederationMemberLastActiveTime();
-
-                this.SaveStatePeriodically = true;
-
-                this.asyncLoop = this.asyncProvider.CreateAndRunAsyncLoop($"{this.GetType().Name}.{nameof(PeriodicSaveAsync)}", async token =>
-                {
-                    await PeriodicSaveAsync().ConfigureAwait(false);
-                }, 
-                this.nodeLifetime.ApplicationStopping,
-                repeatEvery: TimeSpan.FromSeconds(30));
-
-                Dictionary<string, uint> loaded = this.keyValueRepository.LoadValueJson<Dictionary<string, uint>>(fedMembersByLastActiveTimeKey);
-                if (loaded != null)
-                {
-                    foreach (KeyValuePair<string, uint> loadedMember in loaded)
-                    {
-                        PubKey pubKey = new PubKey(loadedMember.Key);
-                        if (!this.lastActiveTimes.TryGetValue(pubKey, out List<uint> activity))
-                        {
-                            activity = new List<uint>();
-                            this.lastActiveTimes[pubKey] = activity;
-                        }
-
-                        activity.Add(loadedMember.Value);
-                    }
-                }
-
-                HashHeightPair lastActiveTip = this.keyValueRepository.LoadValue<HashHeightPair>(lastActiveTipKey);
-                if (lastActiveTip != null)
-                {
-                    this.lastActiveTip = this.chainIndexer.GetHeader(lastActiveTip.Hash);
-                    return;
-                }
-
-                if (this.lastActiveTimes.Count == 0)
-                    return;
-
-                // Try to determine the tip if none could be loaded.
-                uint maxTime = 0;
-
-                foreach ((PubKey pubKey, List<uint> activity) in this.lastActiveTimes)
-                {
-                    if (activity.LastOrDefault() > maxTime)
-                        maxTime = activity.LastOrDefault();
-                }
-
-                if (this.chainIndexer.Tip.Header.Time < maxTime)
-                {
-                    DiscardActivityAboveTime(this.chainIndexer.Tip.Header.Time);
-                    this.lastActiveTip = this.chainIndexer.Tip;
-                    return;
-                }
-
-                int height = BinarySearch.BinaryFindFirst(x => this.chainIndexer.GetHeader(x).Header.Time >= maxTime, 0, this.chainIndexer.Tip.Height + 1);
-
-                this.lastActiveTip = this.chainIndexer.GetHeader(height);
-            }
-        }
-
-        /// <inheritdoc />
-        public void ResetFederationMemberLastActiveTime()
-        {
-            lock (this.lockObject)
-            {
-                this.lastActiveTip = null;
-                this.lastActiveTimes = new ConcurrentDictionary<PubKey, List<uint>>();
-            }
-        }
-
-        /// <inheritdoc />
-        public ConcurrentDictionary<IFederationMember, uint> GetFederationMembersByLastActiveTime()
-        {
-            lock (this.lockObject)
-            {
-                ChainedHeader tip = this.lastActiveTip ?? this.chainIndexer.GetHeader(0);
-
-                List<IFederationMember> federationMembers = this.federationHistory.GetFederationForBlock(tip);
-
-                return new ConcurrentDictionary<IFederationMember, uint>(federationMembers
-                    .Select(m => (m, (this.GetLastActiveTime(m, tip, out uint lastActiveTime) && lastActiveTime != default) ? lastActiveTime : this.network.GenesisTime))
-                    .ToDictionary(x => x.m, x => x.Item2));
-            }
-        }
-
-        private void DiscardActivityAboveTime(uint discardAboveTime)
-        {
-            var remove = new List<PubKey>();
-
-            foreach ((PubKey pubKey, List<uint> activity) in this.lastActiveTimes)
-            {
-                int pos = BinarySearch.BinaryFindFirst(x => x > discardAboveTime, 0, activity.Count);
-                if (pos >= 0)
-                {
-                    if (pos == 0)
-                        remove.Add(pubKey);
-                    else
-                        activity.RemoveRange(pos, activity.Count - pos);
-                }
-            }
-
-            foreach (PubKey pubKey in remove)
-                this.lastActiveTimes.Remove(pubKey, out _);
-        }
-
-        private void UpdateTip(ChainedHeader blockHeader)
-        {
-            if (this.lastActiveTip != null)
-            {
-                if (blockHeader == this.lastActiveTip)
-                    return;
-
-                ChainedHeader fork = this.lastActiveTip.FindFork(blockHeader);
-
-                // If the current chain includes the block then do nothing.
-                if (fork == blockHeader)
-                    return;
-
-                // If the fork shows blocks that are not in common then discard those blocks.
-                if (fork != this.lastActiveTip)
-                {
-                    DiscardActivityAboveTime(fork.Header.Time);
-                    this.lastActiveTip = fork;
-                }
-            }
-
-            var federationMemberActivationTime = ((PoAConsensusOptions)this.network.Consensus.Options).FederationMemberActivationTime ?? 0;
-
-            ChainedHeader[] headers = blockHeader
-                .EnumerateToGenesis()
-                .TakeWhile(h => h.HashBlock != this.lastActiveTip?.HashBlock && h.Header.Time >= federationMemberActivationTime)
-                .Reverse().ToArray();
-
-            if (headers.Length != 0)
-            {
-                (IFederationMember[] miners, (List<IFederationMember> members, HashSet<IFederationMember> whoJoined)[] federations) = this.federationHistory.GetFederationMembersForBlocks(headers);
-
-                for (int i = 0; i < headers.Length; i++)
-                {
-                    ChainedHeader header = headers[i];
-
-                    uint headerTime = header.Header.Time;
-
-                    if (miners[i] != null)
-                    {
-                        if (!this.lastActiveTimes.TryGetValue(miners[i].PubKey, out List<uint> minerActivity))
-                        {
-                            minerActivity = new List<uint>();
-                            this.lastActiveTimes[miners[i].PubKey] = minerActivity;
-                        }
-
-                        if (minerActivity.LastOrDefault() != headerTime)
-                            minerActivity.Add(headerTime);
-                    }
-
-                    foreach (IFederationMember member in federations[i].whoJoined)
-                    {
-                        if (!this.lastActiveTimes.TryGetValue(member.PubKey, out List<uint> joinActivity))
-                        {
-                            joinActivity = new List<uint>();
-                            this.lastActiveTimes[member.PubKey] = joinActivity;
-                        }
-
-                        if (joinActivity.LastOrDefault() != headerTime)
-                            joinActivity.Add(headerTime);
-                    }
-                }
-            }
-
-            this.lastActiveTip = blockHeader;
-        }
-
-        /// <inheritdoc />
-        public bool GetLastActiveTime(IFederationMember federationMember, ChainedHeader blockHeader, out uint lastActiveTime)
-        {
-            lock (this.lockObject)
-            {
-                UpdateTip(blockHeader);
-
-                if (this.lastActiveTimes.TryGetValue(federationMember.PubKey, out List<uint> activity))
-                {
-                    uint blockTime = blockHeader.Header.Time;
-
-                    lastActiveTime = activity.Last();
-                    if (activity.Last() <= blockTime)
-                        return true;
-
-                    int pos = BinarySearch.BinaryFindFirst(i => activity[i] > blockTime, 0, activity.Count);
-
-                    if (pos > 0)
-                    {
-                        lastActiveTime = activity[pos - 1];
-                        return true;
-                    }
-                }
-
-                if (((PoAConsensusOptions)this.network.Consensus.Options).GenesisFederationMembers.Any(m => m.PubKey == federationMember.PubKey))
-                {
-                    lastActiveTime = default;
-                    return true;
-                }
-
-                // This should never happen.
-                this.logger.LogWarning("Could not resolve federation member's first activity.");
-
-                lastActiveTime = default;
-                return false;
-            }
         }
 
         /// <inheritdoc />
@@ -342,11 +96,8 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             {
                 PubKey pubKey = federationMember.PubKey;
 
-                if (this.lastActiveTimes == null)
-                    throw new Exception($"'{nameof(IdleFederationMembersKicker)}' has not been initialized.");
-
                 uint lastActiveTime = this.network.GenesisTime;
-                if (this.GetLastActiveTime(federationMember, currentTip, out lastActiveTime))
+                if (this.federationHistory.GetLastActiveTime(federationMember, currentTip, out lastActiveTime))
                     lastActiveTime = (lastActiveTime != default) ? lastActiveTime : this.network.GenesisTime;
 
                 uint blockTime = blockHeader.Header.Time;
@@ -379,10 +130,8 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                 try
                 {
-                    UpdateTip(consensusTip);
-
                     // Check if any fed member was idle for too long. Use the timestamp of the mined block.
-                    foreach ((IFederationMember federationMember, uint lastActiveTime) in this.GetFederationMembersByLastActiveTime())
+                    foreach ((IFederationMember federationMember, uint lastActiveTime) in this.federationHistory.GetFederationMembersByLastActiveTime())
                     {
                         if (this.ShouldMemberBeKicked(federationMember, consensusTip, consensusTip, out uint inactiveForSeconds))
                         {
@@ -412,31 +161,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     this.logger.LogError(ex, ex.ToString());
                     throw;
                 }
-            }
-        }
-
-        /// <inheritdoc />
-        private void SaveMembersByLastActiveTime()
-        {
-            if (this.lastActiveTip != null)
-            {
-                var members = this.GetFederationMembersByLastActiveTime();
-                var dataToSave = new Dictionary<string, uint>();
-
-                foreach (KeyValuePair<IFederationMember, uint> pair in members)
-                    dataToSave.Add(pair.Key.PubKey.ToHex(), pair.Value);
-
-                this.keyValueRepository.SaveValueJson(fedMembersByLastActiveTimeKey, dataToSave);
-                this.keyValueRepository.SaveValueJson(lastActiveTipKey, new HashHeightPair(this.lastActiveTip));
-            }
-        }
-
-        public async Task PeriodicSaveAsync()
-        {
-            lock (this.lockObject)
-            {
-                if (this.SaveStatePeriodically && this.votingManager.IsInitialized)
-                    this.SaveMembersByLastActiveTime();
             }
         }
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -86,7 +86,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         private readonly PoAConsensusFactory consensusFactory;
 
         public ConcurrentDictionary<PubKey, List<uint>> lastActiveTimes;
-        public ChainedHeader lastActiveTip; // Need to handle forks with this...
+        public ChainedHeader lastActiveTip;
 
         private const string fedMembersByLastActiveTimeKey = "fedMembersByLastActiveTime";
         private const string lastActiveTipKey = "lastActiveTip";

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/IdleFederationMembersKicker.cs
@@ -85,7 +85,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
         private readonly PoAConsensusFactory consensusFactory;
 
-        // TODO: Use SortedSet? Can it be an ordinary list, assuming items can be added sequentially? How are re-orgs handled?
         public ConcurrentDictionary<PubKey, List<uint>> lastActiveTimes;
         public ChainedHeader lastActiveTip; // Need to handle forks with this...
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
@@ -58,6 +58,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 try
                 {
                     this.isBusyReconstructing = true;
+                    this.idleFederationMembersKicker.SaveStatePeriodically = false;
 
                     // Determine the reconstruction height.
                     this.logger.Info($"Reconstructing voting data: Determining the reconstruction height.");
@@ -90,8 +91,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     this.logger.Info($"Reconstructing voting data...");
                     this.votingManager.ReconstructVotingDataFromHeightLocked(reconstructionHeight);
 
-                    this.idleFederationMembersKicker.SaveMembersByLastActiveTime();
-
                     this.logger.Info($"Reconstruction completed");
 
                     SetReconstructionFlag(false);
@@ -103,6 +102,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 }
                 finally
                 {
+                    this.idleFederationMembersKicker.SaveStatePeriodically = true;
                     this.isBusyReconstructing = false;
                 }
             }

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
@@ -82,11 +82,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     this.logger.Info($"Reconstructing voting data: Re-initializing federation members.");
                     this.federationManager.Initialize();
 
-                    // Re-initialize the idle members kicker as we will be resetting the
-                    // last active times via the reconstruction events.
-                    this.logger.Info($"Reconstructing voting data: Re-initializing federation members last active times.");
-                    this.idleFederationMembersKicker.ResetFederationMemberLastActiveTime();
-
                     // Reconstruct polls per block which will rebuild the federation.
                     this.logger.Info($"Reconstructing voting data...");
                     this.votingManager.ReconstructVotingDataFromHeightLocked(reconstructionHeight);

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
@@ -61,7 +61,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                     // Determine the reconstruction height.
                     this.logger.Info($"Reconstructing voting data: Determining the reconstruction height.");
-                    var federationMemberActivationTime = ((PoAConsensusOptions)this.nodeSettings.Network.Consensus.Options).FederationMemberActivationTime;
+                    var federationMemberActivationTime = ((PoAConsensusOptions)this.nodeSettings.Network.Consensus.Options).FederationMemberActivationTime ?? 0;
                     int reconstructionHeight;
                     if (this.chainIndexer.Tip.Header.Time < federationMemberActivationTime)
                     {

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
@@ -58,7 +58,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 try
                 {
                     this.isBusyReconstructing = true;
-                    this.idleFederationMembersKicker.SaveStatePeriodically = false;
 
                     // Determine the reconstruction height.
                     this.logger.Info($"Reconstructing voting data: Determining the reconstruction height.");
@@ -89,9 +88,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     this.logger.Info($"Reconstruction completed");
 
                     SetReconstructionFlag(false);
-
-                    // Only if successful...
-                    this.idleFederationMembersKicker.SaveStatePeriodically = true;
                 }
                 catch (Exception ex)
                 {

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
@@ -90,6 +90,8 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     this.logger.Info($"Reconstructing voting data...");
                     this.votingManager.ReconstructVotingDataFromHeightLocked(reconstructionHeight);
 
+                    this.idleFederationMembersKicker.SaveMembersByLastActiveTime();
+
                     this.logger.Info($"Reconstruction completed");
 
                     SetReconstructionFlag(false);

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
@@ -4,18 +4,18 @@ using System.Linq;
 using NBitcoin;
 using NLog;
 using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.PoA.Voting
 {
     public sealed class ReconstructFederationService
     {
-        private const int ReconstructionHeight = 1_410_000;
-
         private readonly IFederationManager federationManager;
         private readonly IIdleFederationMembersKicker idleFederationMembersKicker;
         private readonly object locker;
         private readonly Logger logger;
         private readonly NodeSettings nodeSettings;
+        private readonly ChainIndexer chainIndexer;
         private readonly PoAConsensusOptions poaConsensusOptions;
         private readonly VotingManager votingManager;
         private bool isBusyReconstructing;
@@ -23,6 +23,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         public ReconstructFederationService(
             IFederationManager federationManager,
             NodeSettings nodeSettings,
+            ChainIndexer chainIndexer,
             Network network,
             IIdleFederationMembersKicker idleFederationMembersKicker,
             VotingManager votingManager)
@@ -30,6 +31,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             this.federationManager = federationManager;
             this.idleFederationMembersKicker = idleFederationMembersKicker;
             this.nodeSettings = nodeSettings;
+            this.chainIndexer = chainIndexer;
             this.votingManager = votingManager;
 
             this.locker = new object();
@@ -57,9 +59,22 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 {
                     this.isBusyReconstructing = true;
 
+                    // Determine the reconstruction height.
+                    this.logger.Info($"Reconstructing voting data: Determining the reconstruction height.");
+                    var federationMemberActivationTime = ((PoAConsensusOptions)this.nodeSettings.Network.Consensus.Options).FederationMemberActivationTime;
+                    int reconstructionHeight;
+                    if (this.chainIndexer.Tip.Header.Time < federationMemberActivationTime)
+                    {
+                        reconstructionHeight = this.chainIndexer.Tip.Height + 1;
+                    }
+                    else
+                    {
+                        reconstructionHeight = BinarySearch.BinaryFindFirst(x => this.chainIndexer.GetHeader(x).Header.Time >= federationMemberActivationTime, 0, this.chainIndexer.Tip.Height + 1);
+                    }
+
                     // First delete all polls that was started on or after the given height.
-                    this.logger.Info($"Reconstructing voting data: Cleaning polls after height {ReconstructionHeight}");
-                    this.votingManager.DeletePollsAfterHeight(ReconstructionHeight);
+                    this.logger.Info($"Reconstructing voting data: Cleaning polls after height {reconstructionHeight}.");
+                    this.votingManager.DeletePollsAfterHeight(reconstructionHeight);
 
                     // Re-initialize the federation manager which will re-contruct the federation make-up
                     // up to the given height.
@@ -69,11 +84,11 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     // Re-initialize the idle members kicker as we will be resetting the
                     // last active times via the reconstruction events.
                     this.logger.Info($"Reconstructing voting data: Re-initializing federation members last active times.");
-                    this.idleFederationMembersKicker.InitializeFederationMemberLastActiveTime(this.federationManager.GetFederationMembers());
+                    this.idleFederationMembersKicker.ResetFederationMemberLastActiveTime();
 
                     // Reconstruct polls per block which will rebuild the federation.
                     this.logger.Info($"Reconstructing voting data...");
-                    this.votingManager.ReconstructVotingDataFromHeightLocked(ReconstructionHeight);
+                    this.votingManager.ReconstructVotingDataFromHeightLocked(reconstructionHeight);
 
                     this.logger.Info($"Reconstruction completed");
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/ReconstructFederationService.cs
@@ -94,6 +94,9 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     this.logger.Info($"Reconstruction completed");
 
                     SetReconstructionFlag(false);
+
+                    // Only if successful...
+                    this.idleFederationMembersKicker.SaveStatePeriodically = true;
                 }
                 catch (Exception ex)
                 {
@@ -101,8 +104,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     throw ex;
                 }
                 finally
-                {
-                    this.idleFederationMembersKicker.SaveStatePeriodically = true;
+                {                    
                     this.isBusyReconstructing = false;
                 }
             }

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -533,14 +533,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     return;
                 }
 
-                string fedMemberKeyHex;
-
-                // Please see the description under `VotingManagerV2ActivationHeight`.
-                // PubKey of the federation member that created the voting data.
-                if (this.poaConsensusOptions.VotingManagerV2ActivationHeight == 0 || blockConnected.ConnectedBlock.ChainedHeader.Height < this.poaConsensusOptions.VotingManagerV2ActivationHeight)
-                    fedMemberKeyHex = this.federationHistory.GetFederationMemberForTimestamp(chBlock.Block.Header.Time, this.poaConsensusOptions).PubKey.ToHex();
-                else
-                    fedMemberKeyHex = this.federationHistory.GetFederationMemberForBlock(chBlock.ChainedHeader).PubKey.ToHex();
+                string fedMemberKeyHex = this.federationHistory.GetFederationMemberForBlock(chBlock.ChainedHeader).PubKey.ToHex();
 
                 List<VotingData> votingDataList = this.votingDataEncoder.Decode(rawVotingData);
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -63,12 +63,15 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         private bool isInitialized;
         private bool isBusyReconstructing;
 
+        private INodeLifetime nodeLifetime;
+
         public VotingManager(IFederationManager federationManager, ILoggerFactory loggerFactory, IPollResultExecutor pollResultExecutor,
             INodeStats nodeStats, DataFolder dataFolder, DBreezeSerializer dBreezeSerializer, ISignals signals,
             IFinalizedBlockInfoRepository finalizedBlockInfo,
             Network network,
             IBlockRepository blockRepository = null,
-            ChainIndexer chainIndexer = null)
+            ChainIndexer chainIndexer = null,
+            INodeLifetime nodeLifetime = null)
         {
             this.federationManager = Guard.NotNull(federationManager, nameof(federationManager));
             this.pollResultExecutor = Guard.NotNull(pollResultExecutor, nameof(pollResultExecutor));
@@ -86,6 +89,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
             this.blockRepository = blockRepository;
             this.chainIndexer = chainIndexer;
+            this.nodeLifetime = nodeLifetime;
 
             this.isInitialized = false;
         }
@@ -131,6 +135,40 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             }
         }
 
+        private IEnumerable<(ChainedHeader, Block)> BatchBlocksFrom(ChainedHeader previousBlock, int batchSize)
+        {
+            for (int height = previousBlock.Height + 1; ;)
+            {
+                if (this.nodeLifetime.ApplicationStopping.IsCancellationRequested)
+                    throw new OperationCanceledException();
+
+                var hashes = new List<uint256>();
+                for (int i = 0; i < batchSize; i++)
+                {
+                    ChainedHeader header = this.chainIndexer.GetHeader(height + i);
+                    if (header == null)
+                        break;
+
+                    if (header.Previous != previousBlock)
+                        break;
+
+                    hashes.Add(header.HashBlock);
+
+                    previousBlock = header;
+                }
+
+                if (hashes.Count == 0)
+                    yield break;
+
+                List<Block> blocks = this.blockRepository.GetBlocks(hashes);
+                for (int i = 0; i < blocks.Count && !this.nodeLifetime.ApplicationStopping.IsCancellationRequested; height++, i++)
+                {
+                    ChainedHeader header = this.chainIndexer.GetHeader(height);
+                    yield return ((header, blocks[i]));
+                }
+            }
+        }
+
         /// <summary> Reconstructs voting and poll data from a given height.</summary>
         /// <param name="height">The height to start reconstructing from.</param>
         public void ReconstructVotingDataFromHeightLocked(int height)
@@ -139,36 +177,22 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             {
                 this.isBusyReconstructing = true;
 
-                var currentHeight = height;
-                var progress = $"Reconstructing voting poll data from height {currentHeight}.";
-                this.logger.LogInformation(progress);
-                this.signals.Publish(new RecontructFederationProgressEvent() { Progress = progress });
-
-                do
+                void Progress(int height)
                 {
-                    ChainedHeader chainedHeader = this.chainIndexer.GetHeader(currentHeight);
-                    if (chainedHeader == null)
-                        break;
+                    string progress = $"Reconstructing poll repository from voting data at height {height}.";
+                    this.logger.LogInformation(progress);
+                    this.signals.Publish(new RecontructFederationProgressEvent() { Progress = progress });
+                }
 
-                    Block block = this.blockRepository.GetBlock(chainedHeader.HashBlock);
-                    if (block == null)
-                        break;
+                Progress(height);
 
-                    var chainedHeaderBlock = new ChainedHeaderBlock(block, chainedHeader);
+                foreach ((ChainedHeader chainedHeader, Block block) in BatchBlocksFrom(this.chainIndexer.GetHeader(height), 1000))
+                {
+                    OnBlockConnected(new BlockConnected(new ChainedHeaderBlock(block, chainedHeader)));
 
-                    this.idleFederationMembersKicker.UpdateFederationMembersLastActiveTime(chainedHeaderBlock, false);
-
-                    OnBlockConnected(new BlockConnected(chainedHeaderBlock));
-
-                    currentHeight++;
-
-                    if (currentHeight % 10000 == 0)
-                    {
-                        progress = $"Reconstructing voting data at height {currentHeight}";
-                        this.logger.LogInformation(progress);
-                        this.signals.Publish(new RecontructFederationProgressEvent() { Progress = progress });
-                    }
-                } while (true);
+                    if (chainedHeader.Height % 10000 == 0)
+                        Progress(chainedHeader.Height);
+                };
             }
             finally
             {
@@ -351,53 +375,98 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             }
         }
 
+        public void EnterStraxEra(List<IFederationMember> modifiedFederation)
+        {
+            // If we are accessing blocks prior to STRAX activation then the IsMultisigMember values for the members may be different. 
+            for (int i = 0; i < modifiedFederation.Count; i++)
+            {
+                bool shouldBeMultisigMember = ((PoANetwork)this.network).StraxMiningMultisigMembers.Contains(modifiedFederation[i].PubKey);
+                var member = (CollateralFederationMember)modifiedFederation[i];
+
+                if (member.IsMultisigMember != shouldBeMultisigMember)
+                {
+                    // Clone the member if we will be changing the flag.
+                    modifiedFederation[i] = new CollateralFederationMember(member.PubKey, shouldBeMultisigMember, member.CollateralAmount, member.CollateralMainchainAddress);
+                }
+            }
+        }
+
         public List<IFederationMember> GetModifiedFederation(ChainedHeader chainedHeader)
+        {
+            return GetModifiedFederations(new[] { chainedHeader }).Single().federation;
+        }
+
+        public IEnumerable<(List<IFederationMember> federation, HashSet<IFederationMember> whoJoined)> GetModifiedFederations(IEnumerable<ChainedHeader> chainedHeaders)
         {
             lock (this.locker)
             {
                 // Starting with the genesis federation...
-                var modifiedFederation = new List<IFederationMember>(this.poaConsensusOptions.GenesisFederationMembers);
-                IEnumerable<Poll> approvedPolls = this.GetApprovedPolls().MemberPolls();
+                List<IFederationMember> modifiedFederation = new List<IFederationMember>(this.poaConsensusOptions.GenesisFederationMembers);
+                Poll[] approvedPolls = this.GetApprovedPolls().MemberPolls().OrderBy(a => a.PollVotedInFavorBlockData.Height).ToArray();
+                int pollIndex = 0;
+                bool straxEra = false;
+                int? multisigMinersApplicabilityHeight = this.federationManager.GetMultisigMinersApplicabilityHeight();
 
-                // Modify the federation with the polls that would have been executed up to the given height.
-                if (this.network.Consensus.ConsensusFactory is PoAConsensusFactory poaConsensusFactory)
+                foreach (ChainedHeader chainedHeader in chainedHeaders)
                 {
-                    foreach (Poll poll in approvedPolls.OrderBy(a => a.PollVotedInFavorBlockData.Height))
+                    var whoJoined = new HashSet<IFederationMember>();
+
+                    if (!(this.network.Consensus.ConsensusFactory is PoAConsensusFactory poaConsensusFactory))
                     {
-                        // When block "PollVotedInFavorBlockData"+MaxReorgLength connects, block "PollVotedInFavorBlockData" is executed. See VotingManager.OnBlockConnected.
-                        if ((poll.PollVotedInFavorBlockData.Height + this.network.Consensus.MaxReorgLength) > chainedHeader.Height)
+                        yield return (new List<IFederationMember>(this.poaConsensusOptions.GenesisFederationMembers), 
+                            new HashSet<IFederationMember>((chainedHeader.Height != 0) ? new List<IFederationMember>() : this.poaConsensusOptions.GenesisFederationMembers));
+
+                        continue;
+                    }
+
+                    if (!straxEra && (multisigMinersApplicabilityHeight != null && chainedHeader.Height >= multisigMinersApplicabilityHeight))
+                    {
+                        EnterStraxEra(modifiedFederation);
+                        straxEra = true;
+                    }
+
+                    // Apply all polls that executed at or before the current height.
+                    for (; pollIndex < approvedPolls.Length; pollIndex++)
+                    {
+                        // Modify the federation with the polls that would have been executed up to the given height.
+                        Poll poll = approvedPolls[pollIndex];
+
+                        // If it executed after the current height then exit this loop.
+                        int pollExecutionHeight = poll.PollVotedInFavorBlockData.Height + (int)this.network.Consensus.MaxReorgLength;
+                        if (pollExecutionHeight > chainedHeader.Height)
                             break;
 
                         IFederationMember federationMember = ((PoAConsensusFactory)(this.network.Consensus.ConsensusFactory)).DeserializeFederationMember(poll.VotingData.Data);
 
                         // Addition/removal.
                         if (poll.VotingData.Key == VoteKey.AddFederationMember)
-                            modifiedFederation.Add(federationMember);
-                        else if (poll.VotingData.Key == VoteKey.KickFederationMember)
-                            modifiedFederation.Remove(federationMember);
-                    }
-
-                    // Set the IsMultisigMember flags to match the expected values.
-                    int? multisigMinersApplicabilityHeight = this.federationManager.GetMultisigMinersApplicabilityHeight();
-                    if (multisigMinersApplicabilityHeight != null && chainedHeader.Height < multisigMinersApplicabilityHeight)
-                    {
-                        // If we are accessing blocks prior to STRAX activation then the IsMultisigMember values for the members may be different. 
-                        foreach (CollateralFederationMember member in modifiedFederation.Where(m => m is CollateralFederationMember))
                         {
-                            bool wasMultisigMember = ((PoAConsensusOptions)this.network.Consensus.Options).GenesisFederationMembers
-                                .Any(m => m.PubKey == member.PubKey && ((CollateralFederationMember)m).IsMultisigMember);
-
-                            if (member.IsMultisigMember != wasMultisigMember)
+                            if (!modifiedFederation.Contains(federationMember))
                             {
-                                // Clone the member if we will be changing the flag.
-                                modifiedFederation[modifiedFederation.IndexOf(member)] = new CollateralFederationMember(member.PubKey,
-                                    wasMultisigMember, member.CollateralAmount, member.CollateralMainchainAddress);
+                                if (straxEra && federationMember is CollateralFederationMember collateralFederationMember)
+                                {
+                                    bool shouldBeMultisigMember = ((PoANetwork)this.network).StraxMiningMultisigMembers.Contains(federationMember.PubKey);
+                                    if (collateralFederationMember.IsMultisigMember != shouldBeMultisigMember)
+                                        collateralFederationMember.IsMultisigMember = shouldBeMultisigMember;
+                                }
+
+                                if (pollExecutionHeight == chainedHeader.Height)
+                                    whoJoined.Add(federationMember);
+
+                                modifiedFederation.Add(federationMember);
+                            }
+                        }
+                        else if (poll.VotingData.Key == VoteKey.KickFederationMember)
+                        {
+                            if (modifiedFederation.Contains(federationMember))
+                            {
+                                modifiedFederation.Remove(federationMember);
                             }
                         }
                     }
-                }
 
-                return modifiedFederation;
+                    yield return (new List<IFederationMember>(modifiedFederation), whoJoined);
+                }
             }
         }
 
@@ -527,7 +596,9 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                             this.logger.LogDebug("Fed member '{0}' already voted for this poll. Ignoring his vote. Poll: '{1}'.", fedMemberKeyHex, poll);
                         }
 
-                        var fedMembersHex = new ConcurrentHashSet<string>(this.federationManager.GetFederationMembers().Select(x => x.PubKey.ToHex()));
+                        List<IFederationMember> modifiedFederation = this.federationManager.GetFederationMembers();
+
+                        var fedMembersHex = new ConcurrentHashSet<string>(modifiedFederation.Select(x => x.PubKey.ToHex()));
 
                         // Member that were about to be kicked when voting started don't participate.
                         if (this.idleFederationMembersKicker != null)
@@ -542,11 +613,11 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                                 Guard.NotNull(chainedHeader.Header, nameof(chainedHeader.Header));
                             }
 
-                            foreach (string pubKey in fedMembersHex)
+                            foreach (IFederationMember member in modifiedFederation)
                             {
-                                if (this.idleFederationMembersKicker.ShouldMemberBeKicked(new PubKey(pubKey), chainedHeader.Header.Time, out _))
+                                if (this.idleFederationMembersKicker.ShouldMemberBeKicked(member, chainedHeader, chBlock.ChainedHeader, out _))
                                 {
-                                    fedMembersHex.TryRemove(pubKey);
+                                    fedMembersHex.TryRemove(member.PubKey.ToHex());
                                 }
                             }
                         }

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -60,7 +60,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         /// <remarks>All access should be protected by <see cref="locker"/>.</remarks>
         private List<VotingData> scheduledVotingData;
 
-        private bool isInitialized;
+        public bool IsInitialized { get; private set; }
         private bool isBusyReconstructing;
 
         private INodeLifetime nodeLifetime;
@@ -91,7 +91,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             this.chainIndexer = chainIndexer;
             this.nodeLifetime = nodeLifetime;
 
-            this.isInitialized = false;
+            this.IsInitialized = false;
         }
 
         public void Initialize(IFederationHistory federationHistory, IIdleFederationMembersKicker idleFederationMembersKicker = null)
@@ -108,7 +108,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
             this.nodeStats.RegisterStats(this.AddComponentStats, StatsType.Component, this.GetType().Name, 1200);
 
-            this.isInitialized = true;
+            this.IsInitialized = true;
 
             this.logger.LogDebug("VotingManager initialized.");
         }
@@ -521,9 +521,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                             poll.PollExecutedBlockData = new HashHeightPair(chBlock.ChainedHeader);
                             this.pollsRepository.UpdatePoll(poll);
-
-                            this.idleFederationMembersKicker.UpdateTip(chBlock.ChainedHeader);
-                            this.idleFederationMembersKicker.SaveMembersByLastActiveTime();
                         }
                     }
                 }
@@ -736,7 +733,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         [NoTrace]
         private void EnsureInitialized()
         {
-            if (!this.isInitialized)
+            if (!this.IsInitialized)
             {
                 throw new Exception("VotingManager is not initialized. Check that voting is enabled in PoAConsensusOptions.");
             }

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -521,6 +521,9 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                             poll.PollExecutedBlockData = new HashHeightPair(chBlock.ChainedHeader);
                             this.pollsRepository.UpdatePoll(poll);
+
+                            this.idleFederationMembersKicker.UpdateTip(chBlock.ChainedHeader);
+                            this.idleFederationMembersKicker.SaveMembersByLastActiveTime();
                         }
                     }
                 }

--- a/src/Stratis.Bitcoin/Utilities/BinarySearch.cs
+++ b/src/Stratis.Bitcoin/Utilities/BinarySearch.cs
@@ -5,7 +5,7 @@ namespace Stratis.Bitcoin.Utilities
     public class BinarySearch
     {
         /// <summary>
-        /// Finds the first index in arange which evaluates to <c>true</c> when <paramref name="func"/> is applied to it.
+        /// Finds the first index in a range which evaluates to <c>true</c> when <paramref name="func"/> is applied to it.
         /// The range should strictly contain zero or more indexes for which <paramref name="func"/> evaluates to <c>false</c>
         /// optionally followed by indexes that evalates to <c>true</c>. The range may contain some indexes that evaluate to <c>null</c>.
         /// </summary>

--- a/src/Stratis.Bitcoin/Utilities/BinarySearch.cs
+++ b/src/Stratis.Bitcoin/Utilities/BinarySearch.cs
@@ -4,22 +4,28 @@ namespace Stratis.Bitcoin.Utilities
 {
     public class BinarySearch
     {
-        private static T BinaryFindFirst<T>(T[] array, Func<T, bool?> func, int first, int length)
+        /// <summary>
+        /// Finds the first index in arange which evaluates to <c>true</c> when <paramref name="func"/> is applied to it.
+        /// The range should strictly contain zero or more indexes for which <paramref name="func"/> evaluates to <c>false</c>
+        /// optionally followed by indexes that evalates to <c>true</c>. The range may contain some indexes that evaluate to <c>null</c>.
+        /// </summary>
+        /// <returns>The first index that evaluate to <c>true</c>. Returns <c>null</c> if no such index is found.</returns>
+        public static int BinaryFindFirst(Func<int, bool?> func, int first, int length)
         {
             // If the last item does not fit the criteria then don't bother looking any further.
-            bool? res = (length >= 1) ? func(array[first + length - 1]) : false;
+            bool? res = (length >= 1) ? func(first + length - 1) : false;
             if (res == false)
-                return default;
+                return -1;
 
             // If there is only one item left then it determines the outcome.
             if (length == 1)
-                return (res == true) ? array[first] : default;
+                return (res == true) ? first : -1;
 
             // Otherwise split the array in two and search each half.
             int pivot = length / 2;
-            var result = BinaryFindFirst(array, func, first, pivot);
-            if (result == null)
-                return BinaryFindFirst(array, func, first + pivot, length - pivot);
+            var result = BinaryFindFirst(func, first, pivot);
+            if (result == -1)
+                return BinaryFindFirst(func, first + pivot, length - pivot);
             return result;
         }
 
@@ -32,7 +38,12 @@ namespace Stratis.Bitcoin.Utilities
         public static T BinaryFindFirst<T>(T[] array, Func<T, bool?> func)
         {
             Guard.Assert(default(T) == null);
-            return BinaryFindFirst<T>(array, func, 0, array.Length);
+
+            int pos = BinaryFindFirst(index => func(array[index]), 0, array.Length);
+            if (pos < 0)
+                return default(T);
+
+            return array[pos];
         }
     }
 }

--- a/src/Stratis.CirrusMinerD/Properties/launchSettings.json
+++ b/src/Stratis.CirrusMinerD/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Stratis.CirrusMinerD": {
       "commandName": "Project",
-      "commandLineArgs": "-txindex=1"
+      "commandLineArgs": "-reconstructfederation -sidechain"
     },
     "Stratis.CirrusMinerD TestNet": {
       "commandName": "Project",

--- a/src/Stratis.CirrusMinerD/Properties/launchSettings.json
+++ b/src/Stratis.CirrusMinerD/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Stratis.CirrusMinerD": {
       "commandName": "Project",
-      "commandLineArgs": "-reconstructfederation -sidechain"
+      "commandLineArgs": "-txindex=1"
     },
     "Stratis.CirrusMinerD TestNet": {
       "commandName": "Project",

--- a/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
+++ b/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
@@ -41,12 +41,12 @@ namespace Stratis.Features.Collateral
 
         public CollateralPoAMiner(IConsensusManager consensusManager, IDateTimeProvider dateTimeProvider, Network network, INodeLifetime nodeLifetime, ILoggerFactory loggerFactory,
             IInitialBlockDownloadState ibdState, BlockDefinition blockDefinition, ISlotsManager slotsManager, IConnectionManager connectionManager, JoinFederationRequestMonitor joinFederationRequestMonitor,
-            PoABlockHeaderValidator poaHeaderValidator, IFederationManager federationManager, IIntegrityValidator integrityValidator, IWalletManager walletManager, ChainIndexer chainIndexer,
+            PoABlockHeaderValidator poaHeaderValidator, IFederationManager federationManager, IFederationHistory federationHistory, IIntegrityValidator integrityValidator, IWalletManager walletManager, ChainIndexer chainIndexer,
             INodeStats nodeStats, VotingManager votingManager, PoASettings poAMinerSettings, ICollateralChecker collateralChecker, IAsyncProvider asyncProvider, ICounterChainSettings counterChainSettings,
             IIdleFederationMembersKicker idleFederationMembersKicker,
             NodeSettings nodeSettings)
             : base(consensusManager, dateTimeProvider, network, nodeLifetime, loggerFactory, ibdState, blockDefinition, slotsManager, connectionManager,
-            poaHeaderValidator, federationManager, integrityValidator, walletManager, nodeStats, votingManager, poAMinerSettings, asyncProvider, idleFederationMembersKicker, nodeSettings)
+            poaHeaderValidator, federationManager, federationHistory, integrityValidator, walletManager, nodeStats, votingManager, poAMinerSettings, asyncProvider, idleFederationMembersKicker, nodeSettings)
         {
             this.counterChainNetwork = counterChainSettings.CounterChainNetwork;
             this.collateralChecker = collateralChecker;

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -73,7 +73,7 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             IFederationManager federationManager = new FederationManager(fullNode.Object, network, nodeSettings, signals, counterChainSettings);
             var votingManager = new VotingManager(federationManager, loggerFactory, new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, nodeSettings.DataFolder, dbreezeSerializer, signals, finalizedBlockRepo, network);
-            var federationHistory = new FederationHistory(federationManager, votingManager);
+            var federationHistory = new FederationHistory(federationManager, network, votingManager);
             votingManager.Initialize(federationHistory);
 
             fullNode.Setup(x => x.NodeService<VotingManager>(It.IsAny<bool>())).Returns(votingManager);

--- a/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationGatewayControllerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationGatewayControllerTests.cs
@@ -229,7 +229,7 @@ namespace Stratis.Features.FederatedPeg.Tests.ControllersTests
 
             var model = ((JsonResult)result).Value as FederationGatewayInfoModel;
             model.IsMainChain.Should().BeFalse();
-            model.FederationMiningPubKeys.Should().Equal(((PoAConsensusOptions)CirrusNetwork.NetworksSelector.Regtest().Consensus.Options).GenesisFederationMembers.Select(keys => keys.ToString()));
+            model.FederationMiningPubKeys.Should().Equal(this.federationManager.GetFederationMembers().Select(keys => keys.ToString()));
             model.MultiSigRedeemScript.Should().Be(redeemScript);
             string.Join(",", model.FederationNodeIpEndPoints).Should().Be(federationIps);
             model.IsActive.Should().BeTrue();

--- a/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationGatewayControllerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/ControllersTests/FederationGatewayControllerTests.cs
@@ -265,7 +265,7 @@ namespace Stratis.Features.FederatedPeg.Tests.ControllersTests
             chainIndexerMock.Setup(x => x.Tip).Returns(new ChainedHeader(header, header.GetHash(), 0));
 
             var votingManager = new VotingManager(this.federationManager, this.loggerFactory, new Mock<IPollResultExecutor>().Object, new Mock<INodeStats>().Object, nodeSettings.DataFolder, dbreezeSerializer, this.signals, finalizedBlockRepo, this.network);
-            var federationHistory = new FederationHistory(this.federationManager, votingManager);
+            var federationHistory = new FederationHistory(this.federationManager, nodeSettings.Network, votingManager);
             votingManager.Initialize(federationHistory);
 
             return votingManager;


### PR DESCRIPTION
See PR #565.

This PR splits out some of the work required for the above PR by first implementing common activity tracking within the existing `FederationHistory` class. The `IdleFederationMemberKicker` now utilizes these methods.

Also implements:

`IEnumerable<(List<IFederationMember> federation, HashSet<IFederationMember> whoJoined)> GetModifiedFederations(IEnumerable<ChainedHeader> chainedHeaders)`

for batch optimised determination of the federation at various height.

Also the re-synchronisation time of the polls repository has been reduced to 25 minutes.