### PR TITLE
Remove duplicate help text

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
@@ -105,7 +105,8 @@ namespace Stratis.Bitcoin.Features.Api
             builder.AppendLine($"-usehttps=<bool>                  Use https protocol on the API. Defaults to false.");
             builder.AppendLine($"-certificatefilepath=<string>     Path to the certificate used for https traffic encryption. Defaults to <null>. Password protected files are not supported. On MacOs, only p12 certificates can be used without password.");
 
-            NodeSettings.Default(network).Logger.LogInformation(builder.ToString());
+            var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(ApiSettings).FullName);
+            logger.LogInformation(builder.ToString());            
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs
@@ -99,11 +99,11 @@ namespace Stratis.Bitcoin.Features.Api
         {
             var builder = new StringBuilder();
 
-            builder.AppendLine($"-apiuri=<string>                  URI to node's API interface. Defaults to '{ DefaultApiHost }'.");
-            builder.AppendLine($"-apiport=<0-65535>                Port of node's API interface. Defaults to { network.DefaultAPIPort }.");
-            builder.AppendLine($"-keepalive=<seconds>              Keep Alive interval (set in seconds). Default: 0 (no keep alive).");
-            builder.AppendLine($"-usehttps=<bool>                  Use https protocol on the API. Defaults to false.");
-            builder.AppendLine($"-certificatefilepath=<string>     Path to the certificate used for https traffic encryption. Defaults to <null>. Password protected files are not supported. On MacOs, only p12 certificates can be used without password.");
+            builder.AppendLine($"-apiuri=<string>               URI to node's API interface. Defaults to '{ DefaultApiHost }'.");
+            builder.AppendLine($"-apiport=<0-65535>             Port of node's API interface. Defaults to { network.DefaultAPIPort }.");
+            builder.AppendLine($"-keepalive=<seconds>           Keep Alive interval (set in seconds). Default: 0 (no keep alive).");
+            builder.AppendLine($"-usehttps=<bool>               Use https protocol on the API. Defaults to false.");
+            builder.AppendLine($"-certificatefilepath=<string>  Path to the certificate used for https traffic encryption. Defaults to <null>. Password protected files are not supported. On MacOs, only p12 certificates can be used without password.");
 
             var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(ApiSettings).FullName);
             logger.LogInformation(builder.ToString());            

--- a/src/Stratis.Bitcoin.Features.BlockStore/StoreSettings.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/StoreSettings.cs
@@ -96,7 +96,8 @@ namespace Stratis.Bitcoin.Features.BlockStore
             builder.AppendLine($"-addressindex=<0 or 1>         Enable to maintain a full address index.");
             builder.AppendLine($"-compactionthreshold=<integer value>         Specify address indexer compaction threshold.");
 
-            NodeSettings.Default(network).Logger.LogInformation(builder.ToString());
+            var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(StoreSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Dns/DnsSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Dns/DnsSettings.cs
@@ -71,7 +71,8 @@ namespace Stratis.Bitcoin.Features.Dns
             builder.AppendLine($"-dnsnameserver=<string>   The DNS Seed Service nameserver.");
             builder.AppendLine($"-dnsmailbox=<string>      The e-mail address used as the administrative point of contact for the domain.");
 
-            NodeSettings.Default(network).Logger.LogInformation(builder.ToString());
+            var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(DnsSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolSettings.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolSettings.cs
@@ -86,18 +86,18 @@ namespace Stratis.Bitcoin.Features.MemoryPool
         {
             var builder = new StringBuilder();
 
-            builder.AppendLine($"-maxmempool=<megabytes>   Maximal size of the transaction memory pool in megabytes. Defaults to { MempoolValidator.DefaultMaxMempoolSize }.");
-            builder.AppendLine($"-mempoolexpiry=<hours>    Maximum number of hours to keep transactions in the mempool. Defaults to { MempoolValidator.DefaultMempoolExpiry }.");
-            builder.AppendLine($"-relaypriority=<0 or 1>   Enable high priority for relaying free or low-fee transactions.");
-            builder.AppendLine($"-limitancestorcount=<count>  Maximum number of ancestors of a transaction in mempool (including itself). Defaults to { MempoolValidator.DefaultAncestorLimit }.");
-            builder.AppendLine($"-limitancestorsize=<kB>   Maximal size in kB of ancestors of a transaction in mempool (including itself). Defaults to { MempoolValidator.DefaultAncestorSizeLimit }.");
+            builder.AppendLine($"-maxmempool=<megabytes>        Maximal size of the transaction memory pool in megabytes. Defaults to { MempoolValidator.DefaultMaxMempoolSize }.");
+            builder.AppendLine($"-mempoolexpiry=<hours>         Maximum number of hours to keep transactions in the mempool. Defaults to { MempoolValidator.DefaultMempoolExpiry }.");
+            builder.AppendLine($"-relaypriority=<0 or 1>        Enable high priority for relaying free or low-fee transactions.");
+            builder.AppendLine($"-limitancestorcount=<count>    Maximum number of ancestors of a transaction in mempool (including itself). Defaults to { MempoolValidator.DefaultAncestorLimit }.");
+            builder.AppendLine($"-limitancestorsize=<kB>        Maximal size in kB of ancestors of a transaction in mempool (including itself). Defaults to { MempoolValidator.DefaultAncestorSizeLimit }.");
             builder.AppendLine($"-limitdescendantcount=<count>  Maximum number of descendants any ancestor can have in mempool (including itself). Defaults to { MempoolValidator.DefaultDescendantLimit }.");
-            builder.AppendLine($"-limitdescendantsize=<kB> Maximum size in kB of descendants any ancestor can have in mempool (including itself). Defaults to { MempoolValidator.DefaultDescendantSizeLimit }.");
-            builder.AppendLine($"-mempoolreplacement=<0 or 1>  Enable transaction replacement in the memory pool.");
-            builder.AppendLine($"-maxorphantx=<kB>         Maximum number of orphan transactions kept in memory. Defaults to { MempoolOrphans.DefaultMaxOrphanTransactions }.");
-            builder.AppendLine($"-whitelistrelay=<0 or 1>  Enable to accept relayed transactions received from whitelisted peers even when not relaying transactions. Defaults to { DefaultWhiteListRelay }.");
-            builder.AppendLine($"-acceptnonstdtxn=<0 or 1> Accept non-standard transactions. Default {(!(network.IsTest())?1:0)}.");
-            builder.AppendLine($"-permitbaremultisig=<0 or 1> Relay non-P2SH multisig. Defaults to { MempoolValidator.DefaultPermitBareMultisig }.");
+            builder.AppendLine($"-limitdescendantsize=<kB>      Maximum size in kB of descendants any ancestor can have in mempool (including itself). Defaults to { MempoolValidator.DefaultDescendantSizeLimit }.");
+            builder.AppendLine($"-mempoolreplacement=<0 or 1>   Enable transaction replacement in the memory pool.");
+            builder.AppendLine($"-maxorphantx=<kB>              Maximum number of orphan transactions kept in memory. Defaults to { MempoolOrphans.DefaultMaxOrphanTransactions }.");
+            builder.AppendLine($"-whitelistrelay=<0 or 1>       Enable to accept relayed transactions received from whitelisted peers even when not relaying transactions. Defaults to { DefaultWhiteListRelay }.");
+            builder.AppendLine($"-acceptnonstdtxn=<0 or 1>      Accept non-standard transactions. Default {(!(network.IsTest())?1:0)}.");
+            builder.AppendLine($"-permitbaremultisig=<0 or 1>   Relay non-P2SH multisig. Defaults to { MempoolValidator.DefaultPermitBareMultisig }.");
 
             var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(MempoolSettings).FullName);
             logger.LogInformation(builder.ToString());

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MempoolSettings.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MempoolSettings.cs
@@ -99,7 +99,8 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             builder.AppendLine($"-acceptnonstdtxn=<0 or 1> Accept non-standard transactions. Default {(!(network.IsTest())?1:0)}.");
             builder.AppendLine($"-permitbaremultisig=<0 or 1> Relay non-P2SH multisig. Defaults to { MempoolValidator.DefaultPermitBareMultisig }.");
 
-            NodeSettings.Default(network).Logger.LogInformation(builder.ToString());
+            var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(MempoolSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Miner/MinerSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MinerSettings.cs
@@ -120,7 +120,8 @@ namespace Stratis.Bitcoin.Features.Miner
             builder.AppendLine($"-minimumstakingcoinvalue=<number>   Minimum size of the coins considered for staking, in satoshis. Default value is {MinimumStakingCoinValueDefaultValue:N0} satoshis (= {MinimumStakingCoinValueDefaultValue / (decimal)Money.COIN:N1} Coin).");
             builder.AppendLine($"-minimumsplitcoinvalue=<number>     Targeted minimum value of staking coins after splitting, in satoshis. Default value is {MinimumSplitCoinValueDefaultValue:N0} satoshis (= {MinimumSplitCoinValueDefaultValue / Money.COIN} Coin).");
 
-            defaults.Logger.LogInformation(builder.ToString());
+            var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(MinerSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -155,7 +155,8 @@ namespace Stratis.Bitcoin.Features.RPC
             builder.AppendLine($"-rpcbind=<ip:port>        Bind to given address to listen for JSON-RPC connections. This option can be specified multiple times. Default: bind to all interfaces");
             builder.AppendLine($"-rpcallowip=<ip>          Allow JSON-RPC connections from specified source. This option can be specified multiple times.");
 
-            defaults.Logger.LogInformation(builder.ToString());
+            var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(RpcSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
 
         /// <summary>Obtains a list of HTTP URLs to RPC interfaces.</summary>

--- a/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RpcSettings.cs
@@ -148,12 +148,12 @@ namespace Stratis.Bitcoin.Features.RPC
             NodeSettings defaults = NodeSettings.Default(network);
             var builder = new StringBuilder();
 
-            builder.AppendLine($"-server=<0 or 1>          Accept command line and JSON-RPC commands. Default false.");
-            builder.AppendLine($"-rpcuser=<string>         Username for JSON-RPC connections");
-            builder.AppendLine($"-rpcpassword=<string>     Password for JSON-RPC connections");
-            builder.AppendLine($"-rpcport=<0-65535>        Listen for JSON-RPC connections on <port>. Default: {network.DefaultRPCPort}");
-            builder.AppendLine($"-rpcbind=<ip:port>        Bind to given address to listen for JSON-RPC connections. This option can be specified multiple times. Default: bind to all interfaces");
-            builder.AppendLine($"-rpcallowip=<ip>          Allow JSON-RPC connections from specified source. This option can be specified multiple times.");
+            builder.AppendLine($"-server=<0 or 1>               Accept command line and JSON-RPC commands. Default false.");
+            builder.AppendLine($"-rpcuser=<string>              Username for JSON-RPC connections");
+            builder.AppendLine($"-rpcpassword=<string>          Password for JSON-RPC connections");
+            builder.AppendLine($"-rpcport=<0-65535>             Listen for JSON-RPC connections on <port>. Default: {network.DefaultRPCPort}");
+            builder.AppendLine($"-rpcbind=<ip:port>             Bind to given address to listen for JSON-RPC connections. This option can be specified multiple times. Default: bind to all interfaces");
+            builder.AppendLine($"-rpcallowip=<ip>               Allow JSON-RPC connections from specified source. This option can be specified multiple times.");
 
             var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(RpcSettings).FullName);
             logger.LogInformation(builder.ToString());

--- a/src/Stratis.Bitcoin.Features.SignalR/SignalRSettings.cs
+++ b/src/Stratis.Bitcoin.Features.SignalR/SignalRSettings.cs
@@ -60,7 +60,8 @@ namespace Stratis.Bitcoin.Features.SignalR
             builder.AppendLine($"-signalruri=<string>                  URI to node's SignalR interface. Defaults to '{DefaultSignalRHost}'.");
             builder.AppendLine($"-signalrport=<0-65535>                Port of node's SignalR interface. Defaults to {network.DefaultAPIPort}.");
 
-            NodeSettings.Default(network).Logger.LogInformation(builder.ToString());
+            var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(SignalRSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSettings.cs
@@ -88,7 +88,9 @@ namespace Stratis.Bitcoin.Features.Wallet
             builder.AppendLine("-defaultwalletpassword=<string> Overrides the default wallet password. Default: default.");
             builder.AppendLine("-unlockdefaultwallet=<0 or 1>   Unlocks the specified default wallet. Default: 0.");
             builder.AppendLine("-walletaddressbuffer=<number>   Size of the buffer of unused addresses maintained in an account. Default: 20.");
-            defaults.Logger.LogInformation(builder.ToString());
+
+            var logger = defaults.LoggerFactory.CreateLogger(typeof(WalletSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletSettings.cs
@@ -83,11 +83,11 @@ namespace Stratis.Bitcoin.Features.Wallet
             NodeSettings defaults = NodeSettings.Default(network);
             var builder = new StringBuilder();
 
-            builder.AppendLine("-savetrxhex=<0 or 1>            Save the hex of transactions in the wallet file. Default: 0.");
-            builder.AppendLine("-defaultwalletname=<string>     Loads the specified wallet on startup. If it doesn't exist, it will be created automatically.");
+            builder.AppendLine("-savetrxhex=<0 or 1>           Save the hex of transactions in the wallet file. Default: 0.");
+            builder.AppendLine("-defaultwalletname=<string>    Loads the specified wallet on startup. If it doesn't exist, it will be created automatically.");
             builder.AppendLine("-defaultwalletpassword=<string> Overrides the default wallet password. Default: default.");
-            builder.AppendLine("-unlockdefaultwallet=<0 or 1>   Unlocks the specified default wallet. Default: 0.");
-            builder.AppendLine("-walletaddressbuffer=<number>   Size of the buffer of unused addresses maintained in an account. Default: 20.");
+            builder.AppendLine("-unlockdefaultwallet=<0 or 1>  Unlocks the specified default wallet. Default: 0.");
+            builder.AppendLine("-walletaddressbuffer=<number>  Size of the buffer of unused addresses maintained in an account. Default: 20.");
 
             var logger = defaults.LoggerFactory.CreateLogger(typeof(WalletSettings).FullName);
             logger.LogInformation(builder.ToString());

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -412,20 +412,20 @@ namespace Stratis.Bitcoin.Configuration
             builder.AppendLine();
             builder.AppendLine("Command line arguments:");
             builder.AppendLine();
-            builder.AppendLine($"-help/--help              Show this help.");
-            builder.AppendLine($"-conf=<Path>              Path to the configuration file. Defaults to {defaults.ConfigurationFile}.");
-            builder.AppendLine($"-datadir=<Path>           Path to the data directory. Defaults to {defaults.DataDir}.");
-            builder.AppendLine($"-datadirroot=<Path>       The path to the root data directory, which holds all node data on the machine. Defaults to 'StratisNode'.");
-            builder.AppendLine($"-debug[=<string>]         Set 'Debug' logging level. Specify what to log via e.g. '-debug=Stratis.Bitcoin.Miner,Stratis.Bitcoin.Wallet'.");
-            builder.AppendLine($"-loglevel=<string>        Direct control over the logging level: '-loglevel=trace/debug/info/warn/error/fatal'.");
+            builder.AppendLine($"-help/--help                   Show this help.");
+            builder.AppendLine($"-conf=<Path>                   Path to the configuration file. Defaults to {defaults.ConfigurationFile}.");
+            builder.AppendLine($"-datadir=<Path>                Path to the data directory. Defaults to {defaults.DataDir}.");
+            builder.AppendLine($"-datadirroot=<Path>            The path to the root data directory, which holds all node data on the machine. Defaults to 'StratisNode'.");
+            builder.AppendLine($"-debug[=<string>]              Set 'Debug' logging level. Specify what to log via e.g. '-debug=Stratis.Bitcoin.Miner,Stratis.Bitcoin.Wallet'.");
+            builder.AppendLine($"-loglevel=<string>             Direct control over the logging level: '-loglevel=trace/debug/info/warn/error/fatal'.");
 
             // Can be overridden in configuration file.
-            builder.AppendLine($"-testnet                  Use the testnet chain.");
-            builder.AppendLine($"-regtest                  Use the regtestnet chain.");
-            builder.AppendLine($"-mintxfee=<number>        Minimum fee rate. Defaults to {network.MinTxFee}.");
-            builder.AppendLine($"-fallbackfee=<number>     Fallback fee rate. Defaults to {network.FallbackFee}.");
-            builder.AppendLine($"-minrelaytxfee=<number>   Minimum relay fee rate. Defaults to {network.MinRelayTxFee}.");
-            builder.AppendLine($"-displaybenchstats=<bool> Logs benchmark statistics to the console window (true/false).");
+            builder.AppendLine($"-testnet                       Use the testnet chain.");
+            builder.AppendLine($"-regtest                       Use the regtestnet chain.");
+            builder.AppendLine($"-mintxfee=<number>             Minimum fee rate. Defaults to {network.MinTxFee}.");
+            builder.AppendLine($"-fallbackfee=<number>          Fallback fee rate. Defaults to {network.FallbackFee}.");
+            builder.AppendLine($"-minrelaytxfee=<number>        Minimum relay fee rate. Defaults to {network.MinRelayTxFee}.");
+            builder.AppendLine($"-displaybenchstats=<bool>      Logs benchmark statistics to the console window (true/false).");
 
             defaults.Logger.LogInformation(builder.ToString());
 

--- a/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/NodeSettings.cs
@@ -43,15 +43,16 @@ namespace Stratis.Bitcoin.Configuration
         /// <summary>The version of the protocol supported by the current implementation of the Full Node.</summary>
         public const ProtocolVersion SupportedProtocolVersion = ProtocolVersion.SENDHEADERS_VERSION;
 
-        /// <summary>A factory responsible for creating a Full Node logger instance.</summary>
         private static ILoggerFactory loggerFactory;
 
-        public ILoggerFactory LoggerFactory {
+        /// <summary>A factory responsible for creating a Full Node logger instance.</summary>
+        public ILoggerFactory LoggerFactory
+        { 
             get
             {
                 if (loggerFactory == null)
                 {
-                    var logSettings = new LogSettings();
+                    logSettings = new LogSettings();
                     logSettings.Load(this.ConfigReader);
                     loggerFactory = ExtendedLoggerFactory.Create(logSettings, this.DataFolder);
 
@@ -61,18 +62,15 @@ namespace Stratis.Bitcoin.Configuration
 
                 return loggerFactory;
             }
-
-            private set
-            {
-                loggerFactory = value;
-            }
         }
 
         /// <summary>An instance of the Full Node logger, which reports on the Full Node's activity.</summary>
         public ILogger Logger { get; private set; }
 
+        private static LogSettings logSettings;
+
         /// <summary>The settings of the Full Node's logger.</summary>
-        public LogSettings LogSettings { get; private set; }
+        public LogSettings LogSettings => logSettings;
 
         /// <summary>A list of paths to folders which Full Node components use to store data. These folders are found
         /// in the <see cref="DataDir"/>.

--- a/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
@@ -254,22 +254,22 @@ namespace Stratis.Bitcoin.Configuration.Settings
             var defaults = NodeSettings.Default(network: network);
 
             var builder = new StringBuilder();
-            builder.AppendLine($"-port=<port>              The default network port to connect to. Default { network.DefaultPort }.");
-            builder.AppendLine($"-listen=<0 or 1>          Accept connections from the outside (defaulted to 1 unless -connect args specified).");
-            builder.AppendLine($"-connect=<ip:port>        Specified node to connect to. Can be specified multiple times.");
-            builder.AppendLine($"-addnode=<ip:port>        Add a node to connect to and attempt to keep the connection open. Can be specified multiple times.");
-            builder.AppendLine($"-bind=<ip:port>           Bind to given address. Use [host]:port notation for IPv6. Can be specified multiple times.");
-            builder.AppendLine($"-whitebind=<ip:port>      Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6. Can be specified multiple times.");
-            builder.AppendLine($"-whitelist=<ip:port>      Whitelist peers having the given IP:port address, both inbound or outbound. Can be specified multiple times.");
-            builder.AppendLine($"-externalip=<ip>          Specify your own public address.");
-            builder.AppendLine($"-bantime=<number>         Number of seconds to keep misbehaving peers from reconnecting. Default {network.DefaultBanTimeSeconds}.");
+            builder.AppendLine($"-port=<port>                   The default network port to connect to. Default { network.DefaultPort }.");
+            builder.AppendLine($"-listen=<0 or 1>               Accept connections from the outside (defaulted to 1 unless -connect args specified).");
+            builder.AppendLine($"-connect=<ip:port>             Specified node to connect to. Can be specified multiple times.");
+            builder.AppendLine($"-addnode=<ip:port>             Add a node to connect to and attempt to keep the connection open. Can be specified multiple times.");
+            builder.AppendLine($"-bind=<ip:port>                Bind to given address. Use [host]:port notation for IPv6. Can be specified multiple times.");
+            builder.AppendLine($"-whitebind=<ip:port>           Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6. Can be specified multiple times.");
+            builder.AppendLine($"-whitelist=<ip:port>           Whitelist peers having the given IP:port address, both inbound or outbound. Can be specified multiple times.");
+            builder.AppendLine($"-externalip=<ip>               Specify your own public address.");
+            builder.AppendLine($"-bantime=<number>              Number of seconds to keep misbehaving peers from reconnecting. Default {network.DefaultBanTimeSeconds}.");
             builder.AppendLine($"-maxoutboundconnections=<number> The maximum number of outbound connections. Default {network.DefaultMaxOutboundConnections}.");
             builder.AppendLine($"-maxinboundconnections=<number> The maximum number of inbound connections. Default {network.DefaultMaxInboundConnections}.");
             builder.AppendLine($"-initialconnectiontarget=<number> The number of connections to be reached before a 1 second connection interval (initally 100ms). Default 1.");
-            builder.AppendLine($"-synctime=<0 or 1>        Sync with peers. Default 1.");
-            builder.AppendLine($"-agentprefix=<string>     An optional prefix for the node's user agent that will be shared with peers in the version handshake.");
-            builder.AppendLine($"-blocksonly=<0 or 1>      Enable bandwidth saving setting to send and received confirmed blocks only. Defaults to { DefaultBlocksOnly }.");
-            builder.AppendLine($"-iprangefiltering=<0 or 1> Disallow connection to peers in same IP range. Default is 1 for remote hosts.");
+            builder.AppendLine($"-synctime=<0 or 1>             Sync with peers. Default 1.");
+            builder.AppendLine($"-agentprefix=<string>          An optional prefix for the node's user agent that will be shared with peers in the version handshake.");
+            builder.AppendLine($"-blocksonly=<0 or 1>           Enable bandwidth saving setting to send and received confirmed blocks only. Defaults to { DefaultBlocksOnly }.");
+            builder.AppendLine($"-iprangefiltering=<0 or 1>     Disallow connection to peers in same IP range. Default is 1 for remote hosts.");
 
             var logger = defaults.LoggerFactory.CreateLogger(typeof(ConnectionManagerSettings).FullName);
             logger.LogInformation(builder.ToString());

--- a/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/Settings/ConnectionManagerSettings.cs
@@ -271,7 +271,8 @@ namespace Stratis.Bitcoin.Configuration.Settings
             builder.AppendLine($"-blocksonly=<0 or 1>      Enable bandwidth saving setting to send and received confirmed blocks only. Defaults to { DefaultBlocksOnly }.");
             builder.AppendLine($"-iprangefiltering=<0 or 1> Disallow connection to peers in same IP range. Default is 1 for remote hosts.");
 
-            defaults.Logger.LogInformation(builder.ToString());
+            var logger = defaults.LoggerFactory.CreateLogger(typeof(ConnectionManagerSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
 
         /// <summary>List of exclusive end points that the node should be connected to.</summary>

--- a/src/Stratis.Bitcoin/Configuration/Settings/ConsensusSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/Settings/ConsensusSettings.cs
@@ -81,7 +81,8 @@ namespace Stratis.Bitcoin.Configuration.Settings
             builder.AppendLine($"-dbcache=<number>                  Max cache memory for the coindb in MB. Default 200 (this does not include the size of objects in memory).");
             builder.AppendLine($"-dbflush=<number>                  How often to flush the cache to disk when in IBD in minutes. Default 10 min (min=1min, max=60min).");
 
-            NodeSettings.Default(network).Logger.LogInformation(builder.ToString());
+            var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(ConsensusSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin/Configuration/Settings/ConsensusSettings.cs
+++ b/src/Stratis.Bitcoin/Configuration/Settings/ConsensusSettings.cs
@@ -74,12 +74,12 @@ namespace Stratis.Bitcoin.Configuration.Settings
 
             var builder = new StringBuilder();
 
-            builder.AppendLine($"-checkpoints=<0 or 1>              Use checkpoints. Default 1.");
-            builder.AppendLine($"-assumevalid=<hex>                 If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all). Defaults to { network.Consensus.DefaultAssumeValid }.");
-            builder.AppendLine($"-maxtipage=<number>                Max tip age. Default {network.MaxTipAge}.");
-            builder.AppendLine($"-maxblkmem=<number>                Max memory to use for unconsumed blocks in MB. Default 200 (this does not include the size of objects in memory).");
-            builder.AppendLine($"-dbcache=<number>                  Max cache memory for the coindb in MB. Default 200 (this does not include the size of objects in memory).");
-            builder.AppendLine($"-dbflush=<number>                  How often to flush the cache to disk when in IBD in minutes. Default 10 min (min=1min, max=60min).");
+            builder.AppendLine($"-checkpoints=<0 or 1>          Use checkpoints. Default 1.");
+            builder.AppendLine($"-assumevalid=<hex>             If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all). Defaults to { network.Consensus.DefaultAssumeValid }.");
+            builder.AppendLine($"-maxtipage=<number>            Max tip age. Default {network.MaxTipAge}.");
+            builder.AppendLine($"-maxblkmem=<number>            Max memory to use for unconsumed blocks in MB. Default 200 (this does not include the size of objects in memory).");
+            builder.AppendLine($"-dbcache=<number>              Max cache memory for the coindb in MB. Default 200 (this does not include the size of objects in memory).");
+            builder.AppendLine($"-dbflush=<number>              How often to flush the cache to disk when in IBD in minutes. Default 10 min (min=1min, max=60min).");
 
             var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(ConsensusSettings).FullName);
             logger.LogInformation(builder.ToString());

--- a/src/Stratis.Features.Diagnostic/DiagnosticSettings.cs
+++ b/src/Stratis.Features.Diagnostic/DiagnosticSettings.cs
@@ -59,12 +59,12 @@ namespace Stratis.Features.Diagnostic
         {
             var builder = new StringBuilder();
 
-            builder.AppendLine($"**DIAGNOSTIC SETTINGS**");
             builder.AppendLine($"-diagpeerstats=<bool>             Start the diagnostic peer statistics collector. Defaults to {DefaultPeersStatisticsCollectorEnabled}.");
             builder.AppendLine($"-diagpeerstatsmaxlog=<number>     Maximum number of logged peer events stored during the diagnostic peer statistics collector. Defaults to {DefaultMaxPeerLoggedEvents}.");
             builder.AppendLine($"**END OF DIAGNOSTIC SETTINGS**");
 
-            NodeSettings.Default(network).Logger.LogInformation(builder.ToString());
+            var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(DiagnosticSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
     }
 }

--- a/src/Stratis.Features.Unity3dApi/Unity3dApiSettings.cs
+++ b/src/Stratis.Features.Unity3dApi/Unity3dApiSettings.cs
@@ -117,7 +117,8 @@ namespace Stratis.Features.Unity3dApi
             builder.AppendLine($"-unityapi_usehttps=<bool>                  Use https protocol on the API. Defaults to false.");
             builder.AppendLine($"-unityapi_certificatefilepath=<string>     Path to the certificate used for https traffic encryption. Defaults to <null>. Password protected files are not supported. On MacOs, only p12 certificates can be used without password.");
 
-            NodeSettings.Default(network).Logger.LogInformation(builder.ToString());
+            var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(Unity3dApiSettings).FullName);
+            logger.LogInformation(builder.ToString());
         }
 
         /// <summary>


### PR DESCRIPTION
After this PR:

- No duplicate help messages
- Help is aligned
- Sections are named appropriately.

```
[info]  Stratis.Bitcoin.Configuration.NodeSettings
        Usage:
         dotnet run Stratis.CirrusMinerD.dll [arguments]

        Command line arguments:

        -help/--help                   Show this help.
        -conf=<Path>                   Path to the configuration file. Defaults to C:\Users\Gustav\AppData\Roaming\StratisNode\cirrus\CirrusMain\cirrus.conf.
        -datadir=<Path>                Path to the data directory. Defaults to C:\Users\Gustav\AppData\Roaming\StratisNode\cirrus\CirrusMain.
        -datadirroot=<Path>            The path to the root data directory, which holds all node data on the machine. Defaults to 'StratisNode'.
        -debug[=<string>]              Set 'Debug' logging level. Specify what to log via e.g. '-debug=Stratis.Bitcoin.Miner,Stratis.Bitcoin.Wallet'.
        -loglevel=<string>             Direct control over the logging level: '-loglevel=trace/debug/info/warn/error/fatal'.
        -testnet                       Use the testnet chain.
        -regtest                       Use the regtestnet chain.
        -mintxfee=<number>             Minimum fee rate. Defaults to 10000.
        -fallbackfee=<number>          Fallback fee rate. Defaults to 10000.
        -minrelaytxfee=<number>        Minimum relay fee rate. Defaults to 10000.
        -displaybenchstats=<bool>      Logs benchmark statistics to the console window (true/false).

[info]  Stratis.Bitcoin.Configuration.Settings.ConnectionManagerSettings
        -port=<port>                   The default network port to connect to. Default 16179.
        -listen=<0 or 1>               Accept connections from the outside (defaulted to 1 unless -connect args specified).
        -connect=<ip:port>             Specified node to connect to. Can be specified multiple times.
        -addnode=<ip:port>             Add a node to connect to and attempt to keep the connection open. Can be specified multiple times.
        -bind=<ip:port>                Bind to given address. Use [host]:port notation for IPv6. Can be specified multiple times.
        -whitebind=<ip:port>           Bind to given address and whitelist peers connecting to it. Use [host]:port notation for IPv6. Can be specified multiple times.
        -whitelist=<ip:port>           Whitelist peers having the given IP:port address, both inbound or outbound. Can be specified multiple times.
        -externalip=<ip>               Specify your own public address.
        -bantime=<number>              Number of seconds to keep misbehaving peers from reconnecting. Default 1920.
        -maxoutboundconnections=<number> The maximum number of outbound connections. Default 16.
        -maxinboundconnections=<number> The maximum number of inbound connections. Default 109.
        -initialconnectiontarget=<number> The number of connections to be reached before a 1 second connection interval (initally 100ms). Default 1.
        -synctime=<0 or 1>             Sync with peers. Default 1.
        -agentprefix=<string>          An optional prefix for the node's user agent that will be shared with peers in the version handshake.
        -blocksonly=<0 or 1>           Enable bandwidth saving setting to send and received confirmed blocks only. Defaults to False.
        -iprangefiltering=<0 or 1>     Disallow connection to peers in same IP range. Default is 1 for remote hosts.

[info]  Stratis.Bitcoin.Features.BlockStore.StoreSettings
        -prune=<amount of blocks>      Enable pruning to reduce storage requirements by enabling deleting of old blocks. Value of 0 means pruning is disabled.
        -maxblkstoremem=<number>       Max memory to use before flushing blocks to disk in MB. Default is 5 MB.
        -txindex=<0 or 1>              Enable to maintain a full transaction index.
        -reindex=<0 or 1>              Rebuild store with tx index from block data files on disk.
        -reindex-chain=<0 or 1>        Rebuild the coindb from block data files on disk.
        -addressindex=<0 or 1>         Enable to maintain a full address index.
        -compactionthreshold=<integer value>         Specify address indexer compaction threshold.

[info]  Stratis.Bitcoin.Configuration.Settings.ConsensusSettings
        -checkpoints=<0 or 1>          Use checkpoints. Default 1.
        -assumevalid=<hex>             If this block is in the chain assume that it and its ancestors are valid and potentially skip their script verification (0 to verify all). Defaults to bfd4a96a6c5250f18bf7c586761256fa5f8753ffa10b24160f0648a452823a95.
        -maxtipage=<number>            Max tip age. Default 768.
        -maxblkmem=<number>            Max memory to use for unconsumed blocks in MB. Default 200 (this does not include the size of objects in memory).
        -dbcache=<number>              Max cache memory for the coindb in MB. Default 200 (this does not include the size of objects in memory).
        -dbflush=<number>              How often to flush the cache to disk when in IBD in minutes. Default 10 min (min=1min, max=60min).

[info]  Stratis.Bitcoin.Features.Api.ApiSettings
        -apiuri=<string>               URI to node's API interface. Defaults to 'http://localhost'.
        -apiport=<0-65535>             Port of node's API interface. Defaults to 37223.
        -keepalive=<seconds>           Keep Alive interval (set in seconds). Default: 0 (no keep alive).
        -usehttps=<bool>               Use https protocol on the API. Defaults to false.
        -certificatefilepath=<string>  Path to the certificate used for https traffic encryption. Defaults to <null>. Password protected files are not supported. On MacOs, only p12 certificates can be used without password.

[info]  Stratis.Bitcoin.Features.MemoryPool.MempoolSettings
        -maxmempool=<megabytes>        Maximal size of the transaction memory pool in megabytes. Defaults to 300.
        -mempoolexpiry=<hours>         Maximum number of hours to keep transactions in the mempool. Defaults to 336.
        -relaypriority=<0 or 1>        Enable high priority for relaying free or low-fee transactions.
        -limitancestorcount=<count>    Maximum number of ancestors of a transaction in mempool (including itself). Defaults to 25.
        -limitancestorsize=<kB>        Maximal size in kB of ancestors of a transaction in mempool (including itself). Defaults to 101.
        -limitdescendantcount=<count>  Maximum number of descendants any ancestor can have in mempool (including itself). Defaults to 25.
        -limitdescendantsize=<kB>      Maximum size in kB of descendants any ancestor can have in mempool (including itself). Defaults to 101.
        -mempoolreplacement=<0 or 1>   Enable transaction replacement in the memory pool.
        -maxorphantx=<kB>              Maximum number of orphan transactions kept in memory. Defaults to 100.
        -whitelistrelay=<0 or 1>       Enable to accept relayed transactions received from whitelisted peers even when not relaying transactions. Defaults to True.
        -acceptnonstdtxn=<0 or 1>      Accept non-standard transactions. Default 1.
        -permitbaremultisig=<0 or 1>   Relay non-P2SH multisig. Defaults to True.

[info]  Stratis.Bitcoin.Features.RPC.RpcSettings
        -server=<0 or 1>               Accept command line and JSON-RPC commands. Default false.
        -rpcuser=<string>              Username for JSON-RPC connections
        -rpcpassword=<string>          Password for JSON-RPC connections
        -rpcport=<0-65535>             Listen for JSON-RPC connections on <port>. Default: 16175
        -rpcbind=<ip:port>             Bind to given address to listen for JSON-RPC connections. This option can be specified multiple times. Default: bind to all interfaces
        -rpcallowip=<ip>               Allow JSON-RPC connections from specified source. This option can be specified multiple times.

[info]  Stratis.Bitcoin.Features.Wallet.WalletSettings
        -savetrxhex=<0 or 1>           Save the hex of transactions in the wallet file. Default: 0.
        -defaultwalletname=<string>    Loads the specified wallet on startup. If it doesn't exist, it will be created automatically.
        -defaultwalletpassword=<string> Overrides the default wallet password. Default: default.
        -unlockdefaultwallet=<0 or 1>  Unlocks the specified default wallet. Default: 0.
        -walletaddressbuffer=<number>  Size of the buffer of unused addresses maintained in an account. Default: 20.
```