### PR TITLE
[SC] State.Clear fix

### DIFF
--- a/src/Stratis.SmartContracts.Core/State/WriteCache.cs
+++ b/src/Stratis.SmartContracts.Core/State/WriteCache.cs
@@ -173,6 +173,13 @@ namespace Stratis.SmartContracts.Core.State
                     Value value = curVal.GetValue();
                     if (value == null) // no idea
                     {
+                        // Could occur if the item has been deleted in the cache only
+                        // If this is the case then we should not return a value from the source.
+                        if (curVal.counter < 0)
+                        {
+                            return default(Value);
+                        }
+
                         return this.Source == null ? default(Value) : this.Source.Get(key);
                     }
                     else

--- a/src/Stratis.SmartContracts.IntegrationTests/ContractBehaviourTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/ContractBehaviourTests.cs
@@ -130,6 +130,105 @@ namespace Stratis.SmartContracts.IntegrationTests
             Assert.True(receipt.Success);
         }
 
+        /// <summary>
+        /// Tests that when clearing persistent state the data is empty immediately after.
+        /// </summary>
+        [Fact]
+        public void PersistentState_Clear_State_Should_Be_Empty_In_Same_Tx()
+        {            
+            // Ensure fixture is funded.
+            this.mockChain.MineBlocks(1);
+
+            // Deploy contract
+            ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/ClearDataContract.cs");
+
+            Assert.True(compilationResult.Success);
+            BuildCreateContractTransactionResponse preResponse = this.node1.SendCreateContractTransaction(compilationResult.Compilation, 0);
+            this.mockChain.WaitAllMempoolCount(1);
+            this.mockChain.MineBlocks(1);
+            Assert.NotNull(this.node1.GetCode(preResponse.NewContractAddress));
+
+            uint256 currentHash = this.node1.GetLastBlock().GetHash();
+
+            // Clear the data and check that it's empty
+            BuildCallContractTransactionResponse response = this.node1.SendCallContractTransaction(
+                nameof(ClearDataContract.ClearDataAndCheck),
+                preResponse.NewContractAddress,
+                0);
+            this.mockChain.WaitAllMempoolCount(1);
+            this.mockChain.MineBlocks(1);
+
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
+
+            // Blocks progressed
+            Assert.NotEqual(currentHash, lastBlock.GetHash());
+
+            ReceiptResponse receipt = this.node1.GetReceipt(response.TransactionId.ToString());
+            Assert.True(receipt.Success);
+            Assert.Equal(true.ToString(), receipt.ReturnValue);
+        }
+
+        /// <summary>
+        /// Tests that when clearing persistent state the data is empty when it is accessed in a new transaction.
+        /// 
+        /// The distinction is important because between txes the storage cache is flushed and values are pushed to
+        /// the underlying storage layer.
+        /// </summary>
+        [Fact]
+        public void PersistentState_Clear_State_Should_Be_Empty_In_New_Tx()
+        {
+            // Ensure fixture is funded.
+            this.mockChain.MineBlocks(1);
+
+            // Deploy contract
+            ContractCompilationResult compilationResult = ContractCompiler.CompileFile("SmartContracts/ClearDataContract.cs");
+
+            Assert.True(compilationResult.Success);
+            BuildCreateContractTransactionResponse preResponse = this.node1.SendCreateContractTransaction(compilationResult.Compilation, 0);
+            this.mockChain.WaitAllMempoolCount(1);
+            this.mockChain.MineBlocks(1);
+            Assert.NotNull(this.node1.GetCode(preResponse.NewContractAddress));
+
+            uint256 currentHash = this.node1.GetLastBlock().GetHash();
+
+            // Clear the data and check that it's empty
+            BuildCallContractTransactionResponse response = this.node1.SendCallContractTransaction(
+                nameof(ClearDataContract.ClearData),
+                preResponse.NewContractAddress,
+                0);
+            this.mockChain.WaitAllMempoolCount(1);
+            this.mockChain.MineBlocks(1);
+
+            NBitcoin.Block lastBlock = this.node1.GetLastBlock();
+
+            // Blocks progressed
+            Assert.NotEqual(currentHash, lastBlock.GetHash());
+
+            ReceiptResponse receipt = this.node1.GetReceipt(response.TransactionId.ToString());
+
+            // Invoke Check in a new tx. It should succeed
+            response = this.node1.SendCallContractTransaction(
+               nameof(ClearDataContract.Check),
+               preResponse.NewContractAddress,
+               0);
+            this.mockChain.WaitAllMempoolCount(1);
+            this.mockChain.MineBlocks(1);
+
+            lastBlock = this.node1.GetLastBlock();
+
+            // Blocks progressed
+            Assert.NotEqual(currentHash, lastBlock.GetHash());
+                        
+            receipt = this.node1.GetReceipt(response.TransactionId.ToString());
+            Assert.True(receipt.Success);
+
+            // The storage value should be null because the transaction completed successfully.
+            Assert.Null(this.node1.GetStorageValue(preResponse.NewContractAddress, nameof(ClearDataContract.Data)));
+
+            // Check should be true because the data is now cleared.
+            Assert.Equal(true.ToString(), receipt.ReturnValue);
+        }
+
         [Fact]
         public void Local_Call_At_Height()
         {

--- a/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/ClearDataContract.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/SmartContracts/ClearDataContract.cs
@@ -1,0 +1,56 @@
+﻿using Stratis.SmartContracts;
+
+public class ClearDataContract : SmartContract
+{
+    public ClearDataContract(ISmartContractState contractState) : base(contractState)
+    {
+        SetData("Test");
+    }
+
+    public byte[] Data
+    {
+        get
+        {
+            return this.State.GetBytes(nameof(Data));
+        }
+
+        private set
+        {
+            this.State.SetBytes(nameof(Data), value);
+        }
+    }
+
+    public void ClearData()
+    {
+        this.State.Clear(nameof(Data));
+    }
+
+    public bool ClearDataAndCheck()
+    {
+        this.State.Clear(nameof(Data));
+
+        return Check();
+    }
+
+    public bool Check()
+    {
+        Assert(Serializer.ToString(this.Data) != "Test", "Value is still test!");
+
+        return this.Data.Length == 0;
+    }
+
+    public void SetData(string data)
+    {
+        this.Data = this.Serializer.Serialize(data);
+    }
+
+    public byte[] GetData()
+    {
+        return this.Data;
+    }
+
+    public bool IsDataEmpty()
+    {
+        return this.Data == null || this.Data.Length == 0;
+    }
+}

--- a/src/Stratis.SmartContracts.IntegrationTests/Stratis.SmartContracts.IntegrationTests.csproj
+++ b/src/Stratis.SmartContracts.IntegrationTests/Stratis.SmartContracts.IntegrationTests.csproj
@@ -75,6 +75,9 @@
     <Compile Update="SmartContracts\CallWithAllParameters.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Compile>
+    <Compile Update="SmartContracts\ClearDataContract.cs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Compile>
     <Compile Update="SmartContracts\ConstructorLoop.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Compile>


### PR DESCRIPTION
Closes #594.

Of the [currently deployed mainnet contracts](https://github.com/stratisproject/CirrusSmartContracts/tree/master/Mainnet):
* AddressMapper uses clear but doesn't attempt to read the value after clearing and is unaffected
* DaoContract doesn't use clear
* IdentityProvider uses clear but is unaffected
* PrivateYesNoVote doesn't use clear
* StandardToken doesn't use clear

[Testnet](https://github.com/stratisproject/CirrusSmartContracts/tree/master/Testnet):
* Airdrop unaffected
* ICOContract **affected**, currently syncing testnet to check if there will be consensus issues
* StratisSwap unaffected
* TicketBooth unaffected
* WheelGame unaffected
