### PR TITLE
[Proposal] Show CS address in getrawtransaction output

### DIFF
--- a/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
@@ -281,6 +281,8 @@ namespace Stratis.Bitcoin.Controllers.Models
         /// <param name="network">The network where the transaction was conducted.</param>
         public ScriptPubKey(NBitcoin.Script script, Network network) : base(script)
         {
+            this.Type = this.GetScriptType(script.FindTemplate(network));
+
             // To avoid modifying the very low-level GetDestination logic, check for cold staking scripts first.
             // The decision to show the cold pubkey's address in the 'addresses' list is based on the following:
             // 1. It seems more intuitive from a user's perspective that their balance will appear against this address.
@@ -299,7 +301,6 @@ namespace Stratis.Bitcoin.Controllers.Models
             }
 
             var destinations = new List<TxDestination> { script.GetDestination(network) };
-            this.Type = this.GetScriptType(script.FindTemplate(network));
 
             if (destinations[0] == null)
             {

--- a/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
@@ -281,6 +281,23 @@ namespace Stratis.Bitcoin.Controllers.Models
         /// <param name="network">The network where the transaction was conducted.</param>
         public ScriptPubKey(NBitcoin.Script script, Network network) : base(script)
         {
+            // To avoid modifying the very low-level GetDestination logic, check for cold staking scripts first.
+            // The decision to show the cold pubkey's address in the 'addresses' list is based on the following:
+            // 1. It seems more intuitive from a user's perspective that their balance will appear against this address.
+            // 2. A balance should never appear against a hot address from an exchange's perspective, as they have no guarantee they will be able to spend those funds.
+            // It is also presumed that it is preferable to show an address rather than not, as a block explorer would then have to show only a relatively meaningless raw script as the output's destination.
+            // Another considered alternative was to show both addresses, but with a modified version byte. The underlying pubkey hashes would be the same, but the resulting addresses would be visually distinct from regular P2PKH.
+            // This may have caused user confusion, however, as the modified addresses would not look like those they used to configure the cold staking setup, making searching for them on a block explorer more difficult.
+            if (script.IsScriptType(ScriptType.ColdStaking))
+            {
+                var coldPubKeyHash = new KeyId(script.ToBytes(true).SafeSubarray(28, 20));
+
+                this.ReqSigs = 1;
+                this.Addresses = new List<string> { coldPubKeyHash.GetAddress(network).ToString() };
+
+                return;
+            }
+
             var destinations = new List<TxDestination> { script.GetDestination(network) };
             this.Type = this.GetScriptType(script.FindTemplate(network));
 
@@ -328,6 +345,7 @@ namespace Stratis.Bitcoin.Controllers.Models
         {
             if (template == null)
                 return "nonstandard";
+
             switch (template.Type)
             {
                 case TxOutType.TX_PUBKEY:

--- a/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/TransactionModel.cs
@@ -283,7 +283,7 @@ namespace Stratis.Bitcoin.Controllers.Models
         {
             this.Type = this.GetScriptType(script.FindTemplate(network));
 
-            // To avoid modifying the very low-level GetDestination logic, check for cold staking scripts first.
+            // To avoid modifying the very low-level GetDestination logic, check for a cold staking script first.
             // The decision to show the cold pubkey's address in the 'addresses' list is based on the following:
             // 1. It seems more intuitive from a user's perspective that their balance will appear against this address.
             // 2. A balance should never appear against a hot address from an exchange's perspective, as they have no guarantee they will be able to spend those funds.


### PR DESCRIPTION
The rationale for this is in the code comments; essentially this is to improve the user experience for block explorer users trying to check their cold staking balances or staking activity.

After picking a cold staking transaction ID at random, the modified `getrawtransaction` output looks like this:

```
    {
      "value": 780.5398,
      "n": 1,
      "scriptPubKey": {
        "asm": "OP_DUP OP_HASH160 OP_ROT OP_IF OP_CHECKCOLDSTAKEVERIFY 98f869eb17b7d9ed5529bb8d139d960624ab7c39 OP_ELSE d8e6de0c675ad75f430ccbd08f3a8b0e519dc6ec OP_ENDIF OP_EQUALVERIFY OP_CHECKSIG",
        "hex": "76a97b63b91498f869eb17b7d9ed5529bb8d139d960624ab7c396714d8e6de0c675ad75f430ccbd08f3a8b0e519dc6ec6888ac",
        "reqSigs": 1,
        "type": "coldstaking",
        "addresses": [
          "Xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
        ]
      }
    }
```