### PR TITLE
Move mining stats to async loop

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/Models/FederationMemberModel.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Models/FederationMemberModel.cs
@@ -47,9 +47,6 @@ namespace Stratis.Bitcoin.Features.PoA.Models
         [JsonProperty("rewardEstimatePerBlock")]
         public double RewardEstimatePerBlock { get; set; }
 
-        [JsonProperty("producedBlockInLastRound")]
-        public bool ProducedBlockInLastRound { get; set; }
-
         [JsonProperty("federationSize")]
         public int FederationSize { get; set; }
 


### PR DESCRIPTION
It is completely unnecessary for the mining statistics to be gathered every 5 secs when the periodic log run and adds unnecessary processing to the node when blocks are only produced every 16secs anyway.