### PR TITLE
[InterFlux] Add resetscanheight endpoint

### DIFF
--- a/src/Stratis.Bitcoin.Features.Interop/Models/ResetScanHeightModel.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/Models/ResetScanHeightModel.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using Stratis.Bitcoin.Features.Wallet;
+
+namespace Stratis.Bitcoin.Features.Interop.Models
+{
+    public sealed class ResetScanHeightModel
+    {
+        [JsonProperty(PropertyName = "destinationChain")]
+        public DestinationChain DestinationChain { get; set; }
+
+        [JsonProperty(PropertyName = "height")]
+        public int Height { get; set; }
+    }
+}


### PR DESCRIPTION
Allows the interop poller to be reset to a specified height for a given chain