### PR TITLE
[IBD/Rewind] Defer DBreezeEngine construction

### DIFF
--- a/src/Stratis.SmartContracts.Core.Tests/StateRepositoryTests.cs
+++ b/src/Stratis.SmartContracts.Core.Tests/StateRepositoryTests.cs
@@ -140,13 +140,15 @@ namespace Stratis.SmartContracts.Core.Tests
         [Fact]
         public void Test20DBreeze()
         {
-            DBreezeEngine engine = new DBreezeEngine(DbreezeTestLocation);
-            using (DBreeze.Transactions.Transaction t = engine.GetTransaction())
+            using (DBreezeEngine engine = new DBreezeEngine(DbreezeTestLocation))
             {
-                t.RemoveAllKeys(DbreezeTestDb, true);
-                t.Commit();
+                using (DBreeze.Transactions.Transaction t = engine.GetTransaction())
+                {
+                    t.RemoveAllKeys(DbreezeTestDb, true);
+                    t.Commit();
+                }
             }
-            ISource<byte[], byte[]> stateDB = new NoDeleteSource<byte[], byte[]>(new DBreezeByteStore(engine, DbreezeTestDb));
+            ISource<byte[], byte[]> stateDB = new NoDeleteSource<byte[], byte[]>(new DBreezeByteStore(DbreezeTestLocation, DbreezeTestDb));
             StateRepositoryRoot repository = new StateRepositoryRoot(stateDB);
             byte[] root = repository.Root;
 

--- a/src/Stratis.SmartContracts.Core/Receipts/PersistentReceiptRepository.cs
+++ b/src/Stratis.SmartContracts.Core/Receipts/PersistentReceiptRepository.cs
@@ -9,21 +9,33 @@ namespace Stratis.SmartContracts.Core.Receipts
     public class PersistentReceiptRepository : IReceiptRepository
     {
         private const string TableName = "receipts";
-        private readonly DBreezeEngine engine;
+        private DBreezeEngine engine;
+        private readonly string folder;
 
         public PersistentReceiptRepository(DataFolder dataFolder)
         {
-            string folder = dataFolder.SmartContractStatePath + TableName;
-            Directory.CreateDirectory(folder);
-            this.engine = new DBreezeEngine(folder);
+            this.folder = dataFolder.SmartContractStatePath + TableName;
+            Directory.CreateDirectory(this.folder);
         }
+
+        private DBreezeEngine Engine
+        {
+            get
+            {
+                if (this.engine == null)
+                    this.engine = new DBreezeEngine(this.folder);
+
+                return this.engine;
+            }
+        }
+            
 
         // TODO: Handle pruning old data in case of reorg.
 
         /// <inheritdoc />
         public void Store(IEnumerable<Receipt> receipts)
         {
-            using (DBreeze.Transactions.Transaction t = this.engine.GetTransaction())
+            using (DBreeze.Transactions.Transaction t = this.Engine.GetTransaction())
             {
                 foreach(Receipt receipt in receipts)
                 {
@@ -36,7 +48,7 @@ namespace Stratis.SmartContracts.Core.Receipts
         /// <inheritdoc />
         public Receipt Retrieve(uint256 hash)
         {
-            using (DBreeze.Transactions.Transaction t = this.engine.GetTransaction())
+            using (DBreeze.Transactions.Transaction t = this.Engine.GetTransaction())
             {
                 return this.GetReceipt(t, hash);
             }
@@ -46,7 +58,7 @@ namespace Stratis.SmartContracts.Core.Receipts
         public IList<Receipt> RetrieveMany(IList<uint256> hashes)
         {
             List<Receipt> ret = new List<Receipt>();
-            using (DBreeze.Transactions.Transaction t = this.engine.GetTransaction())
+            using (DBreeze.Transactions.Transaction t = this.Engine.GetTransaction())
             {
                 foreach(uint256 hash in hashes)
                 {

--- a/src/Stratis.SmartContracts.Core/State/DBreezeByteStore.cs
+++ b/src/Stratis.SmartContracts.Core/State/DBreezeByteStore.cs
@@ -13,16 +13,28 @@ namespace Stratis.SmartContracts.Core.State
     {
         private DBreezeEngine engine;
         private string table;
+        private string folder;
 
-        public DBreezeByteStore(DBreezeEngine engine, string table)
+        public DBreezeByteStore(string folder, string table)
         {
-            this.engine = engine;
+            this.folder = folder;
             this.table = table;
+        }
+
+        private DBreezeEngine Engine
+        {
+            get
+            {
+                if (this.engine == null)
+                    this.engine = new DBreezeEngine(this.folder);
+
+                return this.engine;
+            }
         }
 
         public byte[] Get(byte[] key)
         {
-            using (DBreeze.Transactions.Transaction t = this.engine.GetTransaction())
+            using (DBreeze.Transactions.Transaction t = this.Engine.GetTransaction())
             {
                 Row<byte[], byte[]> row = t.Select<byte[], byte[]>(this.table, key);
 
@@ -35,7 +47,7 @@ namespace Stratis.SmartContracts.Core.State
 
         public void Put(byte[] key, byte[] val)
         {
-            using (DBreeze.Transactions.Transaction t = this.engine.GetTransaction())
+            using (DBreeze.Transactions.Transaction t = this.Engine.GetTransaction())
             {
                 t.Insert(this.table, key, val);
                 t.Commit();
@@ -44,7 +56,7 @@ namespace Stratis.SmartContracts.Core.State
 
         public void Delete(byte[] key)
         {
-            using (DBreeze.Transactions.Transaction t = this.engine.GetTransaction())
+            using (DBreeze.Transactions.Transaction t = this.Engine.GetTransaction())
             {
                 t.RemoveKey(this.table, key);
                 t.Commit();
@@ -61,7 +73,7 @@ namespace Stratis.SmartContracts.Core.State
         /// </summary>
         public void Empty()
         {
-            using (DBreeze.Transactions.Transaction t = this.engine.GetTransaction())
+            using (DBreeze.Transactions.Transaction t = this.Engine.GetTransaction())
             {
                 t.RemoveAllKeys(this.table, false);
                 t.Commit();
@@ -74,6 +86,6 @@ namespace Stratis.SmartContracts.Core.State
     /// </summary>
     public class DBreezeContractStateStore : DBreezeByteStore
     {
-        public DBreezeContractStateStore(DataFolder dataFolder) : base(new DBreezeEngine(dataFolder.SmartContractStatePath), "state") { }
+        public DBreezeContractStateStore(DataFolder dataFolder) : base(dataFolder.SmartContractStatePath, "state") { }
     }
 }

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
@@ -329,8 +329,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
                 this.keyEncodingStrategy = BasicKeyEncodingStrategy.Default;
 
                 this.Folder = TestBase.AssureEmptyDir(Path.Combine(AppContext.BaseDirectory, "TestCase", callingMethod)).FullName;
-                var engine = new DBreezeEngine(Path.Combine(this.Folder, "contracts"));
-                var byteStore = new DBreezeByteStore(engine, "ContractState1");
+                var byteStore = new DBreezeByteStore(Path.Combine(this.Folder, "contracts"), "ContractState1");
                 byteStore.Empty();
                 ISource<byte[], byte[]> stateDB = new NoDeleteSource<byte[], byte[]>(byteStore);
 


### PR DESCRIPTION
https://app.clickup.com/t/20jbtz5

As part of IBD optimization it is necessary to update the "contracts" and "contractsreceipts" folders during the smart contract feature initialize. Early DBreezeEngine construction locks these folders. This PR resolves the issue via JIT engine construction.