### PR TITLE
Fix compatibility issue for Unreal Engine client

### DIFF
--- a/src/Stratis.Features.Unity3dApi/Controllers/Unity3dController.cs
+++ b/src/Stratis.Features.Unity3dApi/Controllers/Unity3dController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -182,18 +182,30 @@ namespace Stratis.Features.Unity3dApi.Controllers
         [HttpGet]
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-        public long GetAddressBalance(string address)
+        public IActionResult GetAddressBalance(string address)
         {
+            long money = -1;
             try
             {
-                AddressBalancesResult result = this.addressIndexer.GetAddressBalances(new []{address}, 1);
-
-                return result.Balances.First().Balance.Satoshi;
+                AddressBalancesResult result = this.addressIndexer.GetAddressBalances(new[] { address }, 1);
+                money = result.Balances.First().Balance.Satoshi;
             }
             catch (Exception e)
             {
                 this.logger.LogError("Exception occurred: {0}", e.ToString());
-                return -1;
+            }
+
+            if (Request.Headers["Accept"] == "application/json")
+            {
+                GetBalanceResponseModel response = new GetBalanceResponseModel()
+                {
+                    Balance = money
+                };
+                return Ok(response);
+            }
+            else
+            {
+                return Ok(money);
             }
         }
 

--- a/src/Stratis.Features.Unity3dApi/ResponseModels.cs
+++ b/src/Stratis.Features.Unity3dApi/ResponseModels.cs
@@ -12,6 +12,11 @@ namespace Stratis.Features.Unity3dApi
         public string Reason;
     }
 
+    public class GetBalanceResponseModel
+    {
+        public long Balance;
+    }
+
     public class UTXOModel
     {
         public UTXOModel()


### PR DESCRIPTION
> Clone of PR #751 with correct base branch

Problem: UE's JSON library doesn't support plain values as response (as defined in RFC7159).
Solution: Wrap return value with proper-formed json object.