### PR TITLE
[IBD/Rewind] Forego unused transactions and unnecessary commits in polls repo

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PollsRepositoryTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PollsRepositoryTests.cs
@@ -31,11 +31,11 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
 
             this.repository.WithTransaction(transaction =>
             {
-                this.repository.AddPolls(transaction, new Poll() { Id = 0 });
-                this.repository.AddPolls(transaction, new Poll() { Id = 1 });
-                this.repository.AddPolls(transaction, new Poll() { Id = 2 });
-                Assert.Throws<ArgumentException>(() => this.repository.AddPolls(transaction, new Poll() { Id = 5 }));
-                this.repository.AddPolls(transaction, new Poll() { Id = 3 });
+                transaction.AddPolls(new Poll() { Id = 0 });
+                transaction.AddPolls(new Poll() { Id = 1 });
+                transaction.AddPolls(new Poll() { Id = 2 });
+                Assert.Throws<ArgumentException>(() => transaction.AddPolls(new Poll() { Id = 5 }));
+                transaction.AddPolls(new Poll() { Id = 3 });
 
                 transaction.Commit();
             });
@@ -44,14 +44,14 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
 
             this.repository.WithTransaction(transaction =>
             {
-                this.repository.RemovePolls(transaction, 3);
+                transaction.RemovePolls(3);
 
-                Assert.Throws<ArgumentException>(() => this.repository.RemovePolls(transaction, 6));
-                Assert.Throws<ArgumentException>(() => this.repository.RemovePolls(transaction, 3));
+                Assert.Throws<ArgumentException>(() => transaction.RemovePolls(6));
+                Assert.Throws<ArgumentException>(() => transaction.RemovePolls(3));
 
-                this.repository.RemovePolls(transaction, 2);
-                this.repository.RemovePolls(transaction, 1);
-                this.repository.RemovePolls(transaction, 0);
+                transaction.RemovePolls(2);
+                transaction.RemovePolls(1);
+                transaction.RemovePolls(0);
 
                 transaction.Commit();
             });
@@ -64,11 +64,9 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         {
             this.repository.WithTransaction(transaction =>
             {
-                this.repository.AddPolls(transaction, new Poll() { Id = 0, PollStartBlockData = new HashHeightPair(1, 1) });
-                this.repository.AddPolls(transaction, new Poll() { Id = 1, PollStartBlockData = new HashHeightPair(2, 2) });
-                this.repository.AddPolls(transaction, new Poll() { Id = 2, PollStartBlockData = new HashHeightPair(3, 3) });
-
-                this.repository.SaveCurrentTip(transaction, new HashHeightPair(this.chainIndexer.Tip.HashBlock, 0));
+                transaction.AddPolls(new Poll() { Id = 0, PollStartBlockData = new HashHeightPair(1, 1) });
+                transaction.AddPolls(new Poll() { Id = 1, PollStartBlockData = new HashHeightPair(2, 2) });
+                transaction.AddPolls(new Poll() { Id = 2, PollStartBlockData = new HashHeightPair(3, 3) });
 
                 transaction.Commit();
             });
@@ -83,19 +81,19 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
         {
             this.repository.WithTransaction(transaction =>
             {
-                this.repository.AddPolls(transaction, new Poll() { Id = 0 });
-                this.repository.AddPolls(transaction, new Poll() { Id = 1 });
-                this.repository.AddPolls(transaction, new Poll() { Id = 2 });
+                transaction.AddPolls(new Poll() { Id = 0 });
+                transaction.AddPolls(new Poll() { Id = 1 });
+                transaction.AddPolls(new Poll() { Id = 2 });
 
                 transaction.Commit();
             });
 
             this.repository.WithTransaction(transaction =>
             {
-                Assert.True(this.repository.GetPolls(transaction, 0, 1, 2).Count == 3);
-                Assert.True(this.repository.GetAllPolls(transaction).Count == 3);
-                Assert.Throws<ArgumentException>(() => this.repository.GetPolls(transaction, -1));
-                Assert.Throws<ArgumentException>(() => this.repository.GetPolls(transaction, 9));
+                Assert.True(transaction.GetPolls( 0, 1, 2).Count == 3);
+                Assert.True(transaction.GetAllPolls().Count == 3);
+                Assert.Throws<ArgumentException>(() => transaction.GetPolls(-1));
+                Assert.Throws<ArgumentException>(() => transaction.GetPolls(9));
             });
         }
 
@@ -106,17 +104,17 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
 
             this.repository.WithTransaction(transaction =>
              {
-                 this.repository.AddPolls(transaction, poll);
+                 transaction.AddPolls(poll);
 
                  poll.VotingData.Key = VoteKey.KickFederationMember;
-                 this.repository.UpdatePoll(transaction, poll);
+                 transaction.UpdatePoll(poll);
 
                  transaction.Commit();
              });
 
             this.repository.WithTransaction(transaction =>
             {
-                Assert.Equal(VoteKey.KickFederationMember, this.repository.GetPolls(transaction, poll.Id).First().VotingData.Key);
+                Assert.Equal(VoteKey.KickFederationMember, transaction.GetPolls(poll.Id).First().VotingData.Key);
             });
         }
     }

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/PollsRepository.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/PollsRepository.cs
@@ -221,7 +221,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             {
                 this.pollsRepository.highestPollId = -1;
                 this.RemoveAllKeys(DataTable, true);
-                this.pollsRepository.CurrentTip = null;
+                this.pollsRepository.CurrentTip = new HashHeightPair(this.pollsRepository.network.GenesisHash, 0);
             }
         }
 
@@ -234,6 +234,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             this.dbreeze = new DBreezeEngine(dataFolder.PollsPath);
             this.dBreezeSerializer = dBreezeSerializer;
             this.network = network;
+            this.CurrentTip = new HashHeightPair(network.GenesisHash, 0);
 
             this.logger = LogManager.GetCurrentClassLogger();
         }
@@ -243,6 +244,9 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             // Load highest index.
             lock (this.lockObject)
             {
+                this.highestPollId = -1;
+                this.CurrentTip = new HashHeightPair(this.network.GenesisHash, 0);
+
                 using (var transaction = new Transaction(this))
                 {
                     try

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/PollsRepository.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/PollsRepository.cs
@@ -35,6 +35,196 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
         private readonly PoANetwork network;
 
+        public class Transaction : IDisposable
+        {
+            private readonly PollsRepository pollsRepository;
+            public bool IsModified { get; private set; }
+
+            private DBreeze.Transactions.Transaction _transaction;
+            private DBreeze.Transactions.Transaction transaction 
+            { 
+                get 
+                {
+                    if (this._transaction == null)
+                        this._transaction = this.pollsRepository.dbreeze.GetTransaction();
+                    
+                    return this._transaction;  
+                } 
+
+                set 
+                { 
+                    this._transaction = value; 
+                } 
+            }
+
+            public Transaction(PollsRepository pollsRepository)
+            {
+                this.pollsRepository = pollsRepository;
+                this.IsModified = false;
+            }
+
+            public void Insert<TKey, TValue>(string tableName, TKey key, TValue value)
+            {
+                this.transaction.Insert(tableName, key, value);
+                this.IsModified = true;
+            }
+
+            public Row<TKey, TValue> Select<TKey, TValue>(string tableName, TKey key)
+            {
+                return this.transaction.Select<TKey, TValue>(tableName, key);
+            }
+
+            public Dictionary<TKey, TValue> SelectDictionary<TKey, TValue>(string tableName)
+            {
+                return this.transaction.SelectDictionary<TKey, TValue>(tableName);
+            }
+
+            public void RemoveKey<TKey>(string tableName, TKey key)
+            {
+                this.transaction.RemoveKey(tableName, key);
+                this.IsModified = true;
+            }
+
+            public void RemoveAllKeys(string tableName, bool withFileRecreation)
+            {
+                this.transaction.RemoveAllKeys(tableName, withFileRecreation);
+                this.IsModified = true;
+            }
+
+            public void Flush()
+            {
+                this.Commit();
+
+                this.transaction.Dispose();
+                this.transaction = null;
+            }
+
+            public void SetTip(ChainedHeader tip)
+            {
+                this.pollsRepository.CurrentTip = new HashHeightPair(tip);
+                this.IsModified = true;
+            }
+
+            public void Commit()
+            {
+                if (this.IsModified)
+                {
+                    this.SaveCurrentTip();
+                    this.transaction.Commit();
+                    this.IsModified = false;
+                }
+            }
+
+            public void Dispose()
+            {
+                this.transaction?.Dispose();
+            }
+
+            /// <summary>Adds new polls.</summary>
+            /// <param name="polls">The polls to add.</param>
+            public void AddPolls(params Poll[] polls)
+            {
+                foreach (Poll pollToAdd in polls.OrderBy(p => p.Id))
+                {
+                    if (pollToAdd.Id != this.pollsRepository.highestPollId + 1)
+                        throw new ArgumentException("Id is incorrect. Gaps are not allowed.");
+
+                    byte[] bytes = this.pollsRepository.dBreezeSerializer.Serialize(pollToAdd);
+
+                    this.Insert(DataTable, pollToAdd.Id.ToBytes(), bytes);
+
+                    this.pollsRepository.highestPollId++;
+                }
+            }
+
+            /// <summary>Updates existing poll.</summary>
+            /// <param name="poll">The poll to update.</param>
+            public void UpdatePoll(Poll poll)
+            {
+                byte[] bytes = this.pollsRepository.dBreezeSerializer.Serialize(poll);
+
+                this.Insert(DataTable, poll.Id.ToBytes(), bytes);
+
+            }
+
+            /// <summary>Loads polls under provided keys from the database.</summary>
+            /// <param name="ids">The ids of the polls to retrieve.</param>
+            /// <returns>A list of retrieved <see cref="Poll"/> entries.</returns>
+            public List<Poll> GetPolls(params int[] ids)
+            {
+                var polls = new List<Poll>(ids.Length);
+
+                foreach (int id in ids)
+                {
+                    Row<byte[], byte[]> row = this.Select<byte[], byte[]>(DataTable, id.ToBytes());
+
+                    if (!row.Exists)
+                        throw new ArgumentException("Value under provided key doesn't exist!");
+
+                    Poll poll = this.pollsRepository.dBreezeSerializer.Deserialize<Poll>(row.Value);
+
+                    polls.Add(poll);
+                }
+
+                return polls;
+            }
+
+            /// <summary>Loads all polls from the database.</summary>
+            /// <returns>A list of retrieved <see cref="Poll"/> entries.</returns>
+            public List<Poll> GetAllPolls()
+            {
+                Dictionary<byte[], byte[]> data = this.SelectDictionary<byte[], byte[]>(DataTable);
+
+                return data
+                    .Where(d => d.Key.Length == 4)
+                    .Select(d => this.pollsRepository.dBreezeSerializer.Deserialize<Poll>(d.Value))
+                    .ToList();
+            }
+
+            private void SaveCurrentTip()
+            {
+                if (this.pollsRepository.CurrentTip != null)
+                {
+                    this.Insert(DataTable, RepositoryTipKey, this.pollsRepository.dBreezeSerializer.Serialize(this.pollsRepository.CurrentTip));
+                }
+            }
+
+            /// <summary>Removes polls for the provided ids.</summary>
+            /// <param name="ids">The ids of the polls to remove.</param>
+            public void DeletePollsAndSetHighestPollId(params int[] ids)
+            {
+                foreach (int pollId in ids.OrderBy(a => a))
+                {
+                    this.RemoveKey(DataTable, pollId.ToBytes());
+                }
+
+                List<Poll> polls = this.GetAllPolls();
+                this.pollsRepository.highestPollId = (polls.Count == 0) ? -1 : polls.Max(a => a.Id);
+            }
+
+            /// <summary>Removes polls under provided ids.</summary>
+            /// <param name="ids">The ids of the polls to remove.</param>
+            public void RemovePolls(params int[] ids)
+            {
+                foreach (int pollId in ids.OrderBy(id => id).Reverse())
+                {
+                    if (this.pollsRepository.highestPollId != pollId)
+                        throw new ArgumentException("Only deletion of the most recent item is allowed!");
+
+                    this.RemoveKey<byte[]>(DataTable, pollId.ToBytes());
+
+                    this.pollsRepository.highestPollId--;
+                }
+            }
+
+            public void ResetLocked()
+            {
+                this.pollsRepository.highestPollId = -1;
+                this.RemoveAllKeys(DataTable, true);
+                this.pollsRepository.CurrentTip = null;
+            }
+        }
+
         public PollsRepository(ChainIndexer chainIndexer, DataFolder dataFolder, DBreezeSerializer dBreezeSerializer, PoANetwork network)
         {
             Guard.NotEmpty(dataFolder.PollsPath, nameof(dataFolder.PollsPath));
@@ -53,11 +243,11 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             // Load highest index.
             lock (this.lockObject)
             {
-                using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())
+                using (var transaction = new Transaction(this))
                 {
                     try
                     {
-                        List<Poll> polls = GetAllPolls(transaction);
+                        List<Poll> polls = transaction.GetAllPolls();
 
                         // If the polls repository contains duplicate polls then reset the highest poll id and 
                         // set the tip to null.
@@ -68,7 +258,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                         {
                             this.logger.LogWarning("The polls repository contains {0} duplicate polls, it will be rebuilt.", polls.Count - uniquePolls.Count);
 
-                            this.ResetLocked(transaction);
+                            transaction.ResetLocked();
                             transaction.Commit();
                             return;
                         }
@@ -78,7 +268,8 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                         if (!rowTip.Exists)
                         {
                             this.logger.LogInformation("The polls repository tip is unknown, it will be rebuilt.");
-                            this.ResetLocked(transaction);
+
+                            transaction.ResetLocked();
                             transaction.Commit();
                             return;
                         }
@@ -113,7 +304,8 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                         if (maxGoodHeight == -1)
                         {
                             this.logger.LogInformation("No common blocks found; the repo will be rebuilt from scratch.");
-                            this.ResetLocked(transaction);
+
+                            transaction.ResetLocked();
                             transaction.Commit();
                             return;
                         }
@@ -164,11 +356,10 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                             }
 
                             if (modified)
-                                UpdatePoll(transaction, poll);
+                                transaction.UpdatePoll(poll);
                         }
 
-                        DeletePollsAndSetHighestPollId(transaction, pollsToDelete.Select(p => p.Id).ToArray());
-                        SaveCurrentTip(transaction, this.CurrentTip);
+                        transaction.DeletePollsAndSetHighestPollId(pollsToDelete.Select(p => p.Id).ToArray());
                         transaction.Commit();
 
                         this.logger.LogInformation("Polls repository initialized at height {0}; highest poll id: {1}.", this.CurrentTip.Height, this.highestPollId);
@@ -176,46 +367,23 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     catch (Exception err) when (err.Message == "No more byte to read")
                     {
                         this.logger.LogWarning("There was an error reading the polls repository, it will be rebuild.");
-                        this.ResetLocked(transaction);
+
+                        transaction.ResetLocked();
                         transaction.Commit();
                     }
                 }
             }
         }
 
-        private void ResetLocked(DBreeze.Transactions.Transaction transaction)
-        {
-            this.highestPollId = -1;
-            transaction.RemoveAllKeys(DataTable, true);
-            this.CurrentTip = null;
-        }
-
         public void Reset()
         {
             lock (this.lockObject)
             {
-                using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())
+                using (var transaction = new Transaction(this))
                 {
-                    ResetLocked(transaction);
+                    transaction.ResetLocked();
                     transaction.Commit();
                 }
-            }
-        }
-
-        public void SaveCurrentTip(DBreeze.Transactions.Transaction transaction, ChainedHeader tip)
-        {
-            SaveCurrentTip(transaction, (tip == null) ? null : new HashHeightPair(tip));
-        }
-
-        public void SaveCurrentTip(DBreeze.Transactions.Transaction transaction, HashHeightPair tip = null)
-        {
-            lock (this.lockObject)
-            {
-                if (tip != null)
-                    this.CurrentTip = tip;
-
-                if (transaction != null)
-                    transaction.Insert<byte[], byte[]>(DataTable, RepositoryTipKey, this.dBreezeSerializer.Serialize(this.CurrentTip));
             }
         }
 
@@ -234,145 +402,25 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             }
         }
 
-        /// <summary>Removes polls for the provided ids.</summary>
-        /// <param name="transaction">See <see cref="DBreeze.Transactions.Transaction"/>.</param>
-        /// <param name="ids">The ids of the polls to remove.</param>
-        public void DeletePollsAndSetHighestPollId(DBreeze.Transactions.Transaction transaction, params int[] ids)
+        public T WithTransaction<T>(Func<Transaction, T> func)
         {
             lock (this.lockObject)
             {
-                foreach (int pollId in ids.OrderBy(a => a))
-                {
-                    transaction.RemoveKey<byte[]>(DataTable, pollId.ToBytes());
-                }
-
-                List<Poll> polls = GetAllPolls(transaction);
-                this.highestPollId = (polls.Count == 0) ? -1 : polls.Max(a => a.Id);
-            }
-        }
-
-        /// <summary>Removes polls under provided ids.</summary>
-        /// <param name="transaction">See <see cref="DBreeze.Transactions.Transaction"/>.</param>
-        /// <param name="ids">The ids of the polls to remove.</param>
-        public void RemovePolls(DBreeze.Transactions.Transaction transaction, params int[] ids)
-        {
-            lock (this.lockObject)
-            {
-                foreach (int pollId in ids.OrderBy(id => id).Reverse())
-                {
-                    if (this.highestPollId != pollId)
-                        throw new ArgumentException("Only deletion of the most recent item is allowed!");
-
-                    transaction.RemoveKey<byte[]>(DataTable, pollId.ToBytes());
-
-                    this.highestPollId--;
-                }
-            }
-        }
-
-        public DBreeze.Transactions.Transaction GetTransaction()
-        {
-            lock (this.lockObject)
-            {
-                return this.dbreeze.GetTransaction();
-            }
-        }
-
-        public T WithTransaction<T>(Func<DBreeze.Transactions.Transaction, T> func)
-        {
-            lock (this.lockObject)
-            {
-                using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())
+                using (var transaction = new Transaction(this))
                 {
                     return func(transaction);
                 }
             }
         }
 
-        public void WithTransaction(Action<DBreeze.Transactions.Transaction> action)
+        public void WithTransaction(Action<Transaction> action)
         {
             lock (this.lockObject)
             {
-                using (DBreeze.Transactions.Transaction transaction = this.dbreeze.GetTransaction())
+                using (var transaction = new Transaction(this))
                 {
                     action(transaction);
                 }
-            }
-        }
-
-        /// <summary>Adds new polls.</summary>
-        /// <param name="transaction">See <see cref="DBreeze.Transactions.Transaction"/>.</param>
-        /// <param name="polls">The polls to add.</param>
-        public void AddPolls(DBreeze.Transactions.Transaction transaction, params Poll[] polls)
-        {
-            lock (this.lockObject)
-            {
-                foreach (Poll pollToAdd in polls.OrderBy(p => p.Id))
-                {
-                    if (pollToAdd.Id != this.highestPollId + 1)
-                        throw new ArgumentException("Id is incorrect. Gaps are not allowed.");
-
-                    byte[] bytes = this.dBreezeSerializer.Serialize(pollToAdd);
-
-                    transaction.Insert<byte[], byte[]>(DataTable, pollToAdd.Id.ToBytes(), bytes);
-
-                    this.highestPollId++;
-                }
-            }
-        }
-
-        /// <summary>Updates existing poll.</summary>
-        /// <param name="transaction">See <see cref="DBreeze.Transactions.Transaction"/>.</param>
-        /// <param name="poll">The poll to update.</param>
-        public void UpdatePoll(DBreeze.Transactions.Transaction transaction, Poll poll)
-        {
-            lock (this.lockObject)
-            {
-                byte[] bytes = this.dBreezeSerializer.Serialize(poll);
-
-                transaction.Insert<byte[], byte[]>(DataTable, poll.Id.ToBytes(), bytes);
-            }
-        }
-
-        /// <summary>Loads polls under provided keys from the database.</summary>
-        /// <param name="transaction">See <see cref="DBreeze.Transactions.Transaction"/>.</param>
-        /// <param name="ids">The ids of the polls to retrieve.</param>
-        /// <returns>A list of retrieved <see cref="Poll"/> entries.</returns>
-        public List<Poll> GetPolls(DBreeze.Transactions.Transaction transaction, params int[] ids)
-        {
-            lock (this.lockObject)
-            {
-                var polls = new List<Poll>(ids.Length);
-
-                foreach (int id in ids)
-                {
-                    Row<byte[], byte[]> row = transaction.Select<byte[], byte[]>(DataTable, id.ToBytes());
-
-                    if (!row.Exists)
-                        throw new ArgumentException("Value under provided key doesn't exist!");
-
-                    Poll poll = this.dBreezeSerializer.Deserialize<Poll>(row.Value);
-
-                    polls.Add(poll);
-                }
-
-                return polls;
-            }
-        }
-
-        /// <summary>Loads all polls from the database.</summary>
-        /// <param name="transaction">See <see cref="DBreeze.Transactions.Transaction"/>.</param>
-        /// <returns>A list of retrieved <see cref="Poll"/> entries.</returns>
-        public List<Poll> GetAllPolls(DBreeze.Transactions.Transaction transaction)
-        {
-            lock (this.lockObject)
-            {
-                Dictionary<byte[], byte[]> data = transaction.SelectDictionary<byte[], byte[]>(DataTable);
-
-                return data
-                    .Where(d => d.Key.Length == 4)
-                    .Select(d => this.dBreezeSerializer.Deserialize<Poll>(d.Value))
-                    .ToList();
             }
         }
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -105,7 +105,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             this.idleFederationMembersKicker = idleFederationMembersKicker;
 
             this.PollsRepository.Initialize();
-            this.PollsRepository.WithTransaction(transaction => this.polls = new PollsCollection(this.network as PoANetwork, this.PollsRepository.GetAllPolls(transaction)));
+            this.PollsRepository.WithTransaction(transaction => this.polls = new PollsCollection(this.network as PoANetwork, transaction.GetAllPolls()));
 
             this.blockConnectedSubscription = this.signals.Subscribe<BlockConnected>(this.OnBlockConnected);
             this.blockDisconnectedSubscription = this.signals.Subscribe<BlockDisconnected>(this.OnBlockDisconnected);
@@ -300,7 +300,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             return false;
         }
 
-        public Poll CreatePendingPoll(DBreeze.Transactions.Transaction transaction, VotingData votingData, ChainedHeader chainedHeader, List<Vote> pubKeysVotedInFavor = null)
+        public Poll CreatePendingPoll(PollsRepository.Transaction transaction, VotingData votingData, ChainedHeader chainedHeader, List<Vote> pubKeysVotedInFavor = null)
         {
             Poll poll = null;
 
@@ -319,9 +319,10 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                 this.polls.Add(poll);
 
-                this.PollsRepository.AddPolls(transaction, poll);
+                transaction.AddPolls(poll);
 
-                this.logger.LogInformation("New poll was created: '{0}'.", poll);
+                this.logger.LogInformation("Created poll {0} [{1}] at height {2}.", 
+                    poll.Id, this.pollResultExecutor.ConvertToString(poll.VotingData), poll.PollStartBlockData.Height);
             });
 
             return poll;
@@ -495,7 +496,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             return this.federationManager.IsMultisigMember(member.PubKey);
         }
 
-        private void ProcessBlock(DBreeze.Transactions.Transaction transaction, ChainedHeaderBlock chBlock)
+        private void ProcessBlock(PollsRepository.Transaction transaction, ChainedHeaderBlock chBlock)
         {
             long flagFall = DateTime.Now.Ticks;
 
@@ -503,8 +504,6 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             {
                 lock (this.locker)
                 {
-                    bool pollsRepositoryModified = false;
-
                     foreach (Poll poll in this.polls.GetPollsToExecuteOrExpire(chBlock.ChainedHeader.Height))
                     {
                         if (!poll.IsApproved)
@@ -514,8 +513,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                             // Flag the poll as expired. The "PollVotedInFavorBlockData" will always be null at this point due to the "GetPendingPolls" filter above.
                             // The value of the hash is not significant but we set it to a non-zero value to prevent the field from being de-serialized as null.
                             this.polls.AdjustPoll(poll, poll => poll.IsExpired = true);
-                            this.PollsRepository.UpdatePoll(transaction, poll);
-                            pollsRepositoryModified = true;
+                            transaction.UpdatePoll(poll);
                         }
                         else
                         {
@@ -523,9 +521,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                             this.pollResultExecutor.ApplyChange(poll.VotingData);
 
                             this.polls.AdjustPoll(poll, poll => poll.PollExecutedBlockData = new HashHeightPair(chBlock.ChainedHeader));
-                            this.PollsRepository.UpdatePoll(transaction, poll);
-
-                            pollsRepositoryModified = true;
+                            transaction.UpdatePoll(poll);
                         }
                     }
 
@@ -536,7 +532,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                     if (rawVotingData == null)
                     {
-                        this.PollsRepository.SaveCurrentTip(pollsRepositoryModified ? transaction : null, chBlock.ChainedHeader);
+                        transaction.SetTip(chBlock.ChainedHeader);
                         return;
                     }
 
@@ -546,7 +542,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                         this.logger.LogError("The block was mined by a non-federation-member!");
                         this.logger.LogTrace("(-)[ALIEN_BLOCK]");
 
-                        this.PollsRepository.SaveCurrentTip(pollsRepositoryModified ? transaction : null, chBlock.ChainedHeader);
+                        transaction.SetTip(chBlock.ChainedHeader);
                         return;
                     }
 
@@ -583,13 +579,11 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                                     continue;
 
                                 poll = CreatePendingPoll(transaction, data, chBlock.ChainedHeader, new List<Vote>() { new Vote() { PubKey = fedMemberKeyHex, Height = chBlock.ChainedHeader.Height } });
-                                pollsRepositoryModified = true;
                             }
                             else if (!poll.PubKeysHexVotedInFavor.Any(v => v.PubKey == fedMemberKeyHex))
                             {
                                 poll.PubKeysHexVotedInFavor.Add(new Vote() { PubKey = fedMemberKeyHex, Height = chBlock.ChainedHeader.Height });
-                                this.PollsRepository.UpdatePoll(transaction, poll);
-                                pollsRepositoryModified = true;
+                                transaction.UpdatePoll(poll);
 
                                 this.logger.LogDebug("Voted on existing poll: '{0}'.", poll);
                             }
@@ -640,12 +634,11 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                                 continue;
 
                             this.polls.AdjustPoll(poll, poll => poll.PollVotedInFavorBlockData = new HashHeightPair(chBlock.ChainedHeader));
-                            this.PollsRepository.UpdatePoll(transaction, poll);
-                            pollsRepositoryModified = true;
+                            transaction.UpdatePoll(poll);
                         }
                     }
 
-                    this.PollsRepository.SaveCurrentTip(pollsRepositoryModified ? transaction : null, chBlock.ChainedHeader);
+                    transaction.SetTip(chBlock.ChainedHeader);
                 }
             }
             catch (Exception ex)
@@ -662,10 +655,8 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             }
         }
 
-        private void UnProcessBlock(DBreeze.Transactions.Transaction transaction, ChainedHeaderBlock chBlock)
+        private void UnProcessBlock(PollsRepository.Transaction transaction, ChainedHeaderBlock chBlock)
         {
-            bool pollsRepositoryModified = false;
-
             lock (this.locker)
             {
                 foreach (Poll poll in this.polls.Where(x => !x.IsPending && x.PollExecutedBlockData?.Hash == chBlock.ChainedHeader.HashBlock).ToList())
@@ -674,8 +665,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     this.pollResultExecutor.RevertChange(poll.VotingData);
 
                     this.polls.AdjustPoll(poll, poll => poll.PollExecutedBlockData = null);
-                    this.PollsRepository.UpdatePoll(transaction, poll);
-                    pollsRepositoryModified = true;
+                    transaction.UpdatePoll(poll);
                 }
 
                 foreach (Poll poll in this.polls.Where(x => x.IsExpired && !PollsRepository.IsPollExpiredAt(x, chBlock.ChainedHeader.Height - 1, this.network as PoANetwork)).ToList())
@@ -684,8 +674,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                     // Revert back to null as this field would have been when the poll was expired.
                     this.polls.AdjustPoll(poll, poll => poll.IsExpired = false);
-                    this.PollsRepository.UpdatePoll(transaction, poll);
-                    pollsRepositoryModified = true;
+                    transaction.UpdatePoll(poll);
                 }
 
                 if (this.federationManager.GetMultisigMinersApplicabilityHeight() == chBlock.ChainedHeader.Height)
@@ -698,7 +687,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             {
                 this.logger.LogTrace("(-)[NO_VOTING_DATA]");
 
-                this.PollsRepository.SaveCurrentTip(pollsRepositoryModified ? transaction : null, chBlock.ChainedHeader.Previous);
+                transaction.SetTip(chBlock.ChainedHeader.Previous);
                 return;
             }
 
@@ -730,8 +719,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     if (targetPoll.PollVotedInFavorBlockData == new HashHeightPair(chBlock.ChainedHeader))
                     {
                         this.polls.AdjustPoll(targetPoll, poll => poll.PollVotedInFavorBlockData = null);
-                        this.PollsRepository.UpdatePoll(transaction, targetPoll);
-                        pollsRepositoryModified = true;
+                        transaction.UpdatePoll(targetPoll);
                     }
 
                     // Pub key of a fed member that created voting data.
@@ -740,9 +728,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     if (voteIndex >= 0)
                     {
                         targetPoll.PubKeysHexVotedInFavor.RemoveAt(voteIndex);
-
-                        this.PollsRepository.UpdatePoll(transaction, targetPoll);
-                        pollsRepositoryModified = true;
+                        transaction.UpdatePoll(targetPoll);
                     }
                 }
 
@@ -751,14 +737,13 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     if (targetPoll.PollStartBlockData.Height >= chBlock.ChainedHeader.Height)
                     {
                         this.polls.Remove(targetPoll);
-                        this.PollsRepository.RemovePolls(transaction, targetPoll.Id);
-                        pollsRepositoryModified = true;
+                        transaction.RemovePolls(targetPoll.Id);
 
                         this.logger.LogDebug("Poll with Id {0} was removed.", targetPoll.Id);
                     }
                 }
 
-                this.PollsRepository.SaveCurrentTip(pollsRepositoryModified ? transaction : null, chBlock.ChainedHeader.Previous);
+                transaction.SetTip(chBlock.ChainedHeader.Previous);
             }
         }
 
@@ -833,17 +818,16 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
                 if (headers.Count > 0)
                 {
-                    DBreeze.Transactions.Transaction currentTransaction = this.PollsRepository.GetTransaction();
-
-                    int i = 0;
-                    foreach (Block block in this.blockRepository.EnumerateBatch(headers))
+                    this.PollsRepository.WithTransaction((currentTransaction) =>
                     {
-                        if (this.nodeLifetime.ApplicationStopping.IsCancellationRequested)
+                        int i = 0;
+                        foreach (Block block in this.blockRepository.GetBlocks(headers.Select(h => h.HashBlock).ToList()))
                         {
-                            this.logger.LogTrace("(-)[NODE_DISPOSED]");
-                            this.PollsRepository.SaveCurrentTip(currentTransaction);
-                            currentTransaction.Commit();
-                            currentTransaction.Dispose();
+                            if (this.nodeLifetime.ApplicationStopping.IsCancellationRequested)
+                            {
+                                this.logger.LogTrace("(-)[NODE_DISPOSED]");
+                                currentTransaction.Commit();
+                                currentTransaction.Dispose();
 
                             bSuccess = false;
                             return;
@@ -861,23 +845,12 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                             this.logger.LogInformation(progressString);
                             this.signals.Publish(new FullNodeEvent() { Message = progressString, State = FullNodeState.Initializing.ToString() });
 
-                            this.PollsRepository.SaveCurrentTip(currentTransaction);
-
-                            currentTransaction.Commit();
-                            currentTransaction.Dispose();
-
-                            currentTransaction = this.PollsRepository.GetTransaction();
+                                currentTransaction.Flush();
+                            }
                         }
-                    }
 
-                    // If we ended the synchronization at say block 10100, the current transaction would still be open and
-                    // thus we need to commit and dispose of it.
-                    // If we ended at block 10000, then the current transaction would have been committed and
-                    // disposed and re-opened.
-                    this.PollsRepository.SaveCurrentTip(currentTransaction);
-
-                    currentTransaction.Commit();
-                    currentTransaction.Dispose();
+                        currentTransaction.Commit();
+                    });
                 }
             });
 


### PR DESCRIPTION
https://app.clickup.com/t/20xtcz0

This PR ensure that the polls repository DB is not involved (empty transactions or unnecessary commits) when ranges of blocks lead to no polls repository updates. After this PR we now see associated block throughput rates of over 100,000 per second:

```
	>> Voting & Poll Data
	Polls Repository Height : 1396716 (Hash: dbb11c175eab61a85033c004bba269fb25143619c0cdee5625a9289a8838108d)
	Blocks Processed        : 1396716         Avg Time: 0 ms      Throughput: 108000.72 per second
```

Approach: When entering transactional context the internal transaction creation is delayed until an actual db operation takes place. We then note the change and only call the commit if changes took place. The details of this behaviour is hidden in a new `PollsRepository.Transaction` class.