### PR TITLE
Fix NBitcoin copyright date

### DIFF
--- a/src/NBitcoin/NBitcoin.csproj
+++ b/src/NBitcoin/NBitcoin.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Company>NStratis</Company>
-    <Copyright>Copyright © Stratis Platform SA 2020</Copyright>
+    <Copyright>Copyright © Stratis Platform SA 2022</Copyright>
     <Description>The C# Bitcoin Library based on NBitcoin</Description>
   </PropertyGroup>
   

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -193,7 +193,7 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
 
                     if (compare?.Trim() != line.Trim())
                     {
-                        debugLog.AppendLine($"'{fileName1}' differs from '{fileName2}' on these lines:{Environment.NewLine}'{line}', and {Environment.NewLine}'{compare}' respectively.");
+                        debugLog.AppendLine($"The published package differs from '{fileName2}' on these lines:{Environment.NewLine}'{line}', and {Environment.NewLine}'{compare}' respectively.");
                         return false;
                     }
 

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -152,7 +152,7 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
                         continue;
                 }
 
-                string msg2 = $"The local project '{project.ProjectName}' differs from the published package but its version {version} is the same.";
+                string msg2 = $"The local project '{project.ProjectName}' differs from the published package but its version ({version}) is the same.";
                 debugLog.AppendLine(msg2);
 
                 modifiedPackages.Add(project.ProjectName);

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -141,7 +141,7 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
 
                         if (cmpVersion != referencedVersions[includeFullPath])
                         {
-                            string msg = $"Comparing the local project '{project.ProjectName}' version {version} with its published package, '{targetName}', the published package references version '{cmpVersion}' of '{name3}' while the local project references version '{referencedVersions[includeFullPath]}'.";
+                            string msg = $"Comparing the local project ({project.ProjectName}) version ({version}) with its published package, ({targetName}), the published package references version '{cmpVersion}' of '{name3}' while the local project references version '{referencedVersions[includeFullPath]}'.";
                             debugLog.AppendLine(msg);
                             referencedPackagesMatch = false;
                             break;

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -116,7 +116,7 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
 
                 // Compare source with files from NuGet.
                 string packageSource = Path.Combine(targetPath, "src", project.ProjectName);
-                if (Directory.Exists(packageSource) && DirectoryEquals(packageSource, Path.GetDirectoryName(projectFolder)))
+                if (Directory.Exists(packageSource) && DirectoryEquals(packageSource, Path.GetDirectoryName(projectFolder), debugLog))
                 {
                     // Even though the project file may be unchanged the references could be referring to different versions.
 
@@ -162,26 +162,26 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
             Assert.True(modifiedPackages.Count == 0, $"{debugLog.ToString()} Affected packages: {string.Join(", ", modifiedPackages)}");
         }
 
-        static bool DirectoryEquals(string directory1, string directory2)
+        static bool DirectoryEquals(string directory1, string directory2, StringBuilder debugLog)
         {
             foreach (string fileName1 in Directory.EnumerateFiles(directory1))
             {
                 string fileName2 = Path.Combine(directory2, Path.GetFileName(fileName1));
-                if (!FileEquals(fileName1, fileName2))
+                if (!FileEquals(fileName1, fileName2, debugLog))
                     return false;
             }
 
             foreach (string subFolder in Directory.EnumerateDirectories(directory1))
             {
                 string directoryName = Path.GetFileName(subFolder);
-                if (!DirectoryEquals(subFolder, Path.Combine(directory2, directoryName)))
+                if (!DirectoryEquals(subFolder, Path.Combine(directory2, directoryName), debugLog))
                     return false;
             }
 
             return true;
         }
 
-        static bool FileEquals(string fileName1, string fileName2)
+        static bool FileEquals(string fileName1, string fileName2, StringBuilder debugLog)
         {
             try
             {
@@ -192,7 +192,10 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
                     string compare = source.Take(1).FirstOrDefault();
 
                     if (compare?.Trim() != line.Trim())
+                    {
+                        debugLog.AppendLine($"'{fileName1}' differs from '{fileName2}' on these lines:{Environment.NewLine}'{compare}', and {Environment.NewLine}'{line}'.");
                         return false;
+                    }
 
                     source = source.Skip(1);
                     continue;

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -152,7 +152,7 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
                         continue;
                 }
 
-                string msg2 = $"The project '{project.ProjectName}' has been modified since it was published but its local version {version} remains unchanged.";
+                string msg2 = $"The local project '{project.ProjectName}' differs from the published package but its version {version} is the same.";
                 debugLog.AppendLine(msg2);
 
                 modifiedPackages.Add(project.ProjectName);

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -193,7 +193,7 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
 
                     if (compare?.Trim() != line.Trim())
                     {
-                        debugLog.AppendLine($"'{fileName1}' differs from '{fileName2}' on these lines:{Environment.NewLine}'{compare}', and {Environment.NewLine}'{line}'.");
+                        debugLog.AppendLine($"'{fileName1}' differs from '{fileName2}' on these lines:{Environment.NewLine}'{line}', and {Environment.NewLine}'{compare}' respectively.");
                         return false;
                     }
 

--- a/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
+++ b/src/Stratis.Bitcoin.Tests/PackagesAndVersions/PackagesAndVersionsTests.cs
@@ -152,7 +152,7 @@ namespace Stratis.Bitcoin.Tests.PackagesAndVersions
                         continue;
                 }
 
-                string msg2 = $"The local project '{project.ProjectName}' differs from the published package but its version ({version}) is the same.";
+                string msg2 = $"The local project ({project.ProjectName}) differs from the published package but its version ({version}) is the same.";
                 debugLog.AppendLine(msg2);
 
                 modifiedPackages.Add(project.ProjectName);


### PR DESCRIPTION
The root cause being addressed is that the `NBitcoin` package was updated with a new copyright date but the `release/1.2.1.0` source was not correspondingly updated.

This PR fixes the `NBitcoin` (NStratis) copyright date and adds more information to the `EnsureVersionsBumpedWhenChangingPublishedPackages` test case to help identify similar issues in the future - e.g.:
```
 EnsureVersionsBumpedWhenChangingPublishedPackages
   Source: PackagesAndVersionsTests.cs line 18
   Duration: 44.7 sec

  Message: 
   The published package differs from '...\StratisFullNode-1\src\NBitcoin\NBitcoin.csproj' on these lines:
    '    <Copyright>Copyright © Stratis Platform SA 2022</Copyright>', and 
    '    <Copyright>Copyright © Stratis Platform SA 2020</Copyright>' respectively.
    The local project (NBitcoin) differs from the published package but its version (4.0.0.84) is the same.
     Affected packages: NBitcoin
    Expected: True
    Actual:   False
  Stack Trace: 
    PackagesAndVersionsTests.EnsureVersionsBumpedWhenChangingPublishedPackages() line 162   
```