### PR TITLE
[InterFlux] Allow polling for transfers on Cirrus to also catch up faster when behind

### DIFF
--- a/src/Stratis.Bitcoin.Features.Interop/ETHClient/ETHClient.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/ETHClient/ETHClient.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Features.Interop.ETHClient
 
         Task<BlockWithTransactions> GetBlockAsync(BigInteger blockNumber);
 
-        Task<List<(string TransactionHash, BurnFunction Burn)>> GetWStraxBurnsFromBlockAsync(BlockWithTransactions block);
+        List<(string TransactionHash, BurnFunction Burn)> GetWStraxBurnsFromBlock(BlockWithTransactions block);
 
         Task<List<(string TransactionHash, string TransferContractAddress, TransferDetails Transfer)>> GetTransfersFromBlockAsync(BlockWithTransactions block, HashSet<string> erc20tokens, HashSet<string> erc721tokens);
 
@@ -275,7 +275,7 @@ namespace Stratis.Bitcoin.Features.Interop.ETHClient
             return await this.web3.Eth.Blocks.GetBlockWithTransactionsByNumber.SendRequestAsync(new HexBigInteger(blockNumber)).ConfigureAwait(false);
         }
 
-        public async Task<List<(string TransactionHash, BurnFunction Burn)>> GetWStraxBurnsFromBlockAsync(BlockWithTransactions block)
+        public List<(string TransactionHash, BurnFunction Burn)> GetWStraxBurnsFromBlock(BlockWithTransactions block)
         {
             var burns = new List<(string TransactionHash, BurnFunction Burn)>();
 
@@ -328,7 +328,7 @@ namespace Stratis.Bitcoin.Features.Interop.ETHClient
                 {
                     this.logger.Debug($"Decoding transaction of interest '{tx.TransactionHash}'");
 
-                    TransactionReceipt receipt = await web3.Eth.Transactions.GetTransactionReceipt.SendRequestAsync(tx.TransactionHash).ConfigureAwait(false);
+                    TransactionReceipt receipt = await this.web3.Eth.Transactions.GetTransactionReceipt.SendRequestAsync(tx.TransactionHash).ConfigureAwait(false);
 
                     IEnumerable<FilterLogVO> logs = tx.GetTransactionLogs(receipt);
 


### PR DESCRIPTION
Currently if a MS node stops for eg. 15 mins and restarts, the Cirrus transfer polling loop will still sync up only one block for each run of the polling loop. This is inconsistent with the behavior when polling for applicable blocks on the ETH chain