### PR TITLE
CirrusMain checkpoint 2_827_550 (1.1.0.0)

### DIFF
--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -270,6 +270,7 @@ namespace Stratis.Sidechains.Networks
                 { 1_850_000, new CheckpointInfo(new uint256("0x6e2590bd9a8eaab25b236c0c9ac314abec70b18aa053b96c9257f2356dec8314")) },
                 { 2_150_000, new CheckpointInfo(new uint256("0x4c65f29b5098479cab275afd77d302ebe5ed8d8ef33e02ae54bf185865763f18")) },
                 { 2_500_000, new CheckpointInfo(new uint256("0x2853be7b7224840d3d4b60427ea832e9bd67d8fc6bfcd4956b8c6b2414cf8fc2")) },
+                { 2_827_550, new CheckpointInfo(new uint256("0xcf0ebdd99ec04ef260d22befe70ef7b948e50b5fcc18d9d37376d49e872372a0")) }
             };
 
             this.DNSSeeds = new List<DNSSeedData>


### PR DESCRIPTION
It appears that the `CirrusMain` chain contains a few blocks that were mined by older/minority versions of the node that would not be mineable with the latest code version. The situation probably came about due to many of the newer nodes not being able to mine at the time.

The purpose of this PR is to exclude the blocks which led to "block timestamp too early" errors from the `PoAHeaderSignatureRule` rule by virtue of this existing code:

```
        public override async Task RunAsync(RuleContext context)
        {
            // Only start validating at the last checkpoint block.
            if (context.ValidationContext.ChainedHeaderToValidate.Height < (this.lastCheckPoint?.Height ?? 0))
                return;

            ChainedHeader chainedHeader = context.ValidationContext.ChainedHeaderToValidate;
```