### PR TITLE
Set release 1.3 activation date lower bound

### DIFF
--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -107,7 +107,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, new DateTime(2022,3,22).ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -107,7 +107,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -197,7 +197,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, DateTime.Parse("2023-1-1").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -197,7 +197,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, new DateTime(2022, 3, 22).ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -126,7 +126,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -126,7 +126,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, new DateTime(2022, 3, 22).ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -148,7 +148,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, new DateTime(2022,3,22).ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -148,7 +148,7 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, 0 /* Voting starts immediately */, DateTime.Parse("2023-1-1").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultMainnetThreshold)
             };
 
             this.Consensus = new Consensus(


### PR DESCRIPTION
https://app.clickup.com/t/1uv60bv

A noticeable delay (a few minutes on start-up) is caused by setting too low a lower bound on the activation start. This is due to too many headers having to be scanned to determine if activation had already been triggered in a prior confirmation window.

This PR modifies that lower bound and replaces it with a more recent past date. As a result the delay is no longer noticeable.

Supplements PR #869.