### PR TITLE
Fix merge error

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/LevelDbProvenBlockHeaderRepository.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ProvenBlockHeaders/LevelDbProvenBlockHeaderRepository.cs
@@ -86,9 +86,6 @@ namespace Stratis.Bitcoin.Features.Consensus.ProvenBlockHeaders
         {
             Task task = Task.Run(() =>
             {
-                // Open a connection to a new DB and create if not found
-                var options = new Options { CreateIfMissing = true };
-                this.leveldb = new DB(options, this.databaseFolder);
 
                 this.TipHashHeight = this.GetTipHash();
 


### PR DESCRIPTION
Fixes the merge error introduced by commit da61e1c3.

See https://github.com/stratisproject/StratisFullNode/commit/da61e1c30d2371bc06556a937985300d54bf28f6#diff-ea7890cb6e24049af7766bb43a9f2437ae14c06a297585c0224e31a3155d8a0cR89-R92

and https://github.com/stratisproject/StratisFullNode/commit/da61e1c30d2371bc06556a937985300d54bf28f6#diff-ea7890cb6e24049af7766bb43a9f2437ae14c06a297585c0224e31a3155d8a0cR77-R78

The code in the initialize should be removed since its also present in the constructor.