### PR TITLE
[RPC] Endpoints returning null appear to be handled incorrectly

### DIFF
--- a/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/TestHelper.cs
@@ -66,6 +66,7 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
 
         public static (bool Passed, string Message) AreNodesSyncedMessage(CoreNode node1, CoreNode node2, bool ignoreMempool = false)
         {
+            // TODO: This does not check mempool equivalence, so this method actually behaves differently in tests involving bitcoind!
             if (node1.runner is BitcoinCoreRunner || node2.runner is BitcoinCoreRunner)
             {
                 return (node1.CreateRPCClient().GetBestBlockHash() == node2.CreateRPCClient().GetBestBlockHash(), "[BEST_BLOCK_HASH_DOES_MATCH]");
@@ -107,6 +108,8 @@ namespace Stratis.Bitcoin.IntegrationTests.Common
 
         public static bool IsNodeSynced(CoreNode node)
         {
+            // TODO: Need test for bitcoin runner too?
+
             // If the node is at genesis it is considered synced.
             if (node.FullNode.ChainIndexer.Tip.Height == 0)
                 return true;


### PR DESCRIPTION
While adding some SFN nodes to the RPC tests run against bitcoind, it was found that the `gettxout` RPC for a nonexistent UTXO was returning different results. I.e. the RPCClient was not receiving a `null` result element in the JSON RPCResponse to convert back to an actual null; which should then be returned at the conclusion of the `GetTxOut` client method.

The fix in the middleware is experimental, it corrects the gettxout case, but there may be other scenarios it does not cater for.