### PR TITLE
[RPC] Make listunspent return watchOnly account transactions

### DIFF
--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -274,6 +274,14 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         IEnumerable<HdAccount> GetAccounts(string walletName);
 
         /// <summary>
+        /// Gets a list of accounts.
+        /// </summary>
+        /// <param name="walletName">The name of the wallet to look into.</param>
+        /// <param name="accountFilter">Optional filter for the accounts to return. Defaults to returning normal accounts only.</param>
+        /// <returns>The list of accounts in the specified wallet.</returns>
+        IEnumerable<HdAccount> GetAccounts(string walletName, Func<HdAccount, bool> accountFilter);
+
+        /// <summary>
         /// Gets a list of all the accounts in all wallets.
         /// </summary>
         /// <returns>The list of all accounts.</returns>

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/UnspentCoinModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/UnspentCoinModel.cs
@@ -4,6 +4,7 @@ using Stratis.Bitcoin.Utilities.JsonConverters;
 
 namespace Stratis.Bitcoin.Features.Wallet.Models
 {
+    // TODO: This is similar to the UnspentCoin class in the RPC feature; perhaps one of the two should be removed?
     /// <summary>
     /// Model for Json response for listunspent RPC call.
     /// </summary>
@@ -77,22 +78,5 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// </summary>
         [JsonProperty(PropertyName = "solvable")]
         public bool IsSolvable { get; set; }
-
-        /*
-        /// <summary>
-        /// A descriptor for spending this output (only when solvable).
-        /// </summary>
-        /// <remarks>Not implemented yet.</remarks>
-        [JsonProperty(PropertyName = "desc")]
-        public string Desc { get; set; }
-
-        /// <summary>
-        /// Whether this output is considered safe to spend. Unconfirmed transactions
-        /// from outside keys and unconfirmed replacement transactions are considered unsafe
-        /// and are not eligible for spending by fundrawtransaction and sendtoaddress.
-        /// </summary>
-        [JsonProperty(PropertyName = "safe")]
-        public bool Safe { get; set; }
-        */
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/UnspentCoinModel.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/UnspentCoinModel.cs
@@ -47,6 +47,12 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         public string RedeemScriptHex { get; set; }
 
         /// <summary>
+        /// If the output is a P2WSH or P2SH-P2WSH whose script belongs to this wallet, this is the redeem script.
+        /// </summary>
+        [JsonProperty(PropertyName = "witnessScript")]
+        public string WitnessScriptHex { get; set; }
+
+        /// <summary>
         /// The transaction amount.
         /// Serialized in coins (BTC).
         /// </summary>
@@ -71,5 +77,22 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// </summary>
         [JsonProperty(PropertyName = "solvable")]
         public bool IsSolvable { get; set; }
+
+        /*
+        /// <summary>
+        /// A descriptor for spending this output (only when solvable).
+        /// </summary>
+        /// <remarks>Not implemented yet.</remarks>
+        [JsonProperty(PropertyName = "desc")]
+        public string Desc { get; set; }
+
+        /// <summary>
+        /// Whether this output is considered safe to spend. Unconfirmed transactions
+        /// from outside keys and unconfirmed replacement transactions are considered unsafe
+        /// and are not eligible for spending by fundrawtransaction and sendtoaddress.
+        /// </summary>
+        [JsonProperty(PropertyName = "safe")]
+        public bool Safe { get; set; }
+        */
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletManager.cs
@@ -956,6 +956,12 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <inheritdoc />
         public IEnumerable<HdAccount> GetAccounts(string walletName)
         {
+            return GetAccounts(walletName, null);
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<HdAccount> GetAccounts(string walletName, Func<HdAccount, bool> accountFilter)
+        {
             Guard.NotEmpty(walletName, nameof(walletName));
 
             Wallet wallet = this.GetWallet(walletName);
@@ -963,7 +969,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             HdAccount[] res = null;
             lock (this.lockObject)
             {
-                res = wallet.GetAccounts().ToArray();
+                res = wallet.GetAccounts(accountFilter).ToArray();
             }
 
             return res;
@@ -1017,6 +1023,7 @@ namespace Stratis.Bitcoin.Features.Wallet
             this.WalletRepository.AddWatchOnlyAddresses(walletName, accountName, 0, pubKeys.Select(pubKey => new HdAddress() { Pubkey = pubKey.ScriptPubKey }).ToList());
         }
 
+        // TODO: Not sure if the intention was to return special accounts too. If not, this method doesn't have much purpose and is essentially a duplicate of GetAccounts(), albeit across all wallets
         public IEnumerable<HdAccount> GetAllAccounts()
         {
             HdAccount[] res = null;

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -126,8 +126,6 @@ namespace Stratis.Bitcoin.Features.Wallet
         [ActionDescription("Sends money to an address. Requires wallet to be unlocked using walletpassphrase.")]
         public async Task<uint256> SendToAddressAsync(BitcoinAddress address, decimal amount, string commentTx, string commentDest)
         {
-            WalletAccountReference account = this.GetWalletAccountReference();
-
             TransactionBuildContext context = new TransactionBuildContext(this.FullNode.Network)
             {
                 AccountReference = this.GetWalletAccountReference(),

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -760,30 +760,41 @@ namespace Stratis.Bitcoin.Features.Wallet
                 JsonConvert.DeserializeObject<List<string>>(addressesJson).ForEach(i => addresses.Add(BitcoinAddress.Create(i, this.FullNode.Network)));
             }
 
-            WalletAccountReference accountReference = this.GetWalletAccountReference();
-            IEnumerable<UnspentOutputReference> spendableTransactions = this.walletManager.GetSpendableTransactionsInAccount(accountReference, minConfirmations);
-
+            string walletName = this.GetWallet();
+            var accounts = this.walletManager.GetAccounts(walletName, Wallet.AllAccounts);
             var unspentCoins = new List<UnspentCoinModel>();
-            foreach (var spendableTx in spendableTransactions)
+
+            foreach (var account in accounts)
             {
-                if (spendableTx.Confirmations <= maxConfirmations)
+                // The intention here is to filter out cold staking accounts. The watch only account can be included.
+                if (!account.IsNormalAccount() && account.Name != Wallet.WatchOnlyAccountName)
+                    continue;
+
+                WalletAccountReference accountReference = new WalletAccountReference(walletName, account.Name);
+            
+                IEnumerable<UnspentOutputReference> spendableTransactions = this.walletManager.GetSpendableTransactionsInAccount(accountReference, minConfirmations);
+
+                foreach (var spendableTx in spendableTransactions)
                 {
-                    if (!addresses.Any() || addresses.Contains(BitcoinAddress.Create(spendableTx.Address.Address, this.FullNode.Network)))
+                    if (spendableTx.Confirmations > maxConfirmations)
+                        continue;
+
+                    if (addresses.Any() && !addresses.Contains(BitcoinAddress.Create(spendableTx.Address.Address, this.FullNode.Network)))
+                        continue;
+
+                    unspentCoins.Add(new UnspentCoinModel()
                     {
-                        unspentCoins.Add(new UnspentCoinModel()
-                        {
-                            Account = accountReference.AccountName,
-                            Address = spendableTx.Address.Address,
-                            Id = spendableTx.Transaction.Id,
-                            Index = spendableTx.Transaction.Index,
-                            Amount = spendableTx.Transaction.Amount,
-                            ScriptPubKeyHex = spendableTx.Transaction.ScriptPubKey.ToHex(),
-                            RedeemScriptHex = null, // TODO: Currently don't support P2SH wallet addresses, review if we do.
-                            Confirmations = spendableTx.Confirmations,
-                            IsSpendable = !spendableTx.Transaction.IsSpent(),
-                            IsSolvable = !spendableTx.Transaction.IsSpent() // If it's spendable we assume it's solvable.
-                        });
-                    }
+                        Account = accountReference.AccountName,
+                        Address = spendableTx.Address.Address,
+                        Id = spendableTx.Transaction.Id,
+                        Index = spendableTx.Transaction.Index,
+                        Amount = spendableTx.Transaction.Amount,
+                        ScriptPubKeyHex = spendableTx.Transaction.ScriptPubKey.ToHex(),
+                        RedeemScriptHex = null, // TODO: Currently don't support P2SH wallet addresses, review if we do.
+                        Confirmations = spendableTx.Confirmations,
+                        IsSpendable = (!spendableTx.Transaction.IsSpent()) && (spendableTx.Account.Name != Wallet.WatchOnlyAccountName),
+                        IsSolvable = (!spendableTx.Transaction.IsSpent()) && (spendableTx.Account.Name != Wallet.WatchOnlyAccountName) // If it's spendable we assume it's solvable.
+                    });
                 }
             }
 
@@ -931,11 +942,10 @@ namespace Stratis.Bitcoin.Features.Wallet
         }
 
         /// <summary>
-        /// Gets the first account from the "default" wallet if it is specified,
-        /// otherwise returns the first available account in the existing wallets.
+        /// Gets the name of the wallet currently associated with RPC. This can be changed via the 'setwallet' RPC command.
         /// </summary>
-        /// <returns>Reference to the default wallet account, or the first available if no default wallet is specified.</returns>
-        private WalletAccountReference GetWalletAccountReference()
+        /// <returns>The active wallet name.</returns>
+        private string GetWallet()
         {
             string walletName = null;
 
@@ -958,6 +968,18 @@ namespace Stratis.Bitcoin.Features.Wallet
             if (walletName == null)
                 throw new RPCServerException(RPCErrorCode.RPC_INVALID_REQUEST, "No wallet found");
 
+            return walletName;
+        }
+
+        /// <summary>
+        /// Gets the first account from the "default" wallet if it is specified,
+        /// otherwise returns the first available account in the existing wallets.
+        /// </summary>
+        /// <returns>Reference to the default wallet account, or the first available if no default wallet is specified.</returns>
+        private WalletAccountReference GetWalletAccountReference()
+        {
+            string walletName = GetWallet();
+
             HdAccount account = this.walletManager.GetAccounts(walletName).FirstOrDefault();
 
             if (account == null)
@@ -973,23 +995,7 @@ namespace Stratis.Bitcoin.Features.Wallet
         /// <returns>Reference to the default wallet watch only account, or the first available if no default wallet is specified.</returns>
         private WalletAccountReference GetWatchOnlyWalletAccountReference()
         {
-            string walletName = null;
-
-            if (string.IsNullOrWhiteSpace(WalletRPCController.CurrentWalletName))
-            {
-                if (this.walletSettings.IsDefaultWalletEnabled())
-                    walletName = this.walletManager.GetWalletsNames().FirstOrDefault(w => w == this.walletSettings.DefaultWalletName);
-                else
-                {
-                    // TODO: Support multi wallet like core by mapping passed RPC credentials to a wallet/account
-                    walletName = this.walletManager.GetWalletsNames().FirstOrDefault();
-                }
-            }
-            else
-            {
-                // Read the wallet name from the class instance.
-                walletName = WalletRPCController.CurrentWalletName;
-            }
+            string walletName = GetWallet();
 
             if (walletName == null)
                 throw new RPCServerException(RPCErrorCode.RPC_INVALID_REQUEST, "No wallet found");

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/RPCTestsMutable.cs
@@ -73,25 +73,40 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
                 TestHelper.ConnectAndSync(node, node2);
 
                 UnspentOutputReference tx = node2.FullNode.WalletManager().GetUnspentTransactionsInWallet("mywallet", 0, Features.Wallet.Wallet.NormalAccounts).First();
-
+                
                 RPCClient rpc = node.CreateRPCClient();
 
                 PubKey pubKey = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(tx.Address.Pubkey);
+                PubKey pubKey2 = new Key().PubKey;
+
+                uint256 blockHash = rpc.GenerateToAddress(1, pubKey2.GetAddress(rpc.Network)).First();
+                Block block = rpc.GetBlock(blockHash);
+                uint256 tx2 = block.Transactions.First().GetHash();
 
                 Assert.Throws<RPCException>(() => rpc.SendCommand(RPCOperations.gettransaction, tx.Transaction.Id.ToString(), true));
+                Assert.Throws<RPCException>(() => rpc.SendCommand(RPCOperations.gettransaction, tx2.ToString(), true));;
 
+                // Test that adding the same pubkey twice doesn't throw.
+                rpc.ImportPubKey(pubKey.ToHex());
                 rpc.ImportPubKey(pubKey.ToHex());
 
+                // Add a second pubkey and ensure it doesn't throw.
+                rpc.ImportPubKey(pubKey2.ToHex());
+
+                // Add an arbitrary pubkey and ensure it doesn't throw.
+                rpc.ImportPubKey(new Key().PubKey.ToHex());
+                
                 TestBase.WaitLoop(() => node.FullNode.WalletManager().WalletTipHeight == node2.FullNode.WalletManager().WalletTipHeight);
 
                 TestBase.WaitLoop(() =>
                 {
                     try
                     {
-                        // Check if gettransaction can now find the transaction in the watch only account.
+                        // Check if gettransaction can now find the transactions in the watch only account.
                         RPCResponse walletTx = rpc.SendCommand(RPCOperations.gettransaction, tx.Transaction.Id.ToString(), true);
+                        RPCResponse walletTx2 = rpc.SendCommand(RPCOperations.gettransaction, tx2.ToString(), true);
 
-                        return walletTx != null;
+                        return walletTx != null && walletTx2 != null;
                     }
                     catch (RPCException e)
                     {
@@ -99,8 +114,9 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
                     }
                 });
 
-                // Check that when include_watchonly is not set, the watched transaction cannot be located in the normal wallet accounts.
+                // Check that when include_watchonly is not set, the watched addresses' transactions cannot be located in the normal wallet accounts.
                 Assert.Throws<RPCException>(() => rpc.SendCommand(RPCOperations.gettransaction, tx.Transaction.Id.ToString(), false));
+                Assert.Throws<RPCException>(() => rpc.SendCommand(RPCOperations.gettransaction, tx2.ToString(), false));
             }
         }
 

--- a/src/Stratis.Features.SQLiteWalletRepository/DBConnection.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/DBConnection.cs
@@ -296,40 +296,46 @@ namespace Stratis.Features.SQLiteWalletRepository
             }
         }
 
-        internal List<HDAddress> CreateWatchOnlyAddresses(HDAccount account, int addressType, List<HdAddress> hdAddresses, bool force = false)
+        internal List<HDAddress> CreateWatchOnlyAddresses(WalletAccountReference accountReference, HDAccount account, int addressType, List<HdAddress> hdAddresses, bool force = false)
         {
             var addresses = new List<HDAddress>();
             int addressIndex = HDAddress.GetAddressCount(this.SQLiteConnection, account.WalletId, account.AccountIndex, addressType);
+            
+            IEnumerable<HdAddress> existingAddresses = this.Repository.GetAccountAddresses(accountReference, addressType, Int32.MaxValue);
+
+            var existingPubKeys = new HashSet<PubKey>();
+
+            foreach (HdAddress existing in existingAddresses)
+            {
+                existingPubKeys.Add(PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(existing.Pubkey));
+            }
 
             foreach (HdAddress hdAddress in hdAddresses)
             {
-                try
+                var pubKey = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(hdAddress.Pubkey);
+
+                if (existingPubKeys.Contains(pubKey))
+                    continue;
+
+                HDAddress address = this.Repository.CreateAddress(account, addressType, addressIndex, pubKey);
+
+                if (force || this.Repository.TestMode)
                 {
-                    var pubKey = PayToPubkeyTemplate.Instance.ExtractScriptPubKeyParameters(hdAddress.Pubkey);
-                    HDAddress address = this.Repository.CreateAddress(account, addressType, addressIndex, pubKey);
-
-                    if (force || this.Repository.TestMode)
-                    {
-                        // Allow greater control over field values for legacy tests.
-                        address.Address = hdAddress?.Address;
-                        address.ScriptPubKey = hdAddress.ScriptPubKey?.ToHex();
-                        address.PubKey = hdAddress.Pubkey?.ToHex();
-                        this.Insert(address);
-                        this.AddTransactions(account, hdAddress, hdAddress.Transactions);
-                    }
-                    else
-                    {
-                        this.Insert(address);
-                    }
-
-                    addresses.Add(address);
-
-                    addressIndex++;
+                    // Allow greater control over field values for legacy tests.
+                    address.Address = hdAddress?.Address;
+                    address.ScriptPubKey = hdAddress.ScriptPubKey?.ToHex();
+                    address.PubKey = hdAddress.Pubkey?.ToHex();
+                    this.Insert(address);
+                    this.AddTransactions(account, hdAddress, hdAddress.Transactions);
                 }
-                catch (Exception)
+                else
                 {
-                    throw;
+                    this.Insert(address);
                 }
+
+                addresses.Add(address);
+
+                addressIndex++;
             }
 
             return addresses;

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -1326,7 +1326,6 @@ namespace Stratis.Features.SQLiteWalletRepository
                 if (extPubKey == null)
                 {
                     // We cannot derive a pubKey from the scriptPubKey as it has been hashed already.
-                    // Therefore we have to construct an UnspentOutputReference
                     Script watchOnlyScriptPubKey = Script.FromHex(transactionData.ScriptPubKey);
 
                     HdAddress watchOnlyAddress = this.ToHdAddress(new HDAddress()
@@ -1337,7 +1336,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                         PubKey = watchOnlyScriptPubKey.ToHex(),
                         ScriptPubKey = watchOnlyScriptPubKey.ToHex(),
                         Address = transactionData.Address,
-                        // No way of determining this without the actual pubkey available.
+                        // TODO: It may be possible to construct a P2WPKH address using the P2PKH scriptPubKey as a starting point
                         //Bech32Address = ""
                     }, this.Network);
 
@@ -1356,16 +1355,14 @@ namespace Stratis.Features.SQLiteWalletRepository
                     continue;
                 }
 
-                PubKey pubKey = null;
-
                 var keyPath = new KeyPath($"{transactionData.AddressType}/{transactionData.AddressIndex}");
 
-                if (!cachedPubKeys.TryGetValue(keyPath, out pubKey))
+                if (!cachedPubKeys.TryGetValue(keyPath, out PubKey pubKey))
                 {
                     pubKey = extPubKey.Derive(keyPath).PubKey;
                     cachedPubKeys.Add(keyPath, pubKey);
                 }
-                    
+
                 Script scriptPubKey = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(pubKey);
                 Script witScriptPubKey = PayToWitPubKeyHashTemplate.Instance.GenerateScriptPubKey(pubKey);
 

--- a/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
+++ b/src/Stratis.Features.SQLiteWalletRepository/SQLiteWalletRepository.cs
@@ -620,7 +620,7 @@ namespace Stratis.Features.SQLiteWalletRepository
                 if (!force && !this.TestMode && account.ExtPubKey != null)
                     throw new Exception("Addresses can only be added to watch-only accounts.");
 
-                conn.CreateWatchOnlyAddresses(account, addressType, addresses, force);
+                conn.CreateWatchOnlyAddresses(new WalletAccountReference(walletName, accountName), account, addressType, addresses, force);
                 conn.Commit();
 
                 walletContainer.AddressesOfInterest.AddAll(account.WalletId, account.AccountIndex);


### PR DESCRIPTION
Watch-only transactions are stored in an account without an extPubKey (as all the transactions generally have pubkeys that are not derived from any keypath within the wallet). This requires some workarounds at the wallet database level.