### PR TITLE
[MultiSig] Fix Federation History lookup (alternative)

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -127,7 +127,7 @@ namespace Stratis.Bitcoin.Features.PoA
                 startHeight = this.lastFederationTip;
             }
 
-            for (int height = startHeight; height < endHeight; height++)
+            for (int height = startHeight; height <= endHeight; height++)
             {
                 if (this.federationHistory.TryGetValue(height, out (List<IFederationMember> modifiedFederation, HashSet<IFederationMember> whoJoined, IFederationMember miner) item))
                 {

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -179,14 +179,13 @@ namespace Stratis.Bitcoin.Features.PoA
             PoABlockHeader[] headers = lastHeader.EnumerateToGenesis().Take(count).Reverse().Select(h => (PoABlockHeader)h.Header).ToArray();
 
             IFederationMember[] miners = new IFederationMember[headers.Length];
-            List<IFederationMember>[] federations = new List<IFederationMember>[headers.Length];
 
             // Reading chainedHeader's "Header" does not play well with asynchronocity so we will load the block times here.
             int votingManagerV2ActivationHeight = (this.network.Consensus.Options as PoAConsensusOptions).VotingManagerV2ActivationHeight;
 
             int startHeight = lastHeader.Height + 1 - count;
 
-            federations = GetFederationsForHeights(startHeight, lastHeader.Height).Select(i => i.members).ToArray();
+            List<IFederationMember>[] federations = GetFederationsForHeights(startHeight, lastHeader.Height).Select(i => i.members).ToArray();
 
             Parallel.For(0, headers.Length, i => miners[i] = GetFederationMemberForBlock(headers[i], federations[i], (i + startHeight) >= votingManagerV2ActivationHeight));
 

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -119,14 +119,6 @@ namespace Stratis.Bitcoin.Features.PoA
 
         private IEnumerable<(List<IFederationMember> members, HashSet<IFederationMember> whoJoined)> GetFederationsForHeights(int startHeight, int endHeight)
         {
-            if (startHeight < this.lastFederationTip)
-            {
-                foreach ((List<IFederationMember>, HashSet<IFederationMember>) item in this.GetFederationsForHeightsNoCache(startHeight, this.lastFederationTip - 1))
-                    yield return item;
-
-                startHeight = this.lastFederationTip;
-            }
-
             for (int height = startHeight; height <= endHeight; height++)
             {
                 if (this.federationHistory.TryGetValue(height, out (List<IFederationMember> modifiedFederation, HashSet<IFederationMember> whoJoined, IFederationMember miner) item))

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
@@ -201,6 +201,9 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             try
             {
                 ChainedHeader chainedHeader = this.chainIndexer.GetHeader(blockHeight);
+                if (chainedHeader == null)
+                    throw new InvalidOperationException("The block is not available at this time.");
+
                 PubKey pubKey = this.federationHistory.GetFederationMemberForBlock(chainedHeader)?.PubKey;
 
                 return Json(pubKey);

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/FederationController.cs
@@ -202,7 +202,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             {
                 ChainedHeader chainedHeader = this.chainIndexer.GetHeader(blockHeight);
                 if (chainedHeader == null)
-                    throw new InvalidOperationException("The block is not available at this time.");
+                    return ErrorHelpers.BuildErrorResponse(HttpStatusCode.NotFound, "The block was not found at this time.", string.Empty);
 
                 PubKey pubKey = this.federationHistory.GetFederationMemberForBlock(chainedHeader)?.PubKey;
 


### PR DESCRIPTION
The federation history uses a cache (window) that moves as the tip progresses. The cache can't be used for blocks that are too far in the past. This PR adapts the code to leverage alternative approaches when it can't use the cache.