### PR TITLE
Refactor federation member votes from PoA miner

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -250,7 +250,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         }
 
         /// <summary>
-        /// Tells us whether we have already voted to boot a federation member.
+        /// Tells us whether we have already voted on this poll.
         /// </summary>
         public bool AlreadyVotingFor(VoteKey voteKey, byte[] federationMemberBytes)
         {

--- a/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
+++ b/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
@@ -138,10 +138,6 @@ namespace Stratis.Features.Collateral
                     ChainedHeader pollStartHeader = this.chainIndexer.GetHeader(poll.PollStartBlockData.Hash);
                     ChainedHeader votingRequestHeader = pollStartHeader.Previous;
 
-                    // Already checked?
-                    if (this.joinFederationRequestMonitor.AlreadyChecked(votingRequestHeader.HashBlock))
-                        continue;
-
                     ChainedHeaderBlock blockData = this.consensusManager.GetBlockData(votingRequestHeader.HashBlock);
 
                     this.joinFederationRequestMonitor.OnBlockConnected(new Bitcoin.EventBus.CoreEvents.BlockConnected(

--- a/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
+++ b/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
@@ -70,7 +70,7 @@ namespace Stratis.Features.Collateral
                         continue;
 
                     // Only mining federation members vote to include new members.
-                    modifiedFederation = modifiedFederation ?? this.votingManager.GetModifiedFederation(blockConnectedData.ConnectedBlock.ChainedHeader);
+                    modifiedFederation ??= this.votingManager.GetModifiedFederation(blockConnectedData.ConnectedBlock.ChainedHeader);
                     if (!modifiedFederation.Any(m => m.PubKey == this.federationManager.CurrentFederationKey.PubKey))
                         return;
 


### PR DESCRIPTION
We can greatly simplify adding votes from the miner's perspective without going through all the join federation request monitor logic.