### PR TITLE
Disable price tracking by default

### DIFF
--- a/src/Stratis.Bitcoin.Features.ExternalAPI/ExternalApiSettings.cs
+++ b/src/Stratis.Bitcoin.Features.ExternalAPI/ExternalApiSettings.cs
@@ -66,9 +66,9 @@ namespace Stratis.Bitcoin.Features.ExternalApi
             // To avoid any rate limiting by Etherscan it is better to have an API key defined, but the API is still supposed to work to a limited extent without one.
             this.EtherscanApiKey = nodeSettings.ConfigReader.GetOrDefault(EtherscanApiKeyKey, "YourApiKeyToken");
             this.EtherscanGasOracleUrl = nodeSettings.ConfigReader.GetOrDefault(EtherscanGasOracleUrlKey, "https://api.etherscan.io/api?module=gastracker&action=gasoracle&apikey=" + this.EtherscanApiKey);
-            this.EthereumGasPriceTracking = nodeSettings.ConfigReader.GetOrDefault(EthereumGasPriceTrackingKey, true);
+            this.EthereumGasPriceTracking = nodeSettings.ConfigReader.GetOrDefault(EthereumGasPriceTrackingKey, false);
             this.PriceUrl = nodeSettings.ConfigReader.GetOrDefault(PriceUrlKey, "https://api.coingecko.com/api/v3/simple/price?ids=stratis,ethereum&vs_currencies=usd");
-            this.PriceTracking = nodeSettings.ConfigReader.GetOrDefault(PriceTrackingKey, true);
+            this.PriceTracking = nodeSettings.ConfigReader.GetOrDefault(PriceTrackingKey, false);
         }
     }
 }


### PR DESCRIPTION
The ExternalApi price tracking polling loops were enabled by default in StraxD; this disables them by default. They can be re-enabled via command line switches for the multisig masternodes as needed.