### PR TITLE
Resolve TODO - Remove MaxReorgLength from ChainState

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinViewRuleTest.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/PosCoinViewRuleTest.cs
@@ -55,13 +55,15 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             var partialValidator = new PartialValidator(asyncProvider, consensusRuleEngine, this.loggerFactory.Object);
             var fullValidator = new FullValidator(consensusRuleEngine, this.loggerFactory.Object);
 
+            var finalizedBlockInfoRepository = new FinalizedBlockInfoRepository(new HashHeightPair());
+
             // Create the chained header tree.
             var chainedHeaderTree = new ChainedHeaderTree(this.network, this.loggerFactory.Object, headerValidator, this.checkpoints.Object,
-                this.chainState.Object, new Mock<IFinalizedBlockInfoRepository>().Object, this.consensusSettings, new InvalidBlockHashStore(new DateTimeProvider()), new ChainWorkComparer());
+                this.chainState.Object, finalizedBlockInfoRepository, this.consensusSettings, new InvalidBlockHashStore(new DateTimeProvider()), new ChainWorkComparer());
 
             // Create consensus manager.
             var consensus = new ConsensusManager(chainedHeaderTree, this.network, this.loggerFactory.Object, this.chainState.Object, integrityValidator,
-                partialValidator, fullValidator, consensusRuleEngine, new Mock<IFinalizedBlockInfoRepository>().Object, signals,
+                partialValidator, fullValidator, consensusRuleEngine, finalizedBlockInfoRepository, signals,
                 new Mock<IPeerBanning>().Object, initialBlockDownloadState, this.ChainIndexer, new Mock<IBlockPuller>().Object, new Mock<IBlockStore>().Object,
                 new Mock<IConnectionManager>().Object, new Mock<INodeStats>().Object, new Mock<INodeLifetime>().Object, this.consensusSettings, this.dateTimeProvider.Object);
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/StraxCoinViewRuleTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/Rules/CommonRules/StraxCoinViewRuleTests.cs
@@ -55,13 +55,15 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.Rules.CommonRules
             var partialValidator = new PartialValidator(asyncProvider, consensusRuleEngine, this.loggerFactory.Object);
             var fullValidator = new FullValidator(consensusRuleEngine, this.loggerFactory.Object);
 
+            var finalizedBlockInfoRepository = new FinalizedBlockInfoRepository(new HashHeightPair());
+
             // Create the chained header tree.
             var chainedHeaderTree = new ChainedHeaderTree(this.network, this.loggerFactory.Object, headerValidator, this.checkpoints.Object,
-                this.chainState.Object, new Mock<IFinalizedBlockInfoRepository>().Object, this.consensusSettings, new InvalidBlockHashStore(new DateTimeProvider()), new ChainWorkComparer());
+                this.chainState.Object, finalizedBlockInfoRepository, this.consensusSettings, new InvalidBlockHashStore(new DateTimeProvider()), new ChainWorkComparer());
 
             // Create consensus manager.
             var consensus = new ConsensusManager(chainedHeaderTree, this.network, this.loggerFactory.Object, this.chainState.Object, integrityValidator,
-                partialValidator, fullValidator, consensusRuleEngine, new Mock<IFinalizedBlockInfoRepository>().Object, signals,
+                partialValidator, fullValidator, consensusRuleEngine, finalizedBlockInfoRepository, signals,
                 new Mock<IPeerBanning>().Object, initialBlockDownloadState, this.ChainIndexer, new Mock<IBlockPuller>().Object, new Mock<IBlockStore>().Object,
                 new Mock<IConnectionManager>().Object, new Mock<INodeStats>().Object, new Mock<INodeLifetime>().Object, this.consensusSettings, this.dateTimeProvider.Object);
 

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusFeature.cs
@@ -40,8 +40,6 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.signals = signals;
             this.consensusManager = consensusManager;
             this.nodeDeployments = nodeDeployments;
-
-            this.chainState.MaxReorgLength = network.Consensus.MaxReorgLength;
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.Features.Consensus/PosConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PosConsensusFeature.cs
@@ -61,8 +61,6 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.checkpoints = checkpoints;
             this.provenBlockHeaderStore = provenBlockHeaderStore;
             this.connectionManagerSettings = connectionManagerSettings;
-
-            this.chainState.MaxReorgLength = network.Consensus.MaxReorgLength;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Consensus/PowConsensusFeature.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/PowConsensusFeature.cs
@@ -45,8 +45,6 @@ namespace Stratis.Bitcoin.Features.Consensus
             this.initialBlockDownloadState = initialBlockDownloadState;
             this.peerBanning = peerBanning;
             this.loggerFactory = loggerFactory;
-
-            this.chainState.MaxReorgLength = network.Consensus.MaxReorgLength;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -112,12 +112,14 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
 
             var asyncProvider = new AsyncProvider(loggerFactory, new Mock<ISignals>().Object);
 
+            var finalizedBlockInfoRepository = new FinalizedBlockInfoRepository(new HashHeightPair());
+
             var stakeChain = new StakeChainStore(network, chain, null, loggerFactory);
             ConsensusRuleEngine consensusRules = new PosConsensusRuleEngine(network, loggerFactory, dateTimeProvider, chain, deployments, consensusSettings, new Checkpoints(),
                 inMemoryCoinView, stakeChain, new StakeValidator(network, stakeChain, chain, inMemoryCoinView, loggerFactory), chainState, new InvalidBlockHashStore(dateTimeProvider),
-                new NodeStats(dateTimeProvider, NodeSettings.Default(network), new Mock<IVersionProvider>().Object), new RewindDataIndexCache(dateTimeProvider, network, new FinalizedBlockInfoRepository(new HashHeightPair()), new Checkpoints()), asyncProvider, consensusRulesContainer).SetupRulesEngineParent();
+                new NodeStats(dateTimeProvider, NodeSettings.Default(network), new Mock<IVersionProvider>().Object), new RewindDataIndexCache(dateTimeProvider, network, finalizedBlockInfoRepository, new Checkpoints()), asyncProvider, consensusRulesContainer).SetupRulesEngineParent();
 
-            ConsensusManager consensus = ConsensusManagerHelper.CreateConsensusManager(network, dataDir, chainState, chainIndexer: chain, consensusRules: consensusRules, inMemoryCoinView: inMemoryCoinView);
+            ConsensusManager consensus = ConsensusManagerHelper.CreateConsensusManager(network, dataDir, chainState, chainIndexer: chain, consensusRules: consensusRules, inMemoryCoinView: inMemoryCoinView, finalizedBlockInfoRepository: finalizedBlockInfoRepository);
 
             var genesis = new ChainedHeader(network.GetGenesis().Header, network.GenesisHash, 0);
             chainState.BlockStoreTip = genesis;

--- a/src/Stratis.Bitcoin.Tests.Common/ConsensusManagerHelper.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/ConsensusManagerHelper.cs
@@ -30,7 +30,8 @@ namespace Stratis.Bitcoin.Tests.Common
             ChainState chainState = null,
             InMemoryCoinView inMemoryCoinView = null,
             ChainIndexer chainIndexer = null,
-            ConsensusRuleEngine consensusRules = null)
+            ConsensusRuleEngine consensusRules = null,
+            IFinalizedBlockInfoRepository finalizedBlockInfoRepository = null)
         {
             string[] param = dataDir == null ? new string[] { } : new string[] { $"-datadir={dataDir}" };
 
@@ -85,12 +86,14 @@ namespace Stratis.Bitcoin.Tests.Common
                     new Checkpoints(), inMemoryCoinView, chainState, new InvalidBlockHashStore(dateTimeProvider), new NodeStats(dateTimeProvider, nodeSettings, new Mock<IVersionProvider>().Object), asyncProvider, new ConsensusRulesContainer()).SetupRulesEngineParent();
             }
 
+            finalizedBlockInfoRepository ??= new Mock<IFinalizedBlockInfoRepository>().Object;
+
             var tree = new ChainedHeaderTree(network, loggerFactory, new HeaderValidator(consensusRules, loggerFactory), new Checkpoints(),
-                new ChainState(), new Mock<IFinalizedBlockInfoRepository>().Object, consensusSettings, new InvalidBlockHashStore(new DateTimeProvider()), new ChainWorkComparer());
+                new ChainState(), finalizedBlockInfoRepository, consensusSettings, new InvalidBlockHashStore(new DateTimeProvider()), new ChainWorkComparer());
 
             var consensus = new ConsensusManager(tree, network, loggerFactory, chainState, new IntegrityValidator(consensusRules, loggerFactory),
                 new PartialValidator(asyncProvider, consensusRules, loggerFactory), new FullValidator(consensusRules, loggerFactory), consensusRules,
-                new Mock<IFinalizedBlockInfoRepository>().Object, new Signals.Signals(loggerFactory, null), peerBanning, new Mock<IInitialBlockDownloadState>().Object, chainIndexer,
+                finalizedBlockInfoRepository, new Signals.Signals(loggerFactory, null), peerBanning, new Mock<IInitialBlockDownloadState>().Object, chainIndexer,
                 new Mock<IBlockPuller>().Object, new Mock<IBlockStore>().Object, new Mock<IConnectionManager>().Object, new Mock<INodeStats>().Object, new NodeLifetime(), consensusSettings, dateTimeProvider);
 
             return consensus;

--- a/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ChainedHeaderTreeTest.cs
@@ -6,6 +6,7 @@ using Moq;
 using NBitcoin;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Primitives;
+using Stratis.Bitcoin.Tests.Common;
 using Stratis.Bitcoin.Utilities;
 using Xunit;
 
@@ -1214,7 +1215,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             // Extend the chain (chain A) with max reorg headers (500) + 50 extra.
             // Example: h1=h2=h3=h4=(h5)=a6=...=a555.
             const int maxReorg = 500;
-            ctx.ChainState.Setup(x => x.MaxReorgLength).Returns(maxReorg);
+            ctx.Network.Consensus.SetPrivatePropertyValue(nameof(ctx.Network.Consensus.MaxReorgLength), (uint)maxReorg);
+
             ChainedHeader chainATip = ctx.ExtendAChain(maxReorg + 50, initialChainTip);
 
             // Chain A is presented by peer 1.
@@ -1776,8 +1778,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             ctx.SetupCheckpoints(checkpoint);
 
             // Setup max reorg of 10.
-            const int maxReorg = 10;
-            ctx.ChainState.Setup(x => x.MaxReorgLength).Returns(maxReorg);
+            const uint maxReorg = 10;
+            ctx.Network.Consensus.SetPrivatePropertyValue(nameof(ctx.Network.Consensus.MaxReorgLength), maxReorg);
 
             // Setup finalized block height to 10.
             ctx.FinalizedBlockMock.Setup(m => m.GetFinalizedBlockInfo()).Returns(new HashHeightPair(uint256.One, 10));
@@ -2119,7 +2121,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             // Setup max reorg to 100.
             const int maxReorg = 100;
-            ctx.ChainState.Setup(x => x.MaxReorgLength).Returns(maxReorg);
+            ctx.Network.Consensus.SetPrivatePropertyValue(nameof(ctx.Network.Consensus.MaxReorgLength), (uint)maxReorg);
 
             // Extend the chain with (checkpoint + MaxReorg + 10) headers, i.e. 115 headers.
             const int extensionSize = 10;
@@ -2753,8 +2755,8 @@ namespace Stratis.Bitcoin.Tests.Consensus
             Assert.Equal(initialChainSize, initialChainTip.Height);
 
             // Setup max reorg of 10.
-            const int maxReorg = 10;
-            testContext.ChainState.Setup(x => x.MaxReorgLength).Returns(maxReorg);
+            const uint maxReorg = 10;
+            testContext.Network.Consensus.SetPrivatePropertyValue(nameof(testContext.Network.Consensus.MaxReorgLength), maxReorg);
 
             // Setup finalized block height to 40.
             const int finalizedBlockHeight = 40;

--- a/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/ConsensusTestContext.cs
@@ -148,6 +148,10 @@ namespace Stratis.Bitcoin.Tests.Consensus
 
             this.consensusRules.SetupRulesEngineParent();
 
+            // Setup finalized block info to not return null.
+            const int finalizedBlockHeight = 0;
+            this.FinalizedBlockMock.Setup(m => m.GetFinalizedBlockInfo()).Returns(new HashHeightPair(uint256.One, finalizedBlockHeight));
+
             var tree = new ChainedHeaderTree(this.Network, this.loggerFactory, this.HeaderValidator.Object, this.checkpoints.Object,
                 this.ChainState.Object, this.FinalizedBlockMock.Object, this.ConsensusSettings, this.hashStore, new ChainWorkComparer());
 

--- a/src/Stratis.Bitcoin/Base/ChainState.cs
+++ b/src/Stratis.Bitcoin/Base/ChainState.cs
@@ -22,10 +22,6 @@ namespace Stratis.Bitcoin.Base
 
         /// <summary>Indicates whether consensus tip is equal to the tip of the most advanced peer node is connected to.</summary>
         bool IsAtBestChainTip { get; set; }
-
-        /// <summary>Maximal length of reorganization that the node is willing to accept, or 0 to disable long reorganization protection.</summary>
-        /// <remarks>TODO: This should be removed once consensus options are part of network.</remarks>
-        uint MaxReorgLength { get; set; }
     }
 
     /// <summary>
@@ -47,9 +43,5 @@ namespace Stratis.Bitcoin.Base
 
         /// <inheritdoc />
         public bool IsAtBestChainTip { get; set; }
-
-        /// <summary>Maximal length of reorganization that the node is willing to accept, or 0 to disable long reorganization protection.</summary>
-        /// <remarks>TODO: This should be removed once consensus options are part of network.</remarks>
-        public uint MaxReorgLength { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
+++ b/src/Stratis.Bitcoin/Consensus/ChainedHeaderTree.cs
@@ -493,7 +493,7 @@ namespace Stratis.Bitcoin.Consensus
         private List<int> FindPeersToResync(ChainedHeader consensusTip)
         {
             var peerIdsToResync = new List<int>();
-            uint maxReorgLength = this.chainState.MaxReorgLength;
+            uint maxReorgLength = this.network.Consensus.MaxReorgLength;
 
             // Find peers with chains that now violate max reorg.
             if (maxReorgLength != 0)
@@ -1168,7 +1168,7 @@ namespace Stratis.Bitcoin.Consensus
         /// <exception cref="MaxReorgViolationException">Thrown in case maximum reorganization rule is violated.</exception>
         private void CheckMaxReorgRuleViolated(ChainedHeader chainedHeader)
         {
-            uint maxReorgLength = this.chainState.MaxReorgLength;
+            uint maxReorgLength = this.network.Consensus.MaxReorgLength;
             ChainedHeader consensusTip = this.GetConsensusTip();
             if (maxReorgLength != 0)
             {

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
@@ -261,7 +261,9 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                         consensusRulesContainer)
                     .SetupRulesEngineParent();
 
-                this.consensusManager = ConsensusManagerHelper.CreateConsensusManager(this.network, chainState: chainState, inMemoryCoinView: inMemoryCoinView, chainIndexer: this.ChainIndexer, consensusRules: this.consensusRules);
+                var finalizedBlockInfoRepository = new FinalizedBlockInfoRepository(new HashHeightPair());
+
+                this.consensusManager = ConsensusManagerHelper.CreateConsensusManager(this.network, chainState: chainState, inMemoryCoinView: inMemoryCoinView, chainIndexer: this.ChainIndexer, consensusRules: this.consensusRules, finalizedBlockInfoRepository: finalizedBlockInfoRepository);
 
                 await this.consensusManager.InitializeAsync(chainState.BlockStoreTip);
 


### PR DESCRIPTION
https://app.clickup.com/t/1vqt5h1

Resolve the following TODO:
```
/// <summary>Maximal length of reorganization that the node is willing to accept, or 0 to disable long reorganization protection.</summary>
/// <remarks>TODO: This should be removed once consensus options are part of network.</remarks>
        uint MaxReorgLength { get; set; }
```

Following this PR we no longer look for `MaxReorgLength` on `ChainState` but instead use `Consensus.MaxReorgLength`. In future PRs `ChainState` will be removed completely.

Some test cases that use a dummy `ChainState` have inadvertently been using `MaxReorgLength = 0`. Those test cases are upgraded to support code paths that expect a non-zero value. Specifically `FinalizedBlockInfoRepository`, which is no longer mocked, now returns a non-null value for `GetFinalizedBlockInfo` to support this flow:
```
        private List<int> FindPeersToResync(ChainedHeader consensusTip)
        {
            var peerIdsToResync = new List<int>();
            uint maxReorgLength = this.network.Consensus.MaxReorgLength;

            // Find peers with chains that now violate max reorg.
            if (maxReorgLength != 0)
            {
                lock (this.lockObject)
                {
                    foreach (KeyValuePair<int, uint256> peerIdToTipHash in this.peerTipsByPeerId)
                    {
                        ChainedHeader peerTip = this.chainedHeadersByHash[peerIdToTipHash.Value];
                        int peerId = peerIdToTipHash.Key;

                        ChainedHeader fork = this.FindForkIfChainedHeadersNotOnSameChain(peerTip, consensusTip);

                        int finalizedHeight = this.finalizedBlockInfo.GetFinalizedBlockInfo().Height;
...
```