### PR TITLE
[Cirrus] Add BIP9 synchronised deployment

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -44,7 +44,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
         /// <summary>All access should be protected by <see cref="locker"/>.</remarks>
         public PollsRepository PollsRepository { get; private set; }
-        public object CirrusBIP9Deployments { get; private set; }
 
         private IIdleFederationMembersKicker idleFederationMembersKicker;
         private readonly INodeLifetime nodeLifetime;

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -192,9 +192,9 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 List<Poll> pendingPolls = this.GetPendingPolls().ToList();
                 List<Poll> approvedPolls = this.GetApprovedPolls().Where(x => !x.IsExecuted).ToList();
 
-                int release1210ActivationHeight = 0;
+                int release1300ActivationHeight = 0;
                 if (this.nodeDeployments?.BIP9.ArraySize > 0 /* Not NoBIP9Deployments */)
-                    release1210ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight;
+                    release1300ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1300 */].ActivationHeight;
 
                 bool IsTooOldToVoteOn(Poll poll) => poll.IsPending && (this.chainIndexer.Tip.Height - poll.PollStartBlockData.Height) >= this.poaConsensusOptions.PollExpiryBlocks;
 
@@ -203,7 +203,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     if (currentScheduledData.Key == VoteKey.AddFederationMember)
                     {
                         // "Add member" votes must have pending polls created by the JoinFederationRequestMonitor (if this behavior was active in the monitor).
-                        if (!pendingPolls.Any(x => x.VotingData == currentScheduledData && x.PollStartBlockData.Height >= release1210ActivationHeight))
+                        if (!pendingPolls.Any(x => x.VotingData == currentScheduledData && x.PollStartBlockData.Height >= release1300ActivationHeight))
                             return false;
                     }
 
@@ -594,11 +594,11 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                                 // Hence, if the poll does not exist then this is not a valid vote.
                                 if (data.Key == VoteKey.AddFederationMember)
                                 {
-                                    int release1210ActivationHeight = 0;
+                                    int release1300ActivationHeight = 0;
                                     if (this.nodeDeployments?.BIP9.ArraySize > 0  /* Not NoBIP9Deployments */)
-                                        release1210ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight;
+                                        release1300ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1300 */].ActivationHeight;
 
-                                    if (chBlock.ChainedHeader.Height >= release1210ActivationHeight)
+                                    if (chBlock.ChainedHeader.Height >= release1300ActivationHeight)
                                         continue;
                                 }
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -193,8 +193,8 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 List<Poll> approvedPolls = this.GetApprovedPolls().Where(x => !x.IsExecuted).ToList();
 
                 int release1210ActivationHeight = 0;
-                if (this.nodeDeployments.BIP9.ArraySize != 0 /* Not NoBIP9Deployments */)
-                    release1210ActivationHeight = this.nodeDeployments?.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight ?? 0;
+                if (this.nodeDeployments?.BIP9.ArraySize > 0 /* Not NoBIP9Deployments */)
+                    release1210ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight;
 
                 bool IsTooOldToVoteOn(Poll poll) => poll.IsPending && (this.chainIndexer.Tip.Height - poll.PollStartBlockData.Height) >= this.poaConsensusOptions.PollExpiryBlocks;
 
@@ -595,8 +595,8 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                                 if (data.Key == VoteKey.AddFederationMember)
                                 {
                                     int release1210ActivationHeight = 0;
-                                    if (this.nodeDeployments.BIP9.ArraySize != 0  /* Not NoBIP9Deployments */)
-                                        release1210ActivationHeight = this.nodeDeployments?.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight ?? 0;
+                                    if (this.nodeDeployments?.BIP9.ArraySize > 0  /* Not NoBIP9Deployments */)
+                                        release1210ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight;
 
                                     if (chBlock.ChainedHeader.Height >= release1210ActivationHeight)
                                         continue;

--- a/src/Stratis.Bitcoin.Features.RPC/RPCClient.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCClient.cs
@@ -491,6 +491,8 @@ namespace Stratis.Bitcoin.Features.RPC
         }
 
         /// <summary>Get the a whole block.</summary>
+        /// <param name="blockId">The hash of the block to get.</param>
+        /// <returns>The asynchronous task returning a <see cref="RPCBlock"/>.</returns>
         public async Task<RPCBlock> GetRPCBlockAsync(uint256 blockId)
         {
             RPCResponse resp = await SendCommandAsync(RPCOperations.getblock, blockId.ToString(), false).ConfigureAwait(false);
@@ -499,6 +501,8 @@ namespace Stratis.Bitcoin.Features.RPC
 
         /// <summary>Send a command.</summary>
         /// <param name="commandName">https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_calls_list</param>
+        /// <param name="parameters">The parameters for the call.</param>
+        /// <returns>See <see cref="RPCResponse"/>.</returns>
         public RPCResponse SendCommand(string commandName, params object[] parameters)
         {
             return SendCommand(new RPCRequest(commandName, parameters));
@@ -538,6 +542,7 @@ namespace Stratis.Bitcoin.Features.RPC
         }
 
         /// <summary>Send all commands in one batch.</summary>
+        /// <returns>The asynchronous task.</returns>
         public async Task SendBatchAsync()
         {
             ConcurrentQueue<(RPCRequest request, TaskCompletionSource<RPCResponse> task)> batches;
@@ -1066,8 +1071,8 @@ namespace Stratis.Bitcoin.Features.RPC
         /// <summary>
         /// Get the a whole block
         /// </summary>
-        /// <param name="blockId"></param>
-        /// <returns></returns>
+        /// <param name="blockId">The hash of the block to get.</param>
+        /// <returns>See <see cref="Block"/>.</returns>
         public Block GetBlock(uint256 blockId)
         {
             return GetBlockAsync(blockId).GetAwaiter().GetResult();
@@ -1174,8 +1179,8 @@ namespace Stratis.Bitcoin.Features.RPC
         /// <summary>
         /// GetTransactions only returns on txn which are not entirely spent unless you run bitcoinq with txindex=1.
         /// </summary>
-        /// <param name="blockHash"></param>
-        /// <returns></returns>
+        /// <param name="blockHash">The hash of the block containing the transactions.</param>
+        /// <returns>An enumeration of <see cref="Transaction"/> instances.</returns>
         public IEnumerable<Transaction> GetTransactions(uint256 blockHash)
         {
             if (blockHash == null)
@@ -1282,6 +1287,7 @@ namespace Stratis.Bitcoin.Features.RPC
         #endregion
 
         #region Utility functions
+
         /// <summary>
         /// Returns information about a base58 or bech32 Bitcoin address
         /// </summary>
@@ -1296,8 +1302,8 @@ namespace Stratis.Bitcoin.Features.RPC
         /// <summary>
         /// Get the estimated fee per kb for being confirmed in nblock
         /// </summary>
-        /// <param name="nblock"></param>
-        /// <returns></returns>
+        /// <param name="nblock">The time expected, in block, before getting confirmed</param>
+        /// <returns>The estimated fee rate</returns>
         [Obsolete("Use EstimateFeeRate or TryEstimateFeeRate instead")]
         public FeeRate EstimateFee(int nblock)
         {
@@ -1312,8 +1318,8 @@ namespace Stratis.Bitcoin.Features.RPC
         /// <summary>
         /// Get the estimated fee per kb for being confirmed in nblock
         /// </summary>
-        /// <param name="nblock"></param>
-        /// <returns></returns>
+        /// <param name="nblock">The time expected, in block, before getting confirmed</param>
+        /// <returns>The estimated fee rate</returns>
         [Obsolete("Use EstimateFeeRateAsync instead")]
         public async Task<Money> EstimateFeeAsync(int nblock)
         {

--- a/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
+++ b/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
@@ -123,11 +123,11 @@ namespace Stratis.Features.Collateral
                         Data = federationMemberBytes
                     };
 
-                    int release1210ActivationHeight = 0;
+                    int release1300ActivationHeight = 0;
                     if (this.nodeDeployments?.BIP9.ArraySize > 0 /* Not NoBIP9Deployments */)
-                        release1210ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight;
+                        release1300ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1300 */].ActivationHeight;
 
-                    if (blockConnectedData.ConnectedBlock.ChainedHeader.Height >= release1210ActivationHeight)
+                    if (blockConnectedData.ConnectedBlock.ChainedHeader.Height >= release1300ActivationHeight)
                     {
                         // Create a pending poll so that the scheduled vote is not "sanitized" away.
                         this.votingManager.PollsRepository.WithTransaction(transaction =>

--- a/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
+++ b/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
@@ -123,7 +123,9 @@ namespace Stratis.Features.Collateral
                         Data = federationMemberBytes
                     };
 
-                    var release1210ActivationHeight = this.nodeDeployments?.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight ?? 0;
+                    int release1210ActivationHeight = 0;
+                    if (this.nodeDeployments.BIP9.ArraySize != 0 /* Not NoBIP9Deployments */)
+                        release1210ActivationHeight = this.nodeDeployments?.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight ?? 0;
 
                     if (blockConnectedData.ConnectedBlock.ChainedHeader.Height >= release1210ActivationHeight)
                     {

--- a/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
+++ b/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
@@ -124,8 +124,8 @@ namespace Stratis.Features.Collateral
                     };
 
                     int release1210ActivationHeight = 0;
-                    if (this.nodeDeployments.BIP9.ArraySize != 0 /* Not NoBIP9Deployments */)
-                        release1210ActivationHeight = this.nodeDeployments?.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight ?? 0;
+                    if (this.nodeDeployments?.BIP9.ArraySize > 0 /* Not NoBIP9Deployments */)
+                        release1210ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1210 */].ActivationHeight;
 
                     if (blockConnectedData.ConnectedBlock.ChainedHeader.Height >= release1210ActivationHeight)
                     {

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -14,6 +14,7 @@ using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
+using Stratis.Sidechains.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
 {
@@ -102,7 +103,11 @@ namespace Stratis.Sidechains.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
-            var bip9Deployments = new NoBIP9Deployments();
+            var bip9Deployments = new CirrusBIP9Deployments()
+            {
+                // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
+                [CirrusBIP9Deployments.Release1210] = new BIP9DeploymentsParameters("Release1210", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+            };
 
             this.Consensus = new Consensus(
                 consensusFactory: consensusFactory,

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -105,7 +105,7 @@ namespace Stratis.Sidechains.Networks
 
             var bip9Deployments = new CirrusBIP9Deployments()
             {
-                // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
+                // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -14,6 +14,7 @@ using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
+using Stratis.Bitcoin.Utilities.Extensions;
 using Stratis.Sidechains.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
@@ -106,7 +107,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -106,7 +106,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
-                [CirrusBIP9Deployments.Release1210] = new BIP9DeploymentsParameters("Release1210", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -14,6 +14,7 @@ using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
+using Stratis.Bitcoin.Utilities.Extensions;
 using Stratis.Sidechains.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
@@ -195,7 +196,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, DateTime.Parse("2023-1-1").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -194,7 +194,7 @@ namespace Stratis.Sidechains.Networks
 
             var bip9Deployments = new CirrusBIP9Deployments()
             {
-                // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
+                // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -14,6 +14,7 @@ using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
+using Stratis.Sidechains.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
 {
@@ -191,7 +192,11 @@ namespace Stratis.Sidechains.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
-            var bip9Deployments = new NoBIP9Deployments();
+            var bip9Deployments = new CirrusBIP9Deployments()
+            {
+                // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
+                [CirrusBIP9Deployments.Release1210] = new BIP9DeploymentsParameters("Release1210", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+            };
 
             this.Consensus = new Consensus(
                 consensusFactory: consensusFactory,

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -195,7 +195,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
-                [CirrusBIP9Deployments.Release1210] = new BIP9DeploymentsParameters("Release1210", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -124,7 +124,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
-                [CirrusBIP9Deployments.Release1210] = new BIP9DeploymentsParameters("Release1210", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -123,7 +123,7 @@ namespace Stratis.Sidechains.Networks
 
             var bip9Deployments = new CirrusBIP9Deployments()
             {
-                // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
+                // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -14,6 +14,7 @@ using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
+using Stratis.Bitcoin.Utilities.Extensions;
 using Stratis.Sidechains.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
@@ -124,7 +125,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -14,6 +14,7 @@ using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
+using Stratis.Sidechains.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
 {
@@ -120,7 +121,11 @@ namespace Stratis.Sidechains.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
-            var bip9Deployments = new NoBIP9Deployments();
+            var bip9Deployments = new CirrusBIP9Deployments()
+            {
+                // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
+                [CirrusBIP9Deployments.Release1210] = new BIP9DeploymentsParameters("Release1210", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+            };
 
             this.Consensus = new Consensus(
                 consensusFactory: consensusFactory,

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -13,6 +13,7 @@ using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
+using Stratis.Sidechains.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
 {
@@ -142,7 +143,11 @@ namespace Stratis.Sidechains.Networks
                 [BuriedDeployments.BIP66] = 0
             };
 
-            var bip9Deployments = new NoBIP9Deployments();
+            var bip9Deployments = new CirrusBIP9Deployments()
+            {
+                // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
+                [CirrusBIP9Deployments.Release1210] = new BIP9DeploymentsParameters("Release1210", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+            };
 
             this.Consensus = new Consensus(
                 consensusFactory: consensusFactory,

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -13,6 +13,7 @@ using Stratis.Bitcoin.Features.SmartContracts.MempoolRules;
 using Stratis.Bitcoin.Features.SmartContracts.PoA;
 using Stratis.Bitcoin.Features.SmartContracts.PoA.Rules;
 using Stratis.Bitcoin.Features.SmartContracts.Rules;
+using Stratis.Bitcoin.Utilities.Extensions;
 using Stratis.Sidechains.Networks.Deployments;
 
 namespace Stratis.Sidechains.Networks
@@ -146,7 +147,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, DateTime.Parse("2023-1-1").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -146,7 +146,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
-                [CirrusBIP9Deployments.Release1210] = new BIP9DeploymentsParameters("Release1210", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -145,7 +145,7 @@ namespace Stratis.Sidechains.Networks
 
             var bip9Deployments = new CirrusBIP9Deployments()
             {
-                // Deployment will go active once 75% of nodes are on 1.2.1.0 or later.
+                // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, 999999999, BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 

--- a/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
+++ b/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
@@ -1,0 +1,36 @@
+﻿using NBitcoin;
+
+namespace Stratis.Sidechains.Networks.Deployments
+{
+    /// <summary>
+    /// BIP9 deployments for the Cirrus network.
+    /// </summary>
+    public class CirrusBIP9Deployments : BIP9DeploymentsArray
+    {
+        // The position of each deployment in the deployments array. Note that this is decoupled from the actual position of the flag bit for the deployment in the block version.
+        public const int Release1210 = 0;
+
+        // The number of deployments.
+        public const int NumberOfDeployments = 1;
+
+        /// <summary>
+        /// Constructs the BIP9 deployments array.
+        /// </summary>
+        public CirrusBIP9Deployments() : base(NumberOfDeployments)
+        {
+        }
+
+        /// <summary>
+        /// Gets the deployment flags to set when the deployment activates.
+        /// </summary>
+        /// <param name="deployment">The deployment number.</param>
+        /// <returns>The deployment flags.</returns>
+        public override BIP9DeploymentFlags GetFlags(int deployment)
+        {
+            // The flags get combined in the caller, so it is ok to make a fresh object here.
+            var flags = new BIP9DeploymentFlags();
+
+            return flags;
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
+++ b/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
@@ -8,7 +8,7 @@ namespace Stratis.Sidechains.Networks.Deployments
     public class CirrusBIP9Deployments : BIP9DeploymentsArray
     {
         // The position of each deployment in the deployments array. Note that this is decoupled from the actual position of the flag bit for the deployment in the block version.
-        public const int Release1210 = 0;
+        public const int Release1300 = 0;
 
         // The number of deployments.
         public const int NumberOfDeployments = 1;


### PR DESCRIPTION
This PR ensures that the logic related to which votes are valid (have a voting request) is activated at the same height for all nodes.