### PR TITLE
Add vote heights

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PollTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PollTests.cs
@@ -57,7 +57,8 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
 
             for (int i = 0; i < poll.PubKeysHexVotedInFavor.Count; i++)
             {
-                Assert.Equal(poll.PubKeysHexVotedInFavor[i], deserializedPoll.PubKeysHexVotedInFavor[i]);
+                Assert.Equal(poll.PubKeysHexVotedInFavor[i].PubKey, deserializedPoll.PubKeysHexVotedInFavor[i].PubKey);
+                Assert.Equal(poll.PubKeysHexVotedInFavor[i].Height, deserializedPoll.PubKeysHexVotedInFavor[i].Height);
             }
         }
     }

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PollTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PollTests.cs
@@ -22,10 +22,10 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
                 },
                 PollVotedInFavorBlockData = new HashHeightPair(uint256.One, 1),
                 PollStartBlockData = new HashHeightPair(uint256.One, 1),
-                PubKeysHexVotedInFavor = new List<string>()
+                PubKeysHexVotedInFavor = new List<Vote>()
                 {
-                    "qwe",
-                    "rty"
+                    new Vote() { PubKey = "qwe" },
+                    new Vote() { PubKey = "rty" }
                 }
             };
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/Poll.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/Poll.cs
@@ -5,10 +5,17 @@ using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.PoA.Voting
 {
-    public class Vote
+    public class Vote : IBitcoinSerializable
     {
         public string PubKey;
         public int Height;
+
+        /// <inheritdoc />
+        public void ReadWrite(BitcoinStream stream)
+        {
+            stream.ReadWrite(ref this.PubKey);
+            stream.ReadWrite(ref this.Height);
+        }
     }
 
     /// <summary>Information about active poll.</summary>
@@ -55,24 +62,11 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
             if (stream.Serializing)
             {
-                string[] pubKeyArr = this.PubKeysHexVotedInFavor.Select(v => v.PubKey).ToArray();
-
-                stream.ReadWrite(ref pubKeyArr);
-
-                int[] heightArr = this.PubKeysHexVotedInFavor.Select(v => v.Height).ToArray();
-
-                stream.ReadWrite(ref heightArr);
-
+                stream.ReadWrite(ref this.PubKeysHexVotedInFavor);
             }
             else
             {
-                string[] pubKeyArr = null;
-                stream.ReadWrite(ref pubKeyArr);
-
-                int[] heightArr = null;
-                stream.ReadWrite(ref heightArr);
-
-                this.PubKeysHexVotedInFavor = pubKeyArr.Select((k, n) => new Vote() { PubKey = k, Height = heightArr[n] }).ToList();
+                stream.ReadWrite(ref this.PubKeysHexVotedInFavor);
 
                 if (this.PollExecutedBlockData.Hash == uint256.Zero)
                     this.PollExecutedBlockData = null;

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/Poll.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/Poll.cs
@@ -5,12 +5,18 @@ using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.PoA.Voting
 {
+    public class Vote
+    {
+        public string PubKey;
+        public int Height;
+    }
+
     /// <summary>Information about active poll.</summary>
     public class Poll : IBitcoinSerializable
     {
         public Poll()
         {
-            this.PubKeysHexVotedInFavor = new List<string>();
+            this.PubKeysHexVotedInFavor = new List<Vote>();
         }
 
         /// <summary>
@@ -36,7 +42,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         public HashHeightPair PollExecutedBlockData;
 
         /// <summary>List of fed member's public keys that voted in favor.</summary>
-        public List<string> PubKeysHexVotedInFavor;
+        public List<Vote> PubKeysHexVotedInFavor;
 
         /// <inheritdoc />
         public void ReadWrite(BitcoinStream stream)
@@ -49,16 +55,24 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
             if (stream.Serializing)
             {
-                string[] arr = this.PubKeysHexVotedInFavor.ToArray();
+                string[] pubKeyArr = this.PubKeysHexVotedInFavor.Select(v => v.PubKey).ToArray();
 
-                stream.ReadWrite(ref arr);
+                stream.ReadWrite(ref pubKeyArr);
+
+                int[] heightArr = this.PubKeysHexVotedInFavor.Select(v => v.Height).ToArray();
+
+                stream.ReadWrite(ref heightArr);
+
             }
             else
             {
-                string[] arr = null;
-                stream.ReadWrite(ref arr);
+                string[] pubKeyArr = null;
+                stream.ReadWrite(ref pubKeyArr);
 
-                this.PubKeysHexVotedInFavor = arr.ToList();
+                int[] heightArr = null;
+                stream.ReadWrite(ref heightArr);
+
+                this.PubKeysHexVotedInFavor = pubKeyArr.Select((k, n) => new Vote() { PubKey = k, Height = heightArr[n] }).ToList();
 
                 if (this.PollExecutedBlockData.Hash == uint256.Zero)
                     this.PollExecutedBlockData = null;
@@ -114,7 +128,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             this.PollStartBlockDataHeight = poll.PollStartBlockData?.Height;
             this.PollExecutedBlockDataHash = poll.PollExecutedBlockData?.Hash;
             this.PollExecutedBlockDataHeight = poll.PollExecutedBlockData?.Height;
-            this.PubKeysHexVotedInFavor = poll.PubKeysHexVotedInFavor;
+            this.PubKeysHexVotedInFavor = poll.PubKeysHexVotedInFavor.Select(v => v.PubKey).ToList();
             this.VotingDataString = executor.ConvertToString(poll.VotingData);
         }
     }

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -232,7 +232,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
             if (approvedPolls.Any(x => !x.IsExecuted &&
                   x.VotingData.Key == voteKey && x.VotingData.Data.SequenceEqual(federationMemberBytes) &&
-                  x.PubKeysHexVotedInFavor.Contains(this.federationManager.CurrentFederationKey.PubKey.ToHex())))
+                  x.PubKeysHexVotedInFavor.Any(v => v.PubKey == this.federationManager.CurrentFederationKey.PubKey.ToHex())))
             {
                 // We've already voted in a finished poll that's only awaiting execution.
                 return true;
@@ -242,7 +242,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
             if (pendingPolls.Any(x => x.VotingData.Key == voteKey &&
                                        x.VotingData.Data.SequenceEqual(federationMemberBytes) &&
-                                       x.PubKeysHexVotedInFavor.Contains(this.federationManager.CurrentFederationKey.PubKey.ToHex())))
+                                       x.PubKeysHexVotedInFavor.Any(v => v.PubKey == this.federationManager.CurrentFederationKey.PubKey.ToHex())))
             {
                 // We've already voted in a pending poll.
                 return true;
@@ -490,7 +490,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                                         PollExecutedBlockData = null,
                                         PollStartBlockData = new HashHeightPair(chBlock.ChainedHeader),
                                         VotingData = data,
-                                        PubKeysHexVotedInFavor = new List<string>() { fedMemberKeyHex }
+                                        PubKeysHexVotedInFavor = new List<Vote>() { new Vote() { PubKey = fedMemberKeyHex, Height = chBlock.ChainedHeader.Height } }
                                     };
 
                                     this.polls.Add(poll);
@@ -499,9 +499,9 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                                     this.logger.LogDebug("New poll was created: '{0}'.", poll);
                                 });
                             }
-                            else if (!poll.PubKeysHexVotedInFavor.Contains(fedMemberKeyHex))
+                            else if (!poll.PubKeysHexVotedInFavor.Any(v => v.PubKey == fedMemberKeyHex))
                             {
-                                poll.PubKeysHexVotedInFavor.Add(fedMemberKeyHex);
+                                poll.PubKeysHexVotedInFavor.Add(new Vote() { PubKey = fedMemberKeyHex, Height = chBlock.ChainedHeader.Height });
                                 this.PollsRepository.UpdatePoll(transaction, poll);
 
                                 this.logger.LogDebug("Voted on existing poll: '{0}'.", poll);
@@ -543,7 +543,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                             // It is possible that there is a vote from a federation member that was deleted from the federation.
                             // Do not count votes from entities that are not active fed members.
-                            int validVotesCount = poll.PubKeysHexVotedInFavor.Count(x => fedMembersHex.Contains(x));
+                            int validVotesCount = poll.PubKeysHexVotedInFavor.Count(x => fedMembersHex.Contains(x.PubKey));
 
                             int requiredVotesCount = (fedMembersHex.Count / 2) + 1;
 
@@ -631,15 +631,18 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                     // Pub key of a fed member that created voting data.
                     string fedMemberKeyHex = this.federationHistory.GetFederationMemberForBlock(chBlock.ChainedHeader).PubKey.ToHex();
-
-                    targetPoll.PubKeysHexVotedInFavor.Remove(fedMemberKeyHex);
-
-                    if (targetPoll.PubKeysHexVotedInFavor.Count == 0)
+                    int voteIndex = targetPoll.PubKeysHexVotedInFavor.FindIndex(v => v.PubKey == fedMemberKeyHex);
+                    if (voteIndex >= 0)
                     {
-                        this.polls.Remove(targetPoll);
-                        this.PollsRepository.RemovePolls(transaction, targetPoll.Id);
+                        targetPoll.PubKeysHexVotedInFavor.RemoveAt(voteIndex);
 
-                        this.logger.LogDebug("Poll with Id {0} was removed.", targetPoll.Id);
+                        if (targetPoll.PubKeysHexVotedInFavor.Count == 0)
+                        {
+                            this.polls.Remove(targetPoll);
+                            this.PollsRepository.RemovePolls(transaction, targetPoll.Id);
+
+                            this.logger.LogDebug("Poll with Id {0} was removed.", targetPoll.Id);
+                        }
                     }
                 }
 

--- a/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
+++ b/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
@@ -124,7 +124,7 @@ namespace Stratis.Features.Collateral
                 List<Poll> pendingAddFederationMemberPolls = this.votingManager.GetPendingPolls().Where(p => p.VotingData.Key == VoteKey.AddFederationMember).ToList();
 
                 // Filter all polls where this federation number has not voted on.
-                pendingAddFederationMemberPolls = pendingAddFederationMemberPolls.Where(p => !p.PubKeysHexVotedInFavor.Contains(this.federationManager.CurrentFederationKey.PubKey.ToString())).ToList();
+                pendingAddFederationMemberPolls = pendingAddFederationMemberPolls.Where(p => !p.PubKeysHexVotedInFavor.Any(v => v.PubKey == this.federationManager.CurrentFederationKey.PubKey.ToString())).ToList();
 
                 if (!pendingAddFederationMemberPolls.Any())
                     return;

--- a/src/Stratis.Features.Collateral/ConsensusRules/MandatoryCollateralMemberVotingRule.cs
+++ b/src/Stratis.Features.Collateral/ConsensusRules/MandatoryCollateralMemberVotingRule.cs
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.Features.Collateral.ConsensusRules
                 .Where(p => p.VotingData.Key == VoteKey.AddFederationMember
                     && p.PollStartBlockData != null
                     && p.PollStartBlockData.Height <= context.ValidationContext.ChainedHeaderToValidate.Height
-                    && p.PubKeysHexVotedInFavor.Any(pk => pk == this.federationManager.CurrentFederationKey.PubKey.ToHex())).ToList();
+                    && p.PubKeysHexVotedInFavor.Any(pk => pk.PubKey == this.federationManager.CurrentFederationKey.PubKey.ToHex())).ToList();
 
             // Exit if there aren't any.
             if (!pendingPolls.Any())
@@ -45,7 +45,7 @@ namespace Stratis.Bitcoin.Features.Collateral.ConsensusRules
 
             // Ignore any polls that the miner has already voted on.
             PubKey blockMiner = this.federationHistory.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate).PubKey;
-            pendingPolls = pendingPolls.Where(p => !p.PubKeysHexVotedInFavor.Any(pk => pk == blockMiner.ToHex())).ToList();
+            pendingPolls = pendingPolls.Where(p => !p.PubKeysHexVotedInFavor.Any(pk => pk.PubKey == blockMiner.ToHex())).ToList();
 
             // Exit if there is nothing remaining.
             if (!pendingPolls.Any())


### PR DESCRIPTION
See https://app.clickup.com/t/46uxar.

It's impossible to quickly rewind the polls repository to a specific height unless we know which individual votes to rewind also - i.e. we need to know at which height each vote was cast.

This PR adds the vote block height to appear alongside the public key of the member casting the vote.