### PR TITLE
[Multsig] Add delete transfer endpoint

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Controllers/FederationGatewayController.cs
+++ b/src/Stratis.Features.FederatedPeg/Controllers/FederationGatewayController.cs
@@ -396,9 +396,13 @@ namespace Stratis.Features.FederatedPeg.Controllers
         [ProducesResponseType((int)HttpStatusCode.InternalServerError)]
         public IActionResult DeleteSuspendedTransfers()
         {
-           var result =  this.crossChainTransferStore.DeleteSuspendedTransfers();
+            if (this.network.IsTest() || this.network.IsRegTest())
+            {
+                var result = this.crossChainTransferStore.DeleteSuspendedTransfers();
+                return this.Json($"{result} suspended transfers has been removed.");
+            }
 
-            return this.Json($"{result} suspended transfers has been removed.");
+            return this.Json($"Deleting suspended transfers is only available on test networks.");
         }
     }
 }

--- a/src/Stratis.Features.FederatedPeg/Controllers/FederationGatewayController.cs
+++ b/src/Stratis.Features.FederatedPeg/Controllers/FederationGatewayController.cs
@@ -24,6 +24,7 @@ namespace Stratis.Features.FederatedPeg.Controllers
 {
     public static class FederationGatewayRouteEndPoint
     {
+        public const string DeleteSuspended = "transfers/deletesuspended";
         public const string GetMaturedBlockDeposits = "deposits";
         public const string GetFederationInfo = "info";
         public const string GetFederationMemberInfo = "member/info";
@@ -386,6 +387,18 @@ namespace Stratis.Features.FederatedPeg.Controllers
                 return this.Json(this.federationWalletManager.ValidateTransaction(transfers[0].PartialTransaction, true));
 
             return this.Json($"{depositIdTransactionId} does not exist.");
+        }
+
+        [Route(FederationGatewayRouteEndPoint.DeleteSuspended)]
+        [HttpDelete]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType((int)HttpStatusCode.InternalServerError)]
+        public IActionResult DeleteSuspendedTransfers()
+        {
+           var result =  this.crossChainTransferStore.DeleteSuspendedTransfers();
+
+            return this.Json($"{result} suspended transfers has been removed.");
         }
     }
 }

--- a/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransferStore.cs
@@ -109,7 +109,16 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// Returns a list of completed withdrawals (those that are seen-in-block).
         /// </summary>
         /// <param name="transfersToDisplay">The max items to display.</param>
-        /// <returns>The completed withdrawals.</returns>
+        /// <returns>The completed withdrawals.</returns>        
         List<WithdrawalModel> GetCompletedWithdrawals(int transfersToDisplay);
+        
+        /// <summary>
+        /// Deletes all suspended transfers from the store.
+        /// <para>
+        /// This should always be used with caution and will only work if all multisig nodes do this.
+        /// </para>
+        /// </summary>
+        /// <returns>The amount of suspended transfers that was deleted.</returns>
+        int DeleteSuspendedTransfers();
     }
 }


### PR DESCRIPTION
We currently have suspended dynamic conversion transactions sitting on CirrusTest which cannot be reprocessed, so we need the ability to delete them so that the CCTS tip can progress.