### PR TITLE
Validate ChainStore tip on load

### DIFF
--- a/src/NBitcoin/ChainStore.cs
+++ b/src/NBitcoin/ChainStore.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 
 namespace NBitcoin
 {
-    public interface IChainStore
+    public interface IChainStore : IDisposable
     {
         BlockHeader GetHeader(ChainedHeader chainedHeader, uint256 hash);
 
@@ -89,6 +89,10 @@ namespace NBitcoin
         {
             foreach (ChainDataItem item in items)
                 this.chainData.TryAdd(item.Height, item.Data);
+        }
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/src/NBitcoin/NBitcoin.csproj
+++ b/src/NBitcoin/NBitcoin.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <Version>4.0.0.81</Version>
+    <Version>4.0.0.82</Version>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
+++ b/src/Stratis.Bitcoin.Api.Tests/ApiSettingsTest.cs
@@ -14,8 +14,10 @@ namespace Stratis.Bitcoin.Api.Tests
     /// <summary>
     /// Tests the settings for the API features.
     /// </summary>
-    public class ApiSettingsTest : TestBase
+    public class ApiSettingsTest : TestBase, IDisposable
     {
+        private IFullNode fullNode;
+
         public ApiSettingsTest() : base(KnownNetworks.Main)
         {
         }
@@ -266,14 +268,20 @@ namespace Stratis.Bitcoin.Api.Tests
             settingsAction.Should().Throw<ConfigurationException>();
         }
 
-        private static ApiSettings FullNodeSetup(NodeSettings nodeSettings)
+        private ApiSettings FullNodeSetup(NodeSettings nodeSettings)
         {
-            return new FullNodeBuilder()
+            this.fullNode = new FullNodeBuilder()
                 .UseNodeSettings(nodeSettings)
                 .UseApi()
                 .UsePowConsensus()
-                .Build()
-                .NodeService<ApiSettings>();
+                .Build();
+
+            return this.fullNode.NodeService<ApiSettings>();
+        }
+
+        public void Dispose()
+        {
+            this.fullNode.NodeService<IChainStore>().Dispose();
         }
     }
 }

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -282,11 +282,15 @@ namespace Stratis.Bitcoin.IntegrationTests
             var chain = new ChainIndexer(this.regTest);
             var data = new DataFolder(TestBase.CreateTestDir(this));
 
-            using (var repo = new ChainRepository(new LevelDbChainStore(this.network, data, chain)))
+            var chainStore = new LevelDbChainStore(this.network, data, chain);
+            chain[0].SetChainStore(chainStore);
+
+            using (var repo = new ChainRepository(chainStore))
             {
                 chain.SetTip(repo.LoadAsync(chain.Genesis).GetAwaiter().GetResult());
                 Assert.True(chain.Tip == chain.Genesis);
                 chain = new ChainIndexer(this.regTest);
+                chain[0].SetChainStore(chainStore);
                 ChainedHeader tip = this.AppendBlock(chain);
                 repo.SaveAsync(chain).GetAwaiter().GetResult();
                 var newChain = new ChainIndexer(this.regTest);

--- a/src/Stratis.Bitcoin.Tests/Base/ChainRepositoryTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Base/ChainRepositoryTest.cs
@@ -77,15 +77,20 @@ namespace Stratis.Bitcoin.Tests.Base
                             new ChainRepository.ChainRepositoryData()
                             { Hash = block.HashBlock, Work = block.ChainWorkBytes }
                                 .ToBytes(this.Network.Consensus.ConsensusFactory));
+
+                        ConsensusFactory consensusFactory = KnownNetworks.StraxRegTest.Consensus.ConsensusFactory;
+                        batch.Put(2, block.Header.GetHash().ToBytes(), block.Header.ToBytes(consensusFactory));
                     }
 
                     engine.Write(batch);
                 }
             }
 
-            using (var repo = new ChainRepository(new LevelDbChainStore(chain.Network, new DataFolder(dir), chain)))
+            var chainStore = new LevelDbChainStore(chain.Network, new DataFolder(dir), chain);
+            using (var repo = new ChainRepository(chainStore))
             {
                 var testChain = new ChainIndexer(KnownNetworks.StraxRegTest);
+                testChain[0].SetChainStore(chainStore);
                 testChain.SetTip(repo.LoadAsync(testChain.Genesis).GetAwaiter().GetResult());
                 Assert.Equal(tip, testChain.Tip);
             }

--- a/src/Stratis.Bitcoin/Base/ChainRepository.cs
+++ b/src/Stratis.Bitcoin/Base/ChainRepository.cs
@@ -65,7 +65,7 @@ namespace Stratis.Bitcoin.Base
                 }
                 else
                 {
-                    // Confirm that the tip exists in the chain table.
+                    // Confirm that the chain tip exists in the headers table.
                     this.chainStore.GetHeader(tip, tip.HashBlock);
                 }
 

--- a/src/Stratis.Bitcoin/Base/ChainRepository.cs
+++ b/src/Stratis.Bitcoin/Base/ChainRepository.cs
@@ -63,6 +63,11 @@ namespace Stratis.Bitcoin.Base
                     genesisHeader.SetChainStore(this.chainStore);
                     tip = genesisHeader;
                 }
+                else
+                {
+                    // Confirm that the tip exists in the chain table.
+                    this.chainStore.GetHeader(tip, tip.HashBlock);
+                }
 
                 this.locator = tip.GetLocator();
                 return tip;

--- a/src/Stratis.Bitcoin/Persistence/ChainStores/LevelDbChainStore.cs
+++ b/src/Stratis.Bitcoin/Persistence/ChainStores/LevelDbChainStore.cs
@@ -7,7 +7,7 @@ using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Persistence.ChainStores
 {
-    public class LevelDbChainStore : IChainStore, IDisposable
+    public class LevelDbChainStore : IChainStore
     {
         private readonly Network network;
 

--- a/src/Stratis.Bitcoin/Persistence/ChainStores/RocksDbChainStore.cs
+++ b/src/Stratis.Bitcoin/Persistence/ChainStores/RocksDbChainStore.cs
@@ -10,7 +10,7 @@ namespace Stratis.Bitcoin.Persistence.ChainStores
     /// <summary>
     /// Rocksdb implementation of the chain storage
     /// </summary>
-    public sealed class RocksDbChainStore : IChainStore, IDisposable
+    public sealed class RocksDbChainStore : IChainStore
     {
         internal static readonly byte ChainTableName = 1;
         internal static readonly byte HeaderTableName = 2;


### PR DESCRIPTION
See https://app.clickup.com/t/46vgx6.

The `ChainStore` consists of two tables which could conceivably go out of whack  due to the fact that these tables are individually updated (i.e. non-atomically). This PR adds a check to `LoadAsync` to ensure that the tip of the chain table corresponds to an available header in the headers table.