### PR TITLE
Enable selective coinview "Rewind" optimisation

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/TestRulesContext.cs
@@ -121,7 +121,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules
             throw new NotImplementedException();
         }
 
-        public override Task<RewindState> RewindAsync()
+        public override Task<RewindState> RewindAsync(HashHeightPair target)
         {
             throw new NotImplementedException();
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -570,7 +570,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             }
         }
 
-        public HashHeightPair Rewind()
+        public HashHeightPair Rewind(HashHeightPair target = null)
         {
             if (this.innerBlockHash == null)
             {
@@ -582,7 +582,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
 
             lock (this.lockobj)
             {
-                HashHeightPair hash = this.coindb.Rewind();
+                HashHeightPair hash = this.coindb.Rewind(target);
 
                 foreach (KeyValuePair<OutPoint, CacheItem> cachedUtxoItem in this.cachedUtxoItems)
                 {

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinView.cs
@@ -57,8 +57,12 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// and restoring recently spent outputs as UTXOs.
         /// </para>
         /// </summary>
+        /// <param name="target">The final rewind target or <c>null</c> if a single block should be rewound. See remarks.</param>
         /// <returns>Hash of the block header which is now the tip of the rewound coinview.</returns>
-        HashHeightPair Rewind();
+        /// <remarks>This method can be implemented to rewind one or more blocks. Implementations
+        /// that rewind only one block can ignore the target, while more advanced implementations
+        /// can rewind a batch of multiple blocks but not overshooting the <paramref name="target"/>.</remarks>
+        HashHeightPair Rewind(HashHeightPair target);
 
         /// <summary>
         /// Gets the rewind data by block height.

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/DBreezeCoindb.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/DBreezeCoindb.cs
@@ -258,7 +258,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         }
 
         /// <inheritdoc />
-        public HashHeightPair Rewind()
+        public HashHeightPair Rewind(HashHeightPair target)
         {
             HashHeightPair res = null;
             using (DBreeze.Transactions.Transaction transaction = this.CreateTransaction())

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/ICoindb.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/ICoindb.cs
@@ -54,8 +54,13 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// and restoring recently spent outputs as UTXOs.
         /// </para>
         /// </summary>
+        /// <param name="target">The final rewind target or <c>null</c> if a single block should be rewound. See remarks.</param>
         /// <returns>Hash of the block header which is now the tip of the rewound coinview.</returns>
-        HashHeightPair Rewind();
+        /// <remarks>This method can be implemented to rewind one or more blocks. Implementations
+        /// that rewind only one block can ignore the target, while more advanced implementations
+        /// can rewind a batch of multiple blocks but not overshooting the <paramref name="target"/>.
+        /// </remarks>
+        HashHeightPair Rewind(HashHeightPair target);
 
         /// <summary>
         /// Gets the rewind data by block height.

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/LeveldbCoindb.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/LeveldbCoindb.cs
@@ -293,7 +293,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         }
 
         /// <inheritdoc />
-        public HashHeightPair Rewind()
+        public HashHeightPair Rewind(HashHeightPair target)
         {
             using (var batch = new WriteBatch())
             {

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/RocksDbCoindb.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/RocksDbCoindb.cs
@@ -278,7 +278,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         }
 
         /// <inheritdoc />
-        public HashHeightPair Rewind()
+        public HashHeightPair Rewind(HashHeightPair target)
         {
             using (var batch = new WriteBatch())
             {

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/InMemoryCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/InMemoryCoinView.cs
@@ -100,7 +100,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             throw new NotImplementedException();
         }
 
-        public HashHeightPair Rewind()
+        public HashHeightPair Rewind(HashHeightPair target)
         {
             throw new NotImplementedException();
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
@@ -52,11 +52,11 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
         }
 
         /// <inheritdoc />
-        public override Task<RewindState> RewindAsync()
+        public override Task<RewindState> RewindAsync(HashHeightPair target)
         {
             var state = new RewindState()
             {
-                BlockHash = this.UtxoSet.Rewind()
+                BlockHash = this.UtxoSet.Rewind(target)
             };
 
             return Task.FromResult(state);
@@ -84,7 +84,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
 
                 // If the block store was initialized behind the coin view's tip, rewind it to on or before it's tip.
                 // The node will complete loading before connecting to peers so the chain will never know that a reorg happened.
-                coinViewTip = coinDatabase.Rewind();
+                coinViewTip = coinDatabase.Rewind(new HashHeightPair(chainTip));
             }
 
             this.logger.LogInformation("Coin view initialized at '{0}'.", coinDatabase.GetTipHash());

--- a/src/Stratis.Bitcoin.Features.Consensus/StakeChainStore.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/StakeChainStore.cs
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.Features.Consensus
             {
                 this.logger.LogInformation("Rewinding {0} from '{1}'.", this.GetType().Name, coinViewTip);
 
-                coinViewTip = this.stakeDb.Rewind();
+                coinViewTip = this.stakeDb.Rewind(coinViewTip);
                 currentHeader = this.chainIndexer.GetHeader(coinViewTip.Hash);
             }
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
@@ -75,7 +75,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             throw new NotImplementedException();
         }
 
-        public HashHeightPair Rewind()
+        public HashHeightPair Rewind(HashHeightPair target)
         {
             throw new NotImplementedException();
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTester.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTester.cs
@@ -77,9 +77,9 @@ namespace Stratis.Bitcoin.IntegrationTests
             return newHash;
         }
 
-        public HashHeightPair Rewind()
+        public HashHeightPair Rewind(HashHeightPair target = null)
         {
-            this.hash = this.coinView.Rewind();
+            this.hash = this.coinView.Rewind(target);
             this.blockHeight--;
             return this.hash;
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
@@ -100,7 +100,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <inheritdoc />
-        public HashHeightPair Rewind()
+        public HashHeightPair Rewind(HashHeightPair target)
         {
             throw new NotImplementedException();
         }

--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -252,7 +252,7 @@ namespace Stratis.Bitcoin.Consensus
 
                 // In case block store initialized behind, rewind until or before the block store tip.
                 // The node will complete loading before connecting to peers so the chain will never know if a reorg happened.
-                RewindState transitionState = await this.ConsensusRules.RewindAsync().ConfigureAwait(false);
+                RewindState transitionState = await this.ConsensusRules.RewindAsync(new HashHeightPair(this.chainState.BlockStoreTip)).ConfigureAwait(false);
                 coinViewTip = transitionState.BlockHash;
             }
 
@@ -739,7 +739,7 @@ namespace Stratis.Bitcoin.Consensus
                     }
                 }
 
-                await this.ConsensusRules.RewindAsync().ConfigureAwait(false);
+                await this.ConsensusRules.RewindAsync(new HashHeightPair(current.Previous)).ConfigureAwait(false);
 
                 lock (this.peerLock)
                 {

--- a/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
@@ -293,7 +293,7 @@ namespace Stratis.Bitcoin.Consensus
         public abstract HashHeightPair GetBlockHash();
 
         /// <inheritdoc />
-        public abstract Task<RewindState> RewindAsync();
+        public abstract Task<RewindState> RewindAsync(HashHeightPair target);
 
         [NoTrace]
         public T GetRule<T>() where T : ConsensusRuleBase

--- a/src/Stratis.Bitcoin/Consensus/IConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/IConsensusRuleEngine.cs
@@ -52,8 +52,12 @@ namespace Stratis.Bitcoin.Consensus
         /// and restoring the chain to an earlier state.
         /// </para>
         /// </summary>
+        /// <param name="target">The final rewind target or <c>null</c> if a single block should be rewound. See remarks.</param>
         /// <returns>Hash of the block header which is now the tip of the chain.</returns>
-        Task<RewindState> RewindAsync();
+        /// <remarks>This method can be implemented to rewind one or more blocks. Implementations
+        /// that rewind only one block can ignore the target, while more advanced implementations
+        /// can rewind a batch of multiple blocks but not overshooting the <paramref name="target"/>.</remarks>
+        Task<RewindState> RewindAsync(HashHeightPair target);
 
         /// <summary>Execute header validation rules.</summary>
         /// <param name="header">The chained header that is going to be validated.</param>


### PR DESCRIPTION
This PR lays the groundwork to enable selective CoinView `Rewind` optimisation. It does so by supplying the `Rewind` method with a `target` argument which divulges the depth of the possible multi-block rewind process. Individual `Rewind` method implementations have the option to either rewind a single block or a batch of multiple blocks for optimisation purposes. Regardless of implementation option the `Rewind` method returns the `HashHeightPair` of the next block to rewind as per usual.