### PR TITLE
[NFT] Add consensus endpoint that returns both tip hash and height

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusController.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusController.cs
@@ -156,5 +156,33 @@ namespace Stratis.Bitcoin.Features.Consensus
                 return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
             }
         }
+
+        /// <summary>
+        /// Returns the current tip of consensus.
+        /// </summary>
+        /// <returns>Json formatted <see cref="uint256"/> hash and height of the block at the consensus tip. Returns <see cref="IActionResult"/> formatted error if fails.</returns>
+        /// <response code="200">Returns the tip hash and height.</response>
+        /// <response code="400">Unexpected exception occurred</response>
+        [Route("api/[controller]/tip")]
+        [HttpGet]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        public IActionResult ConsensusTip()
+        {
+            try
+            {
+                if (this.ConsensusManager.Tip == null)
+                    return this.Json("Consensus is not initialized.");
+
+                var tip = this.ConsensusManager.Tip;
+
+                return this.Json(new { TipHash = tip.HashBlock, TipHeight = tip.Height });
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
     }
 }

--- a/src/Stratis.CirrusD/Properties/launchSettings.json
+++ b/src/Stratis.CirrusD/Properties/launchSettings.json
@@ -1,7 +1,8 @@
-﻿{
+{
   "profiles": {
     "Stratis.CirrusD": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "-datadir=D:\\Stratis\\CirrusTestNetNode\\Data -testnet"
     },
     "Stratis.CirrusD Test": {
       "commandName": "Project",

--- a/src/Stratis.CirrusD/Properties/launchSettings.json
+++ b/src/Stratis.CirrusD/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "Stratis.CirrusD": {
-      "commandName": "Project",
-      "commandLineArgs": "-datadir=D:\\Stratis\\CirrusTestNetNode\\Data -testnet"
+      "commandName": "Project"
     },
     "Stratis.CirrusD Test": {
       "commandName": "Project",


### PR DESCRIPTION
This is so that we don't have to do 2-3 calls to get the block number/height and hash