### PR TITLE
Refactor PoAHeaderSignatureRule

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -72,11 +72,11 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 PoAConsensusErrors.InvalidHeaderSignature.Throw();
             }
 
-            uint diff = this.slotsManager.GetMiningTimestamp(chainedHeader.Previous, (uint)(chainedHeader.Previous.Header.Time + this.Parent.ConsensusParams.TargetSpacing.TotalSeconds), pubKey) - chainedHeader.Header.Time;
+            uint expectedSlot = this.slotsManager.GetMiningTimestamp(chainedHeader.Previous, chainedHeader.Header.Time, pubKey);
 
-            if (diff != 0)
+            if (chainedHeader.Header.Time != expectedSlot)
             {
-                this.Logger.LogDebug("Block {0} was mined in the wrong slot by miner '{1}'.", chainedHeader.HashBlock, pubKey.ToHex());
+                this.Logger.LogDebug("Block {0} was mined in the wrong slot by miner '{1}'. The miner was expected to mine at {2}.", chainedHeader.HashBlock, pubKey.ToHex(), expectedSlot);
                 this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
                 ConsensusErrors.BlockTimestampTooEarly.Throw();
             }

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -76,7 +76,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
             if (chainedHeader.Header.Time != expectedSlot)
             {
-                this.Logger.LogDebug("Block {0} was mined in the wrong slot by miner '{1}'. The timestamp on the miner's block is {2} seconds earlier than expected.", chainedHeader.HashBlock, pubKey.ToHex(), expectedSlot - chainedHeader.Header.Time);
+                this.Logger.LogDebug("Block {0} was mined in the wrong slot by miner '{1}'. The timestamp on the miner's block is {2} seconds earlier than expected.", chainedHeader.Height, pubKey.ToHex(), expectedSlot - chainedHeader.Header.Time);
                 this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
                 ConsensusErrors.BlockTimestampTooEarly.Throw();
             }

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -72,36 +72,11 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 PoAConsensusErrors.InvalidHeaderSignature.Throw();
             }
 
-            // Look at the last round of blocks to find the previous time that the miner mined.
-            TimeSpan roundTime = this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(chainedHeader).Count);
+            uint diff = this.slotsManager.GetMiningTimestamp(chainedHeader.Previous, (uint)(chainedHeader.Previous.Header.Time + this.Parent.ConsensusParams.TargetSpacing.TotalSeconds), pubKey) - chainedHeader.Header.Time;
 
-            // Quick check for optimisation.
-            this.federationHistory.GetLastActiveTime(federationMember, chainedHeader.Previous, out uint lastActiveTime);
-            if ((chainedHeader.Header.Time - lastActiveTime) >= roundTime.TotalSeconds)
-                return Task.CompletedTask;
-
-            int blockCounter = 0;
-
-            for (ChainedHeader prevHeader = chainedHeader.Previous; prevHeader.Previous != null; prevHeader = prevHeader.Previous)
+            if (diff != 0)
             {
-                blockCounter += 1;
-
-                if ((header.BlockTime - prevHeader.Header.BlockTime) >= roundTime)
-                    break;
-
-                // If the miner is found again within the same round then throw a consensus error.
-                if (this.federationHistory.GetFederationMemberForBlock(prevHeader)?.PubKey != pubKey)
-                    continue;
-
-                // Mining slots shift when the federation changes. 
-                // Only raise an error if the federation did not change.
-                if (this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(prevHeader).Count) != roundTime)
-                    break;
-
-                if (this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(prevHeader.Previous).Count) != roundTime)
-                    break;
-
-                this.Logger.LogDebug("Block {0} was mined by the same miner '{1}' as {2} blocks ({3})s ago and there was no federation change.", prevHeader.HashBlock, pubKey.ToHex(), blockCounter, header.Time - prevHeader.Header.Time);
+                this.Logger.LogDebug("Block {0} was mined in the wrong slot the miner '{1}'.", chainedHeader.HashBlock, pubKey.ToHex());
                 this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
                 ConsensusErrors.BlockTimestampTooEarly.Throw();
             }

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -75,14 +75,53 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 PoAConsensusErrors.InvalidHeaderSignature.Throw();
             }
 
+            // TODO: Remove this code once the last checkpoint exceeds 'GetMiningTimestampV2ActivationStrictHeight'.
+            if (chainedHeader.Height < this.poAConsensusOptions.GetMiningTimestampV2ActivationStrictHeight)
+            {
+                // Look at the last round of blocks to find the previous time that the miner mined.
+                TimeSpan roundTime = this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(chainedHeader).Count);
+
+                // Quick check for optimisation.
+                this.federationHistory.GetLastActiveTime(federationMember, chainedHeader.Previous, out uint lastActiveTime);
+                if ((chainedHeader.Header.Time - lastActiveTime) >= roundTime.TotalSeconds)
+                    return Task.CompletedTask;
+
+                int blockCounter = 0;
+
+                for (ChainedHeader prevHeader = chainedHeader.Previous; prevHeader.Previous != null; prevHeader = prevHeader.Previous)
+                {
+                    blockCounter += 1;
+
+                    if ((header.BlockTime - prevHeader.Header.BlockTime) >= roundTime)
+                        break;
+
+                    // If the miner is found again within the same round then throw a consensus error.
+                    if (this.federationHistory.GetFederationMemberForBlock(prevHeader)?.PubKey != pubKey)
+                        continue;
+
+                    // Mining slots shift when the federation changes. 
+                    // Only raise an error if the federation did not change.
+                    if (this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(prevHeader).Count) != roundTime)
+                        break;
+
+                    if (this.slotsManager.GetRoundLength(this.federationHistory.GetFederationForBlock(prevHeader.Previous).Count) != roundTime)
+                        break;
+
+                    this.Logger.LogDebug("Block {0} was mined by the same miner '{1}' as {2} blocks ({3})s ago and there was no federation change.", prevHeader.HashBlock, pubKey.ToHex(), blockCounter, header.Time - prevHeader.Header.Time);
+                    this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
+                    ConsensusErrors.BlockTimestampTooEarly.Throw();
+                }
+
+                return Task.CompletedTask;
+            }
+
             uint expectedSlot = this.slotsManager.GetMiningTimestamp(chainedHeader.Previous, chainedHeader.Header.Time, pubKey);
 
             if (chainedHeader.Header.Time != expectedSlot)
             {
-                this.Logger.LogDebug("Block {0} was mined in the wrong slot by miner '{1}'. The timestamp on the miner's block is {2} seconds earlier than expected.", chainedHeader.Height, pubKey.ToHex(), expectedSlot - chainedHeader.Header.Time);
+                this.Logger.LogWarning("Block {0} was mined in the wrong slot by miner '{1}'. The timestamp on the miner's block is {2} seconds earlier than expected.", chainedHeader.Height, pubKey.ToHex(), expectedSlot - chainedHeader.Header.Time);
                 this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
-                if (chainedHeader.Height >= this.poAConsensusOptions.GetMiningTimestampV2ActivationStrictHeight)
-                    ConsensusErrors.BlockTimestampTooEarly.Throw();
+                ConsensusErrors.BlockTimestampTooEarly.Throw();
             }
 
             return Task.CompletedTask;

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -76,7 +76,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
             if (diff != 0)
             {
-                this.Logger.LogDebug("Block {0} was mined in the wrong slot the miner '{1}'.", chainedHeader.HashBlock, pubKey.ToHex());
+                this.Logger.LogDebug("Block {0} was mined in the wrong slot by miner '{1}'.", chainedHeader.HashBlock, pubKey.ToHex());
                 this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
                 ConsensusErrors.BlockTimestampTooEarly.Throw();
             }

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -76,7 +76,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
             if (chainedHeader.Header.Time != expectedSlot)
             {
-                this.Logger.LogDebug("Block {0} was mined in the wrong slot by miner '{1}'. The miner was expected to mine a block with a timestamp {2} seconds later.", chainedHeader.HashBlock, pubKey.ToHex(), expectedSlot - chainedHeader.Header.Time);
+                this.Logger.LogDebug("Block {0} was mined in the wrong slot by miner '{1}'. The timestamp on the miner's block is {2} seconds earlier than expected.", chainedHeader.HashBlock, pubKey.ToHex(), expectedSlot - chainedHeader.Header.Time);
                 this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
                 ConsensusErrors.BlockTimestampTooEarly.Throw();
             }

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -76,7 +76,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
             if (chainedHeader.Header.Time != expectedSlot)
             {
-                this.Logger.LogDebug("Block {0} was mined in the wrong slot by miner '{1}'. The miner was expected to mine at {2}.", chainedHeader.HashBlock, pubKey.ToHex(), expectedSlot);
+                this.Logger.LogDebug("Block {0} was mined in the wrong slot by miner '{1}'. The miner was expected to mine a block with a timestamp {2} seconds later.", chainedHeader.HashBlock, pubKey.ToHex(), expectedSlot - chainedHeader.Header.Time);
                 this.Logger.LogTrace("(-)[TIME_TOO_EARLY]");
                 ConsensusErrors.BlockTimestampTooEarly.Throw();
             }

--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
@@ -61,6 +61,12 @@ namespace Stratis.Bitcoin.Features.PoA
         public int GetMiningTimestampV2ActivationHeight { get; set; }
 
         /// <summary>
+        /// The height at which inituitive mining slots are enfored without any lenience.
+        /// Currently errors are sometimes suppressed if a federation change occurred.
+        /// </summary>
+        public int GetMiningTimestampV2ActivationStrictHeight { get; set; }
+
+        /// <summary>
         /// Logic related to release 1.1.0.0 will activate at this height, this includes Poll Expiry and the Join Federation Voting Request consensus rule.
         /// </summary>
         public int Release1100ActivationHeight { get; set; }

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -278,7 +278,7 @@ namespace Stratis.Sidechains.Networks
                 { 3_000_000, new CheckpointInfo(new uint256("0x79afa4a91a24b5e72632ad01d2a18330aecd1bc2cd4eea82eda5e3945fb0b238")) },
                 { 3_200_000, new CheckpointInfo(new uint256("0x6ec55b3b252f45e6677abf553601fb7bc97637319a9646e84d787769afe65988")) },
                 { 3_500_000, new CheckpointInfo(new uint256("0x1772356d6498935ab93cbd5eaf1b868c5265480edeef2b5fec133fbc21b292cb")) },
-                { 3_714_917, new CheckpointInfo(new uint256("0xf116a62f1f736fe30a9257c0020e9ac4699408ebf521634a537333f96a95b174")) }
+                { 3_718_682, new CheckpointInfo(new uint256("0x6aecd4d0e841b64c62d14aa9e84ffbcdf85d3f1e90a077dc0dbd863949c698b4")) }
             };
 
             this.DNSSeeds = new List<DNSSeedData>

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -181,6 +181,7 @@ namespace Stratis.Sidechains.Networks
                 Release1100ActivationHeight = 3_426_950, // Monday, 20 December 2021 10:00:00 AM (Estimated)
                 PollExpiryBlocks = 50_000, // Roughly 9 days
                 GetMiningTimestampV2ActivationHeight = 3_709_000, // Monday 14 February 00:00:00 (Estimated)
+                GetMiningTimestampV2ActivationStrictHeight = 3_719_500, // Monday 14 February 00:00:00 (Estimated)
                 ContractSerializerV2ActivationHeight = 3_386_335 // Monday 13 December 16:00:00 (Estimated)
             };
 
@@ -277,8 +278,7 @@ namespace Stratis.Sidechains.Networks
                 { 2_827_550, new CheckpointInfo(new uint256("0xcf0ebdd99ec04ef260d22befe70ef7b948e50b5fcc18d9d37376d49e872372a0")) },
                 { 3_000_000, new CheckpointInfo(new uint256("0x79afa4a91a24b5e72632ad01d2a18330aecd1bc2cd4eea82eda5e3945fb0b238")) },
                 { 3_200_000, new CheckpointInfo(new uint256("0x6ec55b3b252f45e6677abf553601fb7bc97637319a9646e84d787769afe65988")) },
-                { 3_500_000, new CheckpointInfo(new uint256("0x1772356d6498935ab93cbd5eaf1b868c5265480edeef2b5fec133fbc21b292cb")) },
-                { 3_718_682, new CheckpointInfo(new uint256("0x6aecd4d0e841b64c62d14aa9e84ffbcdf85d3f1e90a077dc0dbd863949c698b4")) }
+                { 3_500_000, new CheckpointInfo(new uint256("0x1772356d6498935ab93cbd5eaf1b868c5265480edeef2b5fec133fbc21b292cb")) } 
             };
 
             this.DNSSeeds = new List<DNSSeedData>

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -277,7 +277,8 @@ namespace Stratis.Sidechains.Networks
                 { 2_827_550, new CheckpointInfo(new uint256("0xcf0ebdd99ec04ef260d22befe70ef7b948e50b5fcc18d9d37376d49e872372a0")) },
                 { 3_000_000, new CheckpointInfo(new uint256("0x79afa4a91a24b5e72632ad01d2a18330aecd1bc2cd4eea82eda5e3945fb0b238")) },
                 { 3_200_000, new CheckpointInfo(new uint256("0x6ec55b3b252f45e6677abf553601fb7bc97637319a9646e84d787769afe65988")) },
-                { 3_500_000, new CheckpointInfo(new uint256("0x1772356d6498935ab93cbd5eaf1b868c5265480edeef2b5fec133fbc21b292cb")) }
+                { 3_500_000, new CheckpointInfo(new uint256("0x1772356d6498935ab93cbd5eaf1b868c5265480edeef2b5fec133fbc21b292cb")) },
+                { 3_714_917, new CheckpointInfo(new uint256("0xf116a62f1f736fe30a9257c0020e9ac4699408ebf521634a537333f96a95b174")) }
             };
 
             this.DNSSeeds = new List<DNSSeedData>

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -181,7 +181,7 @@ namespace Stratis.Sidechains.Networks
                 Release1100ActivationHeight = 3_426_950, // Monday, 20 December 2021 10:00:00 AM (Estimated)
                 PollExpiryBlocks = 50_000, // Roughly 9 days
                 GetMiningTimestampV2ActivationHeight = 3_709_000, // Monday 14 February 00:00:00 (Estimated)
-                GetMiningTimestampV2ActivationStrictHeight = 3_725_064, // Friday 18 February 10:00:00 (London Time) (Estimated)
+                GetMiningTimestampV2ActivationStrictHeight = 3_725_000, // Friday 18 February 10:00:00 (London Time) (Estimated)
                 ContractSerializerV2ActivationHeight = 3_386_335 // Monday 13 December 16:00:00 (Estimated)
             };
 

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -181,7 +181,7 @@ namespace Stratis.Sidechains.Networks
                 Release1100ActivationHeight = 3_426_950, // Monday, 20 December 2021 10:00:00 AM (Estimated)
                 PollExpiryBlocks = 50_000, // Roughly 9 days
                 GetMiningTimestampV2ActivationHeight = 3_709_000, // Monday 14 February 00:00:00 (Estimated)
-                GetMiningTimestampV2ActivationStrictHeight = 3_719_500, // Monday 14 February 00:00:00 (Estimated)
+                GetMiningTimestampV2ActivationStrictHeight = 3_725_064, // Friday 18 February 10:00:00 (London Time) (Estimated)
                 ContractSerializerV2ActivationHeight = 3_386_335 // Monday 13 December 16:00:00 (Estimated)
             };
 

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -110,6 +110,7 @@ namespace Stratis.Sidechains.Networks
                 autoKickIdleMembers: true)
             {
                 GetMiningTimestampV2ActivationHeight = 100,
+                GetMiningTimestampV2ActivationStrictHeight = 100,
                 PollExpiryBlocks = 450 // 2 hours
             };
 

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -132,6 +132,7 @@ namespace Stratis.Sidechains.Networks
                 Release1100ActivationHeight = 2_796_000,
                 PollExpiryBlocks = 450, // 2 hours,
                 GetMiningTimestampV2ActivationHeight = 3_000_000, // 15 January 2022
+                GetMiningTimestampV2ActivationStrictHeight = 3_000_500, // 15 January 2022
                 ContractSerializerV2ActivationHeight = 2_842_681
             };
 


### PR DESCRIPTION
The idea with this PR is to leverage `GetMiningTimestamp` in the `PoAHeaderSignatureRule` to guarantee consistency between generating and verifying timestamps.

The code adapts `GetMiningTimestamp` to work for nodes other than just the current node. It can then be used in `PoAHeaderSignatureRule` to check that the other nodes are mining at the appropriate times.