### PR TITLE
[Tests] Support DI constructor calls from tests

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -42,9 +42,8 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
                     TxIndex = true
                 })
                 .AddService(new DataFolder(TestBase.CreateTestDir(this)))
-                .AddService(new ChainIndexer(this.network))
-                .AddService<IDateTimeProvider>(new DateTimeProvider())
-                .AddService<IConsensusManager>();
+                .AddService<ChainIndexer>(typeof(ChainIndexer).GetConstructor(new[] { typeof(Network) }))
+                .AddService<IDateTimeProvider>(new DateTimeProvider());
 
             this.addressIndexer = mockingContext.GetService<IAddressIndexer>(typeof(AddressIndexer));
 

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -34,11 +34,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         public AddressIndexerTests()
         {
             this.network = new StraxMain();
-            var nodeSettings = NodeSettings.Default(this.network);
             var mockingContext = new MockingContext()
                 .AddService(this.network)
-                .AddService(nodeSettings)
-                .AddService(new StoreSettings(nodeSettings)
+                .AddService(new StoreSettings(NodeSettings.Default(this.network))
                 {
                     AddressIndex = true,
                     TxIndex = true
@@ -49,6 +47,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
                 .AddService<IConsensusManager>();
 
             this.addressIndexer = mockingContext.GetService<IAddressIndexer>(typeof(AddressIndexer));
+
             this.genesisHeader = new ChainedHeader(this.network.GetGenesis().Header, this.network.GetGenesis().Header.GetHash(), 0);
             this.mockingContext = mockingContext;
             this.consensusManagerMock = this.mockingContext.GetMock<IConsensusManager>();

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -29,8 +29,6 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
         private readonly ChainedHeader genesisHeader;
 
-        private readonly MockingContext mockingContext;
-
         public AddressIndexerTests()
         {
             this.network = new StraxMain();
@@ -42,14 +40,12 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
                     TxIndex = true
                 })
                 .AddService(new DataFolder(TestBase.CreateTestDir(this)))
-                .AddService<ChainIndexer>(typeof(ChainIndexer).GetConstructor(new[] { typeof(Network) }))
+                .AddService(new ChainIndexer(this.network))
                 .AddService<IDateTimeProvider>(new DateTimeProvider());
 
-            this.addressIndexer = mockingContext.GetService<IAddressIndexer>(typeof(AddressIndexer));
-
-            this.genesisHeader = new ChainedHeader(this.network.GetGenesis().Header, this.network.GetGenesis().Header.GetHash(), 0);
-            this.mockingContext = mockingContext;
-            this.consensusManagerMock = this.mockingContext.GetMock<IConsensusManager>();
+            this.addressIndexer = mockingContext.GetService<IAddressIndexer>(typeof(AddressIndexer), addIfNotExists: true);
+            this.genesisHeader = mockingContext.GetService<ChainIndexer>().GetHeader(0);
+            this.consensusManagerMock = mockingContext.GetMock<IConsensusManager>();
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -5,7 +5,6 @@ using System.Runtime.InteropServices;
 using LiteDB;
 using Moq;
 using NBitcoin;
-using Stratis.Bitcoin.AsyncWork;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Controllers.Models;
@@ -26,35 +25,33 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
         private readonly Mock<IConsensusManager> consensusManagerMock;
 
-        private readonly Mock<IAsyncProvider> asyncProviderMock;
-
         private readonly Network network;
 
         private readonly ChainedHeader genesisHeader;
 
+        private readonly MockingContext mockingContext;
+
         public AddressIndexerTests()
         {
             this.network = new StraxMain();
-            var storeSettings = new StoreSettings(NodeSettings.Default(this.network))
-            {
-                AddressIndex = true,
-                TxIndex = true
-            };
+            var nodeSettings = NodeSettings.Default(this.network);
+            var mockingContext = new MockingContext()
+                .AddService(this.network)
+                .AddService(nodeSettings)
+                .AddService(new StoreSettings(nodeSettings)
+                {
+                    AddressIndex = true,
+                    TxIndex = true
+                })
+                .AddService(new DataFolder(TestBase.CreateTestDir(this)))
+                .AddService(new ChainIndexer(this.network))
+                .AddService<IDateTimeProvider>(new DateTimeProvider())
+                .AddService<IConsensusManager>();
 
-            var dataFolder = new DataFolder(TestBase.CreateTestDir(this));
-            var stats = new Mock<INodeStats>();
-            var indexer = new ChainIndexer(this.network);
-
-            this.consensusManagerMock = new Mock<IConsensusManager>();
-
-            this.asyncProviderMock = new Mock<IAsyncProvider>();
-
-            var utxoIndexerMock = new Mock<IUtxoIndexer>();
-
-            this.addressIndexer = new AddressIndexer(storeSettings, dataFolder, this.network, stats.Object,
-                this.consensusManagerMock.Object, this.asyncProviderMock.Object, indexer, new DateTimeProvider(), utxoIndexerMock.Object);
-
+            this.addressIndexer = mockingContext.GetService<IAddressIndexer>(typeof(AddressIndexer));
             this.genesisHeader = new ChainedHeader(this.network.GetGenesis().Header, this.network.GetGenesis().Header.GetHash(), 0);
+            this.mockingContext = mockingContext;
+            this.consensusManagerMock = this.mockingContext.GetMock<IConsensusManager>();
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NBitcoin;

--- a/src/Stratis.Bitcoin.Tests.Common/MockingContext.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/MockingContext.cs
@@ -38,10 +38,9 @@ namespace Stratis.Bitcoin.Tests.Common
         }
 
         private object GetOrAddService(Type serviceType, Type implementationType = null, ConstructorInfo constructorInfo = null, bool allowAdd = true)
-        {
+        {            
             var service = this.serviceCollection
-                .Where(s => s.ServiceType == serviceType)
-                .Where(s => (implementationType == null && constructorInfo == null) || s.ImplementationType == (implementationType ?? constructorInfo.DeclaringType))
+                .Where(s => s.ServiceType == serviceType && (implementationType == null || s.ImplementationType == implementationType))
                 .SingleOrDefault()?.ImplementationInstance;
 
             if (service != null || !allowAdd)
@@ -58,7 +57,8 @@ namespace Stratis.Bitcoin.Tests.Common
             }
             else
             {
-                object[] args = (constructorInfo ?? implementationType.GetConstructors().Single()).GetParameters().Select(p => GetOrAddService(p.ParameterType)).ToArray();
+                constructorInfo ??= implementationType.GetConstructors().Single();
+                object[] args = constructorInfo.GetParameters().Select(p => GetOrAddService(p.ParameterType)).ToArray();
                 service = Activator.CreateInstance(implementationType, args);
             }
 

--- a/src/Stratis.Bitcoin.Tests.Common/MockingContext.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/MockingContext.cs
@@ -75,11 +75,6 @@ namespace Stratis.Bitcoin.Tests.Common
             return this;
         }
 
-        public MockingContext AddService<T>(Func<T> implementationInstance) where T : class
-        {
-            return AddService<T>(implementationInstance?.Invoke());
-        }
-
         public void Dispose()
         {
             this.serviceCollection.Clear();

--- a/src/Stratis.Bitcoin.Tests.Common/MockingContext.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/MockingContext.cs
@@ -28,8 +28,7 @@ namespace Stratis.Bitcoin.Tests.Common
 
         public Mock<T> GetMock<T>() where T : class
         {
-            Type mockType = MockType(typeof(T));
-            return (Mock<T>)this.serviceCollection.SingleOrDefault(s => s.ServiceType == mockType)?.ImplementationInstance;
+            return (Mock<T>)GetMock(typeof(T));
         }
 
         public object GetService(Type serviceType, Type? implementationType = null)
@@ -57,11 +56,6 @@ namespace Stratis.Bitcoin.Tests.Common
             this.serviceCollection.AddSingleton(serviceType, service);
 
             return service;
-        }
-
-        public IServiceCollection GetServiceCollection()
-        {
-            return this.serviceCollection;
         }
 
         public T GetService<T>(Type? implementationType = null) where T : class

--- a/src/Stratis.Bitcoin.Tests.Common/MockingContext.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/MockingContext.cs
@@ -31,7 +31,7 @@ namespace Stratis.Bitcoin.Tests.Common
             return (Mock<T>)GetMock(typeof(T));
         }
 
-        public object GetService(Type serviceType, Type? implementationType = null)
+        public object GetService(Type serviceType, Type implementationType = null)
         {
             var service = this.serviceCollection.SingleOrDefault(s => s.ServiceType == serviceType)?.ImplementationInstance;
             if (service != null)
@@ -58,7 +58,7 @@ namespace Stratis.Bitcoin.Tests.Common
             return service;
         }
 
-        public T GetService<T>(Type? implementationType = null) where T : class
+        public T GetService<T>(Type implementationType = null) where T : class
         {
             return (T)GetService(typeof(T), implementationType);
         }

--- a/src/Stratis.Bitcoin.Tests.Common/MockingContext.cs
+++ b/src/Stratis.Bitcoin.Tests.Common/MockingContext.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Linq;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Stratis.Bitcoin.Tests.Common
+{
+    public class MockingContext : IDisposable
+    {
+        private IServiceCollection serviceCollection;
+
+        public MockingContext() : this(new ServiceCollection())
+        {
+        }
+
+        public MockingContext(IServiceCollection serviceCollection)
+        {
+            this.serviceCollection = serviceCollection;
+        }
+
+        private Type MockType(Type serviceType) => typeof(Mock<>).MakeGenericType(serviceType);
+
+        public object GetMock(Type serviceType)
+        {
+            Type mockType = MockType(serviceType);
+            return this.serviceCollection.SingleOrDefault(s => s.ServiceType == mockType)?.ImplementationInstance;
+        }
+
+        public Mock<T> GetMock<T>() where T : class
+        {
+            Type mockType = MockType(typeof(T));
+            return (Mock<T>)this.serviceCollection.SingleOrDefault(s => s.ServiceType == mockType)?.ImplementationInstance;
+        }
+
+        public object GetService(Type serviceType, Type? implementationType = null)
+        {
+            var service = this.serviceCollection.SingleOrDefault(s => s.ServiceType == serviceType)?.ImplementationInstance;
+            if (service != null)
+                return service;
+
+            implementationType ??= serviceType;
+
+            if (!implementationType.IsInterface)
+            {
+                object[] args = implementationType.GetConstructors().Single().GetParameters().Select(p => GetService(p.ParameterType)).ToArray();
+                service = Activator.CreateInstance(implementationType, args);
+                this.serviceCollection.AddSingleton(serviceType, service);
+                return service;
+            }
+
+            Type mockType = MockType(implementationType);
+            var mock = Activator.CreateInstance(mockType);
+
+            service = ((dynamic)mock).Object;
+
+            this.serviceCollection.AddSingleton(mockType, mock);
+            this.serviceCollection.AddSingleton(serviceType, service);
+
+            return service;
+        }
+
+        public IServiceCollection GetServiceCollection()
+        {
+            return this.serviceCollection;
+        }
+
+        public T GetService<T>(Type? implementationType = null) where T : class
+        {
+            return (T)GetService(typeof(T), implementationType);
+        }
+
+        public MockingContext AddService<T>() where T : class
+        {
+            this.serviceCollection.AddSingleton(typeof(T));
+            return this;
+        }
+
+        public MockingContext AddService<T>(T implementationInstance) where T : class
+        {
+            this.serviceCollection.AddSingleton(typeof(T), implementationInstance);
+            return this;
+        }
+
+        public MockingContext AddService<T>(Func<T> implementationInstance) where T : class
+        {
+            return AddService<T>(implementationInstance?.Invoke());
+        }
+
+        public void Dispose()
+        {
+            this.serviceCollection.Clear();
+        }
+    }
+}


### PR DESCRIPTION
https://app.clickup.com/t/1z4emdx

This PR allows us to simulate DI constructor calls from test classes:

`this.addressIndexer = mockingContext.GetService<IAddressIndexer>(typeof(AddressIndexer));`