### PR TITLE
Add API federation/get-mining-pubkey-at-height

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
@@ -194,7 +194,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             try
             {
                 var chainedHeader = this.chainIndexer.GetHeader(blockHeight);
-
                 PubKey pubKey = this.federationHistory.GetFederationMemberForBlock(chainedHeader)?.PubKey;
 
                 return Json(pubKey);

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
@@ -222,15 +222,14 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             try
             {
                 var chainedHeader = this.chainIndexer.GetHeader(blockHeight);
-
-		var federationMembers = this.federationHistory.GetFederationForBlock(chainedHeader);
-		List<PubKey> federationPubKeys = new List<PubKey>();
-
-		foreach (IFederationMember federationMember in federationMembers)
-		{
-		    federationPubKeys.Add(federationMember.PubKey);
-		}
-	
+                var federationMembers = this.federationHistory.GetFederationForBlock(chainedHeader);
+                List<PubKey> federationPubKeys = new List<PubKey>();
+                
+                foreach (IFederationMember federationMember in federationMembers)
+                {
+                    federationPubKeys.Add(federationMember.PubKey);
+                }
+                
                 return Json(federationPubKeys);
             }
             catch (Exception e)

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
@@ -185,7 +185,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         /// <returns>Pubkey of federation member at specified height</returns>
         /// <response code="200">Returns pubkey of miner at block height</response>
         /// <response code="400">Unexpected exception occurred</response>
-        [Route("get-mining-pubkey-at-height")]
+        [Route("mineratheight")]
         [HttpGet]
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
@@ -213,7 +213,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         /// <returns>Federation membership at the given height</returns>
         /// <response code="200">Returns a list of pubkeys representing the federation membership at the given block height.</response>
         /// <response code="400">Unexpected exception occurred</response>
-        [Route("get-federation-members-at-height")]
+        [Route("federationatheight")]
         [HttpGet]
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
@@ -222,15 +222,15 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             try
             {
                 var chainedHeader = this.chainIndexer.GetHeader(blockHeight);
-				
-				var federationMembers = this.federationHistory.GetFederationForBlock(chainedHeader);
-				List<PubKey> federationPubKeys = new List<PubKey>();
-				
-				foreach (IFederationMember federationMember in federationMembers)
-				{
-					federationPubKeys.Add(federationMember.PubKey);
-				}
-				
+
+		var federationMembers = this.federationHistory.GetFederationForBlock(chainedHeader);
+		List<PubKey> federationPubKeys = new List<PubKey>();
+
+		foreach (IFederationMember federationMember in federationMembers)
+		{
+		    federationPubKeys.Add(federationMember.PubKey);
+		}
+	
                 return Json(federationPubKeys);
             }
             catch (Exception e)

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
@@ -177,5 +177,33 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
             }
         }
+        
+        /// <summary>
+        /// Retrieves the pubkey of federation member that produced a block at the specified height.
+        /// </summary>
+        /// <param name="blockHeight">Block height at which to retrieve pubkey from.</param>
+        /// <returns>Pubkey of federation member at specified height</returns>
+        /// <response code="200">Returns pubkey of miner at block height</response>
+        /// <response code="400">Unexpected exception occurred</response>
+        [Route("get-mining-pubkey-at-height")]
+        [HttpGet]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        public IActionResult GetPubkeyAtHeight([FromQuery(Name = "blockHeight")] int blockHeight)
+        {
+            try
+            {
+                var chainedHeader = this.chainIndexer.GetHeader(blockHeight);
+
+                PubKey pubKey = this.federationHistory.GetFederationMemberForBlock(chainedHeader)?.PubKey;
+
+                return Json(pubKey);
+            }
+            catch (Exception e)
+            {
+                this.logger.Error("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
     }
 }


### PR DESCRIPTION
Obtains federation pubkey at specified height. Can be used to map mining pubkey to distribution address for DAO.