### PR TITLE
Improve LastRemovalEventId determinism by adding ordering

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/Voting/JoinFederationRequestService.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/JoinFederationRequestService.cs
@@ -49,6 +49,23 @@ namespace Stratis.Features.PoA.Voting
             this.votingManager = votingManager;
         }
 
+        public static byte[] GetFederationMemberBytes(JoinFederationRequest joinRequest, Network network, Network counterChainNetwork)
+        {
+            Script collateralScript = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(joinRequest.CollateralMainchainAddress);
+            BitcoinAddress bitcoinAddress = collateralScript.GetDestinationAddress(counterChainNetwork);
+            var collateralFederationMember = new CollateralFederationMember(joinRequest.PubKey, false, joinRequest.CollateralAmount, bitcoinAddress.ToString());
+
+            return (network.Consensus.ConsensusFactory as CollateralPoAConsensusFactory).SerializeFederationMember(collateralFederationMember);
+        }
+
+        public static void SetLastRemovalEventId(JoinFederationRequest joinRequest, byte[] federationMemberBytes, VotingManager votingManager)
+        {
+            Poll poll = votingManager.GetApprovedPolls().OrderByDescending(p => p.PollStartBlockData.Height).FirstOrDefault(x => x.IsExecuted &&
+                x.VotingData.Key == VoteKey.KickFederationMember && x.VotingData.Data.SequenceEqual(federationMemberBytes));
+
+            joinRequest.RemovalEventId = (poll == null) ? Guid.Empty : new Guid(poll.PollExecutedBlockData.Hash.ToBytes().TakeLast(16).ToArray());
+        }
+
         public async Task<PubKey> JoinFederationAsync(JoinFederationRequestModel request, CancellationToken cancellationToken)
         {
             // Wait until the node is synced before joining.
@@ -74,13 +91,7 @@ namespace Stratis.Features.PoA.Voting
             var joinRequest = new JoinFederationRequest(minerKey.PubKey, new Money(expectedCollateralAmount, MoneyUnit.BTC), addressKey);
 
             // Populate the RemovalEventId.
-            var collateralFederationMember = new CollateralFederationMember(minerKey.PubKey, false, joinRequest.CollateralAmount, request.CollateralAddress);
-
-            byte[] federationMemberBytes = (this.network.Consensus.ConsensusFactory as CollateralPoAConsensusFactory).SerializeFederationMember(collateralFederationMember);
-            Poll poll = this.votingManager.GetApprovedPolls().FirstOrDefault(x => x.IsExecuted &&
-                  x.VotingData.Key == VoteKey.KickFederationMember && x.VotingData.Data.SequenceEqual(federationMemberBytes));
-
-            joinRequest.RemovalEventId = (poll == null) ? Guid.Empty : new Guid(poll.PollExecutedBlockData.Hash.ToBytes().TakeLast(16).ToArray());
+            SetLastRemovalEventId(joinRequest, GetFederationMemberBytes(joinRequest, this.network, this.counterChainSettings.CounterChainNetwork), this.votingManager);
 
             // Get the signature by calling the counter-chain "signmessage" API.
             var signMessageRequest = new SignMessageRequest()

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/JoinFederationRequestService.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/JoinFederationRequestService.cs
@@ -60,7 +60,7 @@ namespace Stratis.Features.PoA.Voting
 
         public static void SetLastRemovalEventId(JoinFederationRequest joinRequest, byte[] federationMemberBytes, VotingManager votingManager)
         {
-            Poll poll = votingManager.GetApprovedPolls().OrderByDescending(p => p.PollStartBlockData.Height).FirstOrDefault(x => x.IsExecuted &&
+            Poll poll = votingManager.GetExecutedPolls().OrderByDescending(p => p.PollExecutedBlockData.Height).FirstOrDefault(x =>
                 x.VotingData.Key == VoteKey.KickFederationMember && x.VotingData.Data.SequenceEqual(federationMemberBytes));
 
             joinRequest.RemovalEventId = (poll == null) ? Guid.Empty : new Guid(poll.PollExecutedBlockData.Hash.ToBytes().TakeLast(16).ToArray());

--- a/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
+++ b/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
@@ -9,7 +9,6 @@ using Stratis.Bitcoin.EventBus.CoreEvents;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Features.PoA.Voting;
 using Stratis.Bitcoin.PoA.Features.Voting;
-using Stratis.Bitcoin.Signals;
 using Stratis.Features.Collateral.CounterChain;
 using Stratis.Features.PoA.Voting;
 
@@ -18,16 +17,14 @@ namespace Stratis.Features.Collateral
     public class JoinFederationRequestMonitor
     {
         private readonly ILogger logger;
-        private readonly ISignals signals;
         private readonly VotingManager votingManager;
         private readonly Network network;
         private readonly Network counterChainNetwork;
         private readonly IFederationManager federationManager;
         private readonly HashSet<uint256> pollsCheckedWithJoinFederationRequestMonitor;
 
-        public JoinFederationRequestMonitor(VotingManager votingManager, Network network, CounterChainNetworkWrapper counterChainNetworkWrapper, IFederationManager federationManager, ISignals signals, IJoinFederationRequestService joinFederationRequestService)
+        public JoinFederationRequestMonitor(VotingManager votingManager, Network network, CounterChainNetworkWrapper counterChainNetworkWrapper, IFederationManager federationManager)
         {
-            this.signals = signals;
             this.logger = LogManager.GetCurrentClassLogger();
             this.votingManager = votingManager;
             this.network = network;

--- a/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
+++ b/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
@@ -5,10 +5,12 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration.Logging;
+using Stratis.Bitcoin.EventBus;
 using Stratis.Bitcoin.EventBus.CoreEvents;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Features.PoA.Voting;
 using Stratis.Bitcoin.PoA.Features.Voting;
+using Stratis.Bitcoin.Signals;
 using Stratis.Features.Collateral.CounterChain;
 using Stratis.Features.PoA.Voting;
 
@@ -17,14 +19,17 @@ namespace Stratis.Features.Collateral
     public class JoinFederationRequestMonitor
     {
         private readonly ILogger logger;
+        private readonly ISignals signals;
+        private SubscriptionToken blockConnectedToken;
         private readonly VotingManager votingManager;
         private readonly Network network;
         private readonly Network counterChainNetwork;
         private readonly IFederationManager federationManager;
         private readonly HashSet<uint256> pollsCheckedWithJoinFederationRequestMonitor;
 
-        public JoinFederationRequestMonitor(VotingManager votingManager, Network network, CounterChainNetworkWrapper counterChainNetworkWrapper, IFederationManager federationManager)
+        public JoinFederationRequestMonitor(VotingManager votingManager, Network network, CounterChainNetworkWrapper counterChainNetworkWrapper, IFederationManager federationManager, ISignals signals)
         {
+            this.signals = signals;
             this.logger = LogManager.GetCurrentClassLogger();
             this.votingManager = votingManager;
             this.network = network;
@@ -37,6 +42,8 @@ namespace Stratis.Features.Collateral
 
         public Task InitializeAsync()
         {
+            this.blockConnectedToken = this.signals.Subscribe<BlockConnected>(this.OnBlockConnected);
+
             return Task.CompletedTask;
         }
 

--- a/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
+++ b/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
@@ -5,13 +5,13 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration.Logging;
-using Stratis.Bitcoin.EventBus;
 using Stratis.Bitcoin.EventBus.CoreEvents;
 using Stratis.Bitcoin.Features.PoA;
 using Stratis.Bitcoin.Features.PoA.Voting;
 using Stratis.Bitcoin.PoA.Features.Voting;
 using Stratis.Bitcoin.Signals;
 using Stratis.Features.Collateral.CounterChain;
+using Stratis.Features.PoA.Voting;
 
 namespace Stratis.Features.Collateral
 {
@@ -19,14 +19,13 @@ namespace Stratis.Features.Collateral
     {
         private readonly ILogger logger;
         private readonly ISignals signals;
-        private SubscriptionToken blockConnectedToken;
         private readonly VotingManager votingManager;
         private readonly Network network;
         private readonly Network counterChainNetwork;
         private readonly IFederationManager federationManager;
         private readonly HashSet<uint256> pollsCheckedWithJoinFederationRequestMonitor;
 
-        public JoinFederationRequestMonitor(VotingManager votingManager, Network network, CounterChainNetworkWrapper counterChainNetworkWrapper, IFederationManager federationManager, ISignals signals)
+        public JoinFederationRequestMonitor(VotingManager votingManager, Network network, CounterChainNetworkWrapper counterChainNetworkWrapper, IFederationManager federationManager, ISignals signals, IJoinFederationRequestService joinFederationRequestService)
         {
             this.signals = signals;
             this.logger = LogManager.GetCurrentClassLogger();
@@ -41,8 +40,6 @@ namespace Stratis.Features.Collateral
 
         public Task InitializeAsync()
         {
-            this.blockConnectedToken = this.signals.Subscribe<BlockConnected>(this.OnBlockConnected);
-
             return Task.CompletedTask;
         }
 
@@ -95,11 +92,7 @@ namespace Stratis.Features.Collateral
                     }
 
                     // Fill in the request.removalEventId (if any).
-                    Script collateralScript = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(request.CollateralMainchainAddress);
-
-                    var collateralFederationMember = new CollateralFederationMember(request.PubKey, false, request.CollateralAmount, collateralScript.GetDestinationAddress(this.counterChainNetwork).ToString());
-
-                    byte[] federationMemberBytes = consensusFactory.SerializeFederationMember(collateralFederationMember);
+                    byte[] federationMemberBytes = JoinFederationRequestService.GetFederationMemberBytes(request, this.network, this.counterChainNetwork);
 
                     // Nothing to do if already voted.
                     if (this.votingManager.AlreadyVotingFor(VoteKey.AddFederationMember, federationMemberBytes))
@@ -110,10 +103,7 @@ namespace Stratis.Features.Collateral
                     }
 
                     // Populate the RemovalEventId.
-                    Poll poll = this.votingManager.GetApprovedPolls().FirstOrDefault(x => x.IsExecuted &&
-                          x.VotingData.Key == VoteKey.KickFederationMember && x.VotingData.Data.SequenceEqual(federationMemberBytes));
-
-                    request.RemovalEventId = (poll == null) ? Guid.Empty : new Guid(poll.PollExecutedBlockData.Hash.ToBytes().TakeLast(16).ToArray());
+                    JoinFederationRequestService.SetLastRemovalEventId(request, federationMemberBytes, this.votingManager);
 
                     // Check the signature.
                     PubKey key = PubKey.RecoverFromMessage(request.SignatureMessage, request.Signature);


### PR DESCRIPTION
This PR adds an `OrderByDescending` to the `FirstOrDefault` used to determine the last kick poll.

Also, two methods are added to unify two slightly different implementations of the same logic.