### PR TITLE
Fix CoinsToWei logic

### DIFF
--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -1257,7 +1257,7 @@ namespace Stratis.Bitcoin.Features.Interop
 
         private BigInteger CoinsToWei(ulong satoshi)
         {
-            BigInteger baseCurrencyUnits = Web3.Convert.ToWei(Money.Satoshis(satoshi), UnitConversion.EthUnit.Ether);
+            BigInteger baseCurrencyUnits = Web3.Convert.ToWei(Money.Satoshis(satoshi).ToDecimal(MoneyUnit.BTC), UnitConversion.EthUnit.Ether);
             return baseCurrencyUnits;
         }
 


### PR DESCRIPTION
This effectively divides the incoming number of 'satoshi' by 10^8 first to give a decimal number of coins, then the `ToWei` method multiplies the number of coins by 10^18 again to give the correct scaling for the token contracts