### PR TITLE
[InterFlux] Add functionality to check which multisigs confirmed a transaction

### DIFF
--- a/src/Stratis.Bitcoin.Features.Interop/Controllers/InteropController.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/Controllers/InteropController.cs
@@ -335,6 +335,48 @@ namespace Stratis.Bitcoin.Features.Interop.Controllers
         }
 
         /// <summary>
+        /// Returns the list of contract owners that confirmed a particular multisig transaction.
+        /// </summary>
+        /// <param name="destinationChain">The chain the multisig wallet contract is deployed to.</param>
+        /// <param name="transactionId">The multisig wallet transactionId (this is an integer, not an on-chain transaction hash).</param>
+        /// <returns>A list of owner addresses that confirmed the transaction.</returns>
+        [Route("multisigconfirmations")]
+        [HttpGet]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType((int)HttpStatusCode.InternalServerError)]
+        public async Task<IActionResult> MultisigConfirmationsAsync(DestinationChain destinationChain, int transactionId)
+        {
+            try
+            {
+                if (!this.ethCompatibleClientProvider.IsChainSupportedAndEnabled(destinationChain))
+                    return this.Json($"{destinationChain} not enabled or supported!");
+
+                IETHClient client = this.ethCompatibleClientProvider.GetClientForChain(destinationChain);
+
+                List<string> owners = await client.GetOwnersAsync().ConfigureAwait(false);
+
+                var ownersConfirmed = new List<string>();
+
+                foreach (string multisig in owners)
+                {
+                    bool confirmed = await client.AddressConfirmedTransactionAsync(transactionId, multisig).ConfigureAwait(false);
+
+                    if (confirmed)
+                        ownersConfirmed.Add(multisig);
+                }
+
+                return this.Json(ownersConfirmed);
+            }
+            catch (Exception e)
+            {
+                this.logger.Error("Exception occurred: {0}", e.ToString());
+
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
         /// Retrieves the wSTRAX balance of a given account.
         /// </summary>
         /// <param name="destinationChain">The chain the wSTRAX ERC20 contract is deployed to.</param>

--- a/src/Stratis.Bitcoin.Features.Interop/ETHClient/ETHClient.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/ETHClient/ETHClient.cs
@@ -73,6 +73,14 @@ namespace Stratis.Bitcoin.Features.Interop.ETHClient
         Task<List<string>> GetOwnersAsync();
 
         /// <summary>
+        /// Checks if the given address confirmed the given multisig transaction.
+        /// </summary>
+        /// <param name="transactionId">The identifier of the transaction.</param>
+        /// <param name="address">The address to check the confirmation status of.</param>
+        /// <returns>True if the address has confirmed the transaction in question.</returns>
+        Task<bool> AddressConfirmedTransactionAsync(BigInteger transactionId, string address);
+
+        /// <summary>
         /// Gets a transaction out of the transactions mapping on the contract and decodes it.
         /// </summary>
         /// <param name="transactionId">The identifier of the transaction to retrieve.</param>
@@ -240,11 +248,21 @@ namespace Stratis.Bitcoin.Features.Interop.ETHClient
             return await MultisigWallet.GetTransactionAsync(this.web3, this.settings.MultisigWalletAddress, transactionId).ConfigureAwait(false);
         }
 
+        /// <inheritdoc />
+        public async Task<bool> AddressConfirmedTransactionAsync(BigInteger transactionId, string address)
+        {
+            ConfirmationsDTO result = await MultisigWallet.AddressConfirmedTransactionAsync(this.web3, this.settings.MultisigWalletAddress, transactionId, address).ConfigureAwait(false);
+
+            return result.Confirmed;
+        }
+
+        /// <inheritdoc />
         public async Task<string> GetRawMultisigTransactionAsync(BigInteger transactionId)
         {
             return await MultisigWallet.GetRawTransactionAsync(this.web3, this.settings.MultisigWalletAddress, transactionId).ConfigureAwait(false);
         }
 
+        /// <inheritdoc />
         public async Task<BigInteger> GetErc20BalanceAsync(string addressToQuery)
         {
             return await WrappedStrax.GetErc20BalanceAsync(this.web3, this.settings.WrappedStraxContractAddress, addressToQuery).ConfigureAwait(false);

--- a/src/Stratis.Bitcoin.Features.Interop/ETHClient/MultisigWallet.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/ETHClient/MultisigWallet.cs
@@ -77,6 +77,23 @@ namespace Stratis.Bitcoin.Features.Interop.ETHClient
     }
 
     [FunctionOutput]
+    public class ConfirmationsDTO : IFunctionOutputDTO
+    {
+        [Parameter("bool", "confirmed", 1)]
+        public bool Confirmed { get; set; }
+    }
+
+    [Function("confirmations", typeof(ConfirmationsDTO))]
+    public class ConfirmationsFunction : FunctionMessage
+    {
+        [Parameter("uint256", "transactionId", 1)]
+        public BigInteger TransactionId { get; set; }
+
+        [Parameter("address", "address", 1)]
+        public string Address { get; set; }
+    }
+
+    [FunctionOutput]
     public class TransactionDTO : IFunctionOutputDTO
     {
         /// <summary>
@@ -158,6 +175,21 @@ namespace Stratis.Bitcoin.Features.Interop.ETHClient
             List<string> owners = await ownerHandler.QueryAsync<List<string>>(contractAddress, getOwnersFunctionMessage).ConfigureAwait(false);
 
             return owners;
+        }
+
+        /// <summary>
+        /// Checks whether the given transaction identified by the transactionId has been confirmed by the given address.
+        /// </summary>
+        /// <param name="web3">The web3 interface instance to use.</param>
+        /// <param name="contractAddress">The address of the deployed multisig wallet contract.</param>
+        /// <param name="transactionId">The multisig wallet transaction identifier.</param>
+        /// <param name="address">The address to check the transaction's confirmation status with.</param>
+        /// <returns>An object containing the boolean confirmation state.</returns>
+        public static async Task<ConfirmationsDTO> AddressConfirmedTransactionAsync(Web3 web3, string contractAddress, BigInteger transactionId, string address)
+        {
+            ContractHandler handler = web3.Eth.GetContractHandler(contractAddress);
+
+            return await handler.QueryDeserializingToObjectAsync<ConfirmationsFunction, ConfirmationsDTO>(new ConfirmationsFunction() { TransactionId = transactionId, Address = address }).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Currently only exposed via the controller, but can easily be used within the fee distribution logic