### PR TITLE
Flush the ChainIndexer when Coinview flushes

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -119,7 +119,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.InitialBlockDownloadState = new InitialBlockDownloadState(testChainContext.ChainState, testChainContext.Network, consensusSettings, new Checkpoints(), testChainContext.DateTimeProvider);
 
             var inMemoryCoinView = new InMemoryCoinView(new HashHeightPair(testChainContext.ChainIndexer.Tip));
-            var cachedCoinView = new CachedCoinView(network, new Checkpoints(), inMemoryCoinView, DateTimeProvider.Default, testChainContext.LoggerFactory, new NodeStats(testChainContext.DateTimeProvider, testChainContext.NodeSettings, new Mock<IVersionProvider>().Object), new ConsensusSettings(testChainContext.NodeSettings));
+            var cachedCoinView = new CachedCoinView(network, new Checkpoints(), inMemoryCoinView, DateTimeProvider.Default, testChainContext.LoggerFactory, new NodeStats(testChainContext.DateTimeProvider, testChainContext.NodeSettings, new Mock<IVersionProvider>().Object), new ConsensusSettings(testChainContext.NodeSettings), testChainContext.ChainIndexer, new ChainRepository(new ChainStore()), null);
 
             var dataFolder = new DataFolder(TestBase.AssureEmptyDir(dataDir).FullName);
             testChainContext.PeerAddressManager =

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -142,7 +142,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         private readonly Random random;
 
         public CachedCoinView(Network network, ICheckpoints checkpoints, ICoindb coindb, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory, INodeStats nodeStats,
-            ConsensusSettings consensusSettings, ChainIndexer chainIndexer, IChainRepository chainRepository, IProvenBlockHeaderStore provenBlockHeaderStore, StakeChainStore stakeChainStore = null, IRewindDataIndexCache rewindDataIndexCache = null)
+            ConsensusSettings consensusSettings, ChainIndexer chainIndexer, IChainRepository chainRepository, IProvenBlockHeaderStore provenBlockHeaderStore = null, StakeChainStore stakeChainStore = null, IRewindDataIndexCache rewindDataIndexCache = null)
         {
             Guard.NotNull(coindb, nameof(CachedCoinView.coindb));
 

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/LeveldbCoindb.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/LeveldbCoindb.cs
@@ -190,6 +190,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         public HashHeightPair Rewind()
         {
             HashHeightPair res = null;
+
             using (var batch = new WriteBatch())
             {
                 HashHeightPair current = this.GetTipHash();

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
@@ -44,15 +44,15 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         }
 
         /// <inheritdoc />
-        public override Task RunAsync(RuleContext context)
+        public override async Task RunAsync(RuleContext context)
         {
             if (this.PowParent.UtxoSet is CachedCoinView cachedCoinView)
             {
                 bool inIBD = this.initialBlockDownloadState.IsInitialBlockDownload();
-                cachedCoinView.Flush(force: !inIBD);
+                await cachedCoinView.FlushAsync(force: !inIBD).ConfigureAwait(false);
             }
 
-            return Task.CompletedTask;
+            return;
         }
     }
 
@@ -94,15 +94,15 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
     public class SaveCoinviewRule : PushCoinviewRule
     {
         /// <inheritdoc />
-        public override Task RunAsync(RuleContext context)
+        public override async Task RunAsync(RuleContext context)
         {
-            base.RunAsync(context);
+            await base.RunAsync(context).ConfigureAwait(false);
 
             // Use the default flush condition to decide if flush is required (currently set to every 60 seconds)
             if (this.PowParent.UtxoSet is CachedCoinView cachedCoinView)
-                cachedCoinView.Flush(false);
+                await cachedCoinView.FlushAsync(false).ConfigureAwait(false);
 
-            return Task.CompletedTask;
+            return;
         }
     }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
@@ -86,7 +86,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
                 coinViewTip = coinDatabase.Rewind();
             }
 
-            this.logger.LogInformation("Coin view rewound to '{0}'.", coinDatabase.GetTipHash());
+            this.logger.LogInformation("Coin view initialized at '{0}'.", coinDatabase.GetTipHash());
         }
 
         public override async Task<ValidationContext> FullValidationAsync(ChainedHeader header, Block block)
@@ -107,11 +107,10 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
         {
             this.prefetcher.Dispose();
 
-            var cache = this.UtxoSet as CachedCoinView;
-            if (cache != null)
+            if (this.UtxoSet is CachedCoinView cache)
             {
                 this.logger.LogInformation("Flushing Cache CoinView.");
-                cache.Flush();
+                cache.FlushAsync().GetAwaiter().GetResult();
             }
 
             ((IDisposable)((CachedCoinView)this.UtxoSet).ICoindb).Dispose();

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -75,7 +75,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
                 var chainStore = new ChainStore();
                 var chainRepository = new ChainRepository(chainStore);
-                var cacheCoinView = new CachedCoinView(this.network, new Checkpoints(), ctx.Coindb, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, NodeSettings.Default(this.network), new Mock<IVersionProvider>().Object), new ConsensusSettings(new NodeSettings(this.network)), new ChainIndexer(), chainRepository, null);
+                var cacheCoinView = new CachedCoinView(this.network, new Checkpoints(), ctx.Coindb, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, NodeSettings.Default(this.network), new Mock<IVersionProvider>().Object), new ConsensusSettings(new NodeSettings(this.network)), new ChainIndexer(this.network), chainRepository, null);
 
                 cacheCoinView.SaveChanges(new UnspentOutput[] { new UnspentOutput(new OutPoint(genesis.Transactions[0], 0), new Coins(0, genesis.Transactions[0].Outputs.First(), true)) }, new HashHeightPair(genesisChainedHeader), new HashHeightPair(chained));
                 Assert.NotNull(cacheCoinView.FetchCoins(new[] { new OutPoint(genesis.Transactions[0], 0) }).UnspentOutputs.Values.FirstOrDefault().Coins);
@@ -110,7 +110,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
                 var chainStore = new ChainStore();
                 var chainRepository = new ChainRepository(chainStore);
-                var cacheCoinView = new CachedCoinView(this.network, new Checkpoints(), nodeContext.Coindb, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, NodeSettings.Default(this.network), new Mock<IVersionProvider>().Object), new ConsensusSettings(new NodeSettings(this.network)), new ChainIndexer(), chainRepository, null);
+                var cacheCoinView = new CachedCoinView(this.network, new Checkpoints(), nodeContext.Coindb, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, NodeSettings.Default(this.network), new Mock<IVersionProvider>().Object), new ConsensusSettings(new NodeSettings(this.network)), new ChainIndexer(this.network), chainRepository, null);
                 var tester = new CoinViewTester(cacheCoinView);
 
                 List<(Coins, OutPoint)> coinsA = tester.CreateCoins(5);

--- a/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/MinerTests.cs
@@ -152,7 +152,7 @@ namespace Stratis.Bitcoin.IntegrationTests
 
                 var inMemoryCoinView = new InMemoryCoinView(new HashHeightPair(this.ChainIndexer.Tip));
                 var nodeStats = new NodeStats(dateTimeProvider, nodeSettings, new Mock<IVersionProvider>().Object);
-                this.cachedCoinView = new CachedCoinView(this.network, new Checkpoints(), inMemoryCoinView, dateTimeProvider, new LoggerFactory(), nodeStats, consensusSettings);
+                this.cachedCoinView = new CachedCoinView(this.network, new Checkpoints(), inMemoryCoinView, dateTimeProvider, new LoggerFactory(), nodeStats, consensusSettings, this.ChainIndexer, new ChainRepository(new ChainStore()), null);
 
                 var signals = new Signals.Signals(loggerFactory, null);
                 var asyncProvider = new AsyncProvider(loggerFactory, signals);

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
@@ -209,7 +209,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 this.NodeSettings = new NodeSettings(this.network, args: new string[] { "-checkpoints" });
                 var consensusSettings = new ConsensusSettings(this.NodeSettings);
                 var checkPoints = new Checkpoints(this.network, consensusSettings);
-                this.cachedCoinView = new CachedCoinView(this.network, checkPoints, inMemoryCoinView, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, this.NodeSettings, new Mock<IVersionProvider>().Object), consensusSettings);
+                this.cachedCoinView = new CachedCoinView(this.network, checkPoints, inMemoryCoinView, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, this.NodeSettings, new Mock<IVersionProvider>().Object), consensusSettings, this.ChainIndexer, new ChainRepository(new ChainStore()), null);
 
                 var nodeDeployments = new NodeDeployments(this.network, this.ChainIndexer);
 

--- a/src/Stratis.StraxD/Properties/launchSettings.json
+++ b/src/Stratis.StraxD/Properties/launchSettings.json
@@ -2,7 +2,6 @@
   "profiles": {
     "Stratis.StraxD": {
       "commandName": "Project",
-      "commandLineArgs": "-datadir=D:\\Stratis\\StraxNodeMainNet\\Data"
     },
     "Stratis.StraxD Test": {
       "commandName": "Project",

--- a/src/Stratis.StraxD/Properties/launchSettings.json
+++ b/src/Stratis.StraxD/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "Stratis.StraxD": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "-datadir=D:\\Stratis\\StraxNodeMainNet\\Data"
     },
     "Stratis.StraxD Test": {
       "commandName": "Project",

--- a/src/Stratis.StraxD/Properties/launchSettings.json
+++ b/src/Stratis.StraxD/Properties/launchSettings.json
@@ -1,7 +1,7 @@
 {
   "profiles": {
     "Stratis.StraxD": {
-      "commandName": "Project",
+      "commandName": "Project"
     },
     "Stratis.StraxD Test": {
       "commandName": "Project",


### PR DESCRIPTION
On occasion when a user shuts down its node whilst syncing, the coin view tip gets set out of sync with the chain indexer/repository. This is because these 2 components have different flushing logic and as such we cant be guaranteed that they flush at the same time.

The solution here is to, when coinview flushes to disk, the chain indexer should also be persisted. This way they will never be out of sync (unless the user shuts down the node in between the 2 calls).