### PR TITLE
[MultiSig] Consolidate less and log more info

### DIFF
--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -298,9 +298,9 @@ namespace Stratis.Bitcoin.Features.Interop
                     this.logger.Warn("Exception raised when consolidating Cirrus rewards wallet. {0}", e);
                 }
             },
-                this.nodeLifetime.ApplicationStopping,
-                repeatEvery: TimeSpans.Minute,
-                startAfter: TimeSpans.Second);
+            this.nodeLifetime.ApplicationStopping,
+            repeatEvery: TimeSpan.FromMinutes(5),
+            startAfter: TimeSpans.Minute);
         }
 
         public void CheckForBlockHeightOverrides(DestinationChain chain)
@@ -681,11 +681,11 @@ namespace Stratis.Bitcoin.Features.Interop
             if (walletStats.TotalUtxoCount < UtxoCountThreshold)
                 return;
 
-            this.logger.Info("Performing consolidation for wallet {0} account {1}.", walletCredentials.WalletName, walletCredentials.AccountName);
+            this.logger.Info("Performing consolidation for wallet '{0}' account '{1}'; UTXO count {2}.", walletCredentials.WalletName, walletCredentials.AccountName, walletStats.TotalUtxoCount);
 
-            bool success = await this.cirrusClient.ConsolidateAsync(walletCredentials.WalletName, walletCredentials.AccountName, walletCredentials.WalletPassword).ConfigureAwait(false);
+            var consolidationTransactionId = await this.cirrusClient.ConsolidateAsync(walletCredentials.WalletName, walletCredentials.AccountName, walletCredentials.WalletPassword).ConfigureAwait(false);
 
-            this.logger.Info("Result of consolidation: {0}", success);
+            this.logger.Info("Consolidation transaction Id (null if failed): {0}", consolidationTransactionId);
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin/Properties/AssemblyInfo.cs
+++ b/src/Stratis.Bitcoin/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.2.2.0")]
-[assembly: AssemblyFileVersion("1.2.2.0")]
+[assembly: AssemblyVersion("1.2.3.0")]
+[assembly: AssemblyFileVersion("1.2.3.0")]
 [assembly: InternalsVisibleTo("Stratis.Bitcoin.Tests")]

--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.2.2.0</Version>
+    <Version>1.2.3.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <CodeAnalysisRuleSet>..\Stratis.ruleset</CodeAnalysisRuleSet>
     <Authors>Stratis Group Ltd.</Authors>


### PR DESCRIPTION
It seems that whilst a consolidation transaction has been created on the multisig node and the consolidation loop runs again, it attempts to create another consolidation tx until the initial tx is mined. This PR increases the times between consolidation loops and logs more information.