### PR TITLE
Remove rocksdb from cirrusminer devmode default.

### DIFF
--- a/src/Stratis.CirrusMinerD/Program.cs
+++ b/src/Stratis.CirrusMinerD/Program.cs
@@ -107,7 +107,7 @@ namespace Stratis.CirrusMinerD
 
         private static IFullNode BuildDevCirrusMiningNode(string[] args)
         {
-            string[] devModeArgs = new[] { "-bootstrap=1", "-dbtype=rocksdb", "-defaultwalletname=cirrusdev", "-defaultwalletpassword=password" }.Concat(args).ToArray();
+            string[] devModeArgs = new[] { "-bootstrap=1", "-defaultwalletname=cirrusdev", "-defaultwalletpassword=password" }.Concat(args).ToArray();
             var network = new CirrusDev();
 
             var nodeSettings = new NodeSettings(network, protocolVersion: ProtocolVersion.CIRRUS_VERSION, args: devModeArgs)


### PR DESCRIPTION
rocksdb default kills node on startup on linux.