### PR TITLE
[InterFlux] Only allow ETH Interflux conversions

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -442,13 +442,14 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
         [ProducesResponseType((int)HttpStatusCode.InternalServerError)]
-        public async Task<IActionResult> BuildInterFluxTransaction([FromBody] BuildInterFluxTransactionRequest request,
-            CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<IActionResult> BuildInterFluxTransaction([FromBody] BuildInterFluxTransactionRequest request)
         {
+            if (request.DestinationChain != (int)DestinationChain.ETH)
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "Invalid destination chain", "Only InterFlux transactions to the Ethereum chain is currently supported.");
+
             request.OpReturnData = InterFluxOpReturnEncoder.Encode((DestinationChain)request.DestinationChain, request.DestinationAddress);
 
-            return await this.Execute(request, cancellationToken,
-                async (req, token) => Json(await this.walletService.BuildTransaction(req, token)));
+            return await this.Execute(request, default, async (req, token) => Json(await this.walletService.BuildTransaction(req, token)));
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -445,7 +445,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         public async Task<IActionResult> BuildInterFluxTransaction([FromBody] BuildInterFluxTransactionRequest request)
         {
             if (request.DestinationChain != (int)DestinationChain.ETH)
-                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "Invalid destination chain", "Only InterFlux transactions to the Ethereum chain is currently supported.");
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, "Invalid destination chain", "Only InterFlux transactions to the Ethereum chain are currently supported.");
 
             request.OpReturnData = InterFluxOpReturnEncoder.Encode((DestinationChain)request.DestinationChain, request.DestinationAddress);
 

--- a/src/Stratis.Bitcoin.Features.Wallet/InterFluxOpReturnEncoder.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/InterFluxOpReturnEncoder.cs
@@ -21,6 +21,8 @@ namespace Stratis.Bitcoin.Features.Wallet
             destinationChain = -1;
             address = string.Empty;
 
+            // If the op_return data does not contain the "INTER" prefix,
+            // then this is not a interflux (conversion) transaction.
             if (prefixIndex == -1 || separatorIndex == -1)
                 return false;
 

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -475,9 +475,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
     {
         /// <summary>Target chain that is supported by InterFlux integration.</summary>
         /// <remarks>See Stratis.Features.FederatedPeg.Conversion.DestinationChain enum.</remarks>
+        [Required]
         public int DestinationChain { get; set; }
 
         /// <summary>Address at destination chain at which coins should be deposited.</summary>
+        [Required]
         public string DestinationAddress { get; set; }
     }
 


### PR DESCRIPTION
Currently, only ETH conversion transactions are fully tested by the multisig, so for the time being we should only allow these interflux conversions.