### PR TITLE
[IBD/Rewind] Disable mempool updates during IBD

### DIFF
--- a/src/Stratis.Bitcoin.Features.ColdStaking.Tests/ColdStakingControllerTest.cs
+++ b/src/Stratis.Bitcoin.Features.ColdStaking.Tests/ColdStakingControllerTest.cs
@@ -28,6 +28,7 @@ using Stratis.Bitcoin.Features.MemoryPool.Rules;
 using Stratis.Bitcoin.Features.Wallet;
 using Stratis.Bitcoin.Features.Wallet.Interfaces;
 using Stratis.Bitcoin.Features.Wallet.Services;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Networks.Policies;
 using Stratis.Bitcoin.Signals;
 using Stratis.Bitcoin.Tests.Common;
@@ -200,7 +201,7 @@ namespace Stratis.Bitcoin.Features.ColdStaking.Tests
             Assert.Equal(this.Network.Consensus.MempoolRules.Count, mempoolRules.Count);
 
             var mempoolValidator = new MempoolValidator(this.txMemPool, mempoolLock, this.dateTimeProvider, this.mempoolSettings, this.chainIndexer,
-                this.coinView.Object, this.loggerFactory, this.nodeSettings, consensusRuleEngine, mempoolRules, new Signals.Signals(this.loggerFactory, null), this.nodeDeployments);
+                this.coinView.Object, this.loggerFactory, this.nodeSettings, consensusRuleEngine, mempoolRules, new Signals.Signals(this.loggerFactory, null), this.nodeDeployments, new Mock<IInitialBlockDownloadState>().Object);
 
             // Create mempool manager.
             var mempoolPersistence = new Mock<IMempoolPersistence>();

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/MempoolPersistenceTest.cs
@@ -338,7 +338,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
 
             var nodeDeployments = new NodeDeployments(this.network, chain);
 
-            var mempoolValidator = new MempoolValidator(txMemPool, mempoolLock, dateTimeProvider, mempoolSettings, chain, coins, loggerFactory, settings, consensusRules, mempoolRules, new Signals.Signals(loggerFactory, null), nodeDeployments);
+            var mempoolValidator = new MempoolValidator(txMemPool, mempoolLock, dateTimeProvider, mempoolSettings, chain, coins, loggerFactory, settings, consensusRules, mempoolRules, new Signals.Signals(loggerFactory, null), nodeDeployments, new Mock<IInitialBlockDownloadState>().Object);
             return new MempoolManager(mempoolLock, txMemPool, mempoolValidator, dateTimeProvider, mempoolSettings, mempoolPersistence, coins, loggerFactory, settings.Network);
         }
     }

--- a/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool.Tests/TestChainFactory.cs
@@ -157,7 +157,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
 
             var nodeDeployments = new NodeDeployments(network, chain);
 
-            var mempoolValidator = new MempoolValidator(mempool, mempoolLock, dateTimeProvider, mempoolSettings, chain, inMemoryCoinView, loggerFactory, nodeSettings, consensusRules, mempoolRules, new Signals.Signals(loggerFactory, null), nodeDeployments);
+            var initialBlockDownloadState = new Mock<IInitialBlockDownloadState>();
+
+            var mempoolValidator = new MempoolValidator(mempool, mempoolLock, dateTimeProvider, mempoolSettings, chain, inMemoryCoinView, loggerFactory, nodeSettings, consensusRules, mempoolRules, new Signals.Signals(loggerFactory, null), nodeDeployments, initialBlockDownloadState.Object);
 
             var blocks = new List<Block>();
             var srcTxs = new List<Transaction>();
@@ -320,7 +322,9 @@ namespace Stratis.Bitcoin.Features.MemoryPool.Tests
 
             var nodeDeployments = new NodeDeployments(network, chain);
 
-            var mempoolValidator = new MempoolValidator(mempool, mempoolLock, dateTimeProvider, mempoolSettings, chain, inMemoryCoinView, loggerFactory, nodeSettings, consensusRules, mempoolRules, new Signals.Signals(loggerFactory, null), nodeDeployments);
+            var initialBlockDownloadState = new Mock<IInitialBlockDownloadState>();
+
+            var mempoolValidator = new MempoolValidator(mempool, mempoolLock, dateTimeProvider, mempoolSettings, chain, inMemoryCoinView, loggerFactory, nodeSettings, consensusRules, mempoolRules, new Signals.Signals(loggerFactory, null), nodeDeployments, initialBlockDownloadState.Object);
 
             return new TestChainContext { MempoolValidator = mempoolValidator, MempoolSettings = mempoolSettings, ChainIndexer = chain, SrcTxs = srcTxs };
         }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/SmartContractMempoolValidator.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/SmartContractMempoolValidator.cs
@@ -30,8 +30,9 @@ namespace Stratis.Bitcoin.Features.SmartContracts
             IConsensusRuleEngine consensusRules,
             IEnumerable<IMempoolRule> mempoolRules,
             Signals.ISignals signals,
-            NodeDeployments nodeDeployments)
-            : base(memPool, mempoolLock, dateTimeProvider, mempoolSettings, chainIndexer, coinView, loggerFactory, nodeSettings, consensusRules, mempoolRules, signals, nodeDeployments)
+            NodeDeployments nodeDeployments,
+            Bitcoin.Interfaces.IInitialBlockDownloadState initialBlockDownLoadState)
+            : base(memPool, mempoolLock, dateTimeProvider, mempoolSettings, chainIndexer, coinView, loggerFactory, nodeSettings, consensusRules, mempoolRules, signals, nodeDeployments, initialBlockDownLoadState)
         {
             // Dirty hack, but due to AllowedScriptTypeRule we don't need to check for standard scripts on any network, even live.
             // TODO: Remove ASAP. Ensure RequireStandard isn't used on SC mainnets, or the StandardScripts check is modular.


### PR DESCRIPTION
https://app.clickup.com/t/20je6g6

The mempool rules can't validate recent incoming transactions when the coinview had not been fully synced yet:

![image](https://user-images.githubusercontent.com/29645989/158281740-958a8a5a-c6bd-4be0-bba4-ea0ffa1222d2.png)
