### PR TITLE
Add GetBlocks and CommonBlock APIs for chain synchronisation

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreControllerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/BlockStoreControllerTests.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Net;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
@@ -169,6 +171,34 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             int result = int.Parse(json.Value.ToString());
 
             Assert.Equal(2, result);
+        }
+
+        [Fact]
+        public void Get_Blocks_Should_Return_Blocks()
+        {
+            var logger = new Mock<ILoggerFactory>();
+            var store = new Mock<IBlockStore>();
+            var chainState = new Mock<IChainState>();
+            var addressIndexer = new Mock<IAddressIndexer>();
+            var utxoIndexer = new Mock<IUtxoIndexer>();
+            var scriptAddressReader = Mock.Of<IScriptAddressReader>();
+
+            ChainIndexer chainIndexer = WalletTestsHelpers.GenerateChainWithHeight(3, new StraxTest());
+
+            logger.Setup(l => l.CreateLogger(It.IsAny<string>())).Returns(Mock.Of<ILogger>);
+
+            chainState.Setup(c => c.ConsensusTip)
+                .Returns(chainIndexer.GetHeader(2));
+
+            store.Setup(s => s.GetBlocks(It.IsAny<List<uint256>>())).Returns((List<uint256> hashes) => hashes.Select(h => chainIndexer[h].Block).ToList());
+
+            var controller = new BlockStoreController(new StraxMain(), logger.Object, store.Object, chainState.Object, chainIndexer, addressIndexer.Object, utxoIndexer.Object, scriptAddressReader);
+
+            var json = (JsonResult)controller.GetBlocks(new SearchByHeightRequest() { Height = 2, NumberOfBlocks = 2 });
+            var jsonResult = Assert.IsType<List<Block>>(json.Value);
+
+            Assert.Equal(2, jsonResult.Count);
+
         }
 
         private static (Mock<IBlockStore> store, BlockStoreController controller) GetControllerAndStore()

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
@@ -189,7 +189,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
                     tip = this.chainIndexer.Tip.Height;
                 }
 
-                List<ChainedHeader> chainedHeaders = this.chainIndexer.Tip.EnumerateToGenesis().Take(query.NumberOfBlocks).Reverse().ToList();
+                List<ChainedHeader> chainedHeaders = this.chainIndexer[tip].EnumerateToGenesis().Take(query.NumberOfBlocks).Reverse().ToList();
                 List<uint256> blockIds = chainedHeaders.Select(h => h.HashBlock).ToList();
                 List<Block> blocks = this.blockStore.GetBlocks(blockIds);
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
@@ -25,6 +25,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         public const string GetVerboseAddressesBalances = "getverboseaddressesbalances";
         public const string GetAddressIndexerTip = "addressindexertip";
         public const string GetBlock = "block";
+        public const string GetBlocks = "blocks";
         public const string GetBlockCount = "getblockcount";
         public const string GetUtxoSet = "getutxoset";
         public const string GetUtxoSetForAddress = "getutxosetforaddress";
@@ -149,35 +150,88 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
                     return this.Json(block);
                 }
 
-                BlockModel blockModel = query.ShowTransactionDetails
-                    ? new BlockTransactionDetailsModel(block, chainedHeader, this.chainIndexer.Tip, this.network)
-                    : new BlockModel(block, chainedHeader, this.chainIndexer.Tip, this.network);
-
-                if (this.network.Consensus.IsProofOfStake)
-                {
-                    var posBlock = block as PosBlock;
-
-                    blockModel.PosBlockSignature = posBlock.BlockSignature.ToHex(this.network);
-                    blockModel.PosBlockTrust = new Target(chainedHeader.GetBlockTarget()).ToUInt256().ToString();
-                    blockModel.PosChainTrust = chainedHeader.ChainWork.ToString(); // this should be similar to ChainWork
-
-                    if (this.stakeChain != null)
-                    {
-                        BlockStake blockStake = this.stakeChain.Get(blockId);
-
-                        blockModel.PosModifierv2 = blockStake?.StakeModifierV2.ToString();
-                        blockModel.PosFlags = blockStake?.Flags == BlockFlag.BLOCK_PROOF_OF_STAKE ? "proof-of-stake" : "proof-of-work";
-                        blockModel.PosHashProof = blockStake?.HashProof?.ToString();
-                    }
-                }
-
-                return this.Json(blockModel);
+                return this.Json(GetBlockModel(block, blockId, chainedHeader, query.ShowTransactionDetails));
             }
             catch (Exception e)
             {
                 this.logger.LogError("Exception occurred: {0}", e.ToString());
                 return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
             }
+        }
+
+
+        /// <summary>
+        /// Retrieves the blocks from a given height onwards.
+        /// </summary>
+        /// <param name="query">An object containing the necessary parameters to search for a block.</param>
+        /// <returns><see cref="BlockModel"/> if block is found, <see cref="NotFoundObjectResult"/> if not found. Returns <see cref="IActionResult"/> with error information if exception thrown.</returns>
+        /// <response code="200">Returns data about the block or block not found message</response>
+        /// <response code="400">Block hash invalid, or an unexpected exception occurred</response>
+        [Route(BlockStoreRouteEndPoint.GetBlocks)]
+        [HttpGet]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType((int)HttpStatusCode.NotFound)]
+        public IActionResult GetBlocks([FromQuery] SearchByHeightRequest query)
+        {
+            if (!this.ModelState.IsValid)
+                return ModelStateErrors.BuildErrorResponse(this.ModelState);
+
+            try
+            {
+                if (query.Height > this.chainIndexer.Tip.Height)
+                    return this.NotFound("No blocks found");
+
+                int tip = query.Height + query.NumberOfBlocks - 1;
+                if (tip > this.chainIndexer.Tip.Height)
+                {
+                    query.NumberOfBlocks -= (this.chainIndexer.Tip.Height - tip);
+                    tip = this.chainIndexer.Tip.Height;
+                }
+
+                List<ChainedHeader> chainedHeaders = this.chainIndexer.Tip.EnumerateToGenesis().Take(query.NumberOfBlocks).Reverse().ToList();
+                List<uint256> blockIds = chainedHeaders.Select(h => h.HashBlock).ToList();
+                List<Block> blocks = this.blockStore.GetBlocks(blockIds);
+
+                if (!query.OutputJson)
+                {
+                    return this.Json(blocks);
+                }
+
+                return this.Json(chainedHeaders.Select((h, n) => GetBlockModel(blocks[n], blockIds[n], h, query.ShowTransactionDetails)));
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        private BlockModel GetBlockModel(Block block, uint256 blockId, ChainedHeader chainedHeader, bool showTransactionDetails)
+        {
+            BlockModel blockModel = showTransactionDetails
+                ? new BlockTransactionDetailsModel(block, chainedHeader, this.chainIndexer.Tip, this.network)
+                : new BlockModel(block, chainedHeader, this.chainIndexer.Tip, this.network);
+
+            if (this.network.Consensus.IsProofOfStake)
+            {
+                var posBlock = block as PosBlock;
+
+                blockModel.PosBlockSignature = posBlock.BlockSignature.ToHex(this.network);
+                blockModel.PosBlockTrust = new Target(chainedHeader.GetBlockTarget()).ToUInt256().ToString();
+                blockModel.PosChainTrust = chainedHeader.ChainWork.ToString(); // this should be similar to ChainWork
+
+                if (this.stakeChain != null)
+                {
+                    BlockStake blockStake = this.stakeChain.Get(blockId);
+
+                    blockModel.PosModifierv2 = blockStake?.StakeModifierV2.ToString();
+                    blockModel.PosFlags = blockStake?.Flags == BlockFlag.BLOCK_PROOF_OF_STAKE ? "proof-of-stake" : "proof-of-work";
+                    blockModel.PosHashProof = blockStake?.HashProof?.ToString();
+                }
+            }
+
+            return blockModel;
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.BlockStore/Models/SearchByHeightRequest.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Models/SearchByHeightRequest.cs
@@ -1,0 +1,29 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Stratis.Bitcoin.Features.BlockStore.Models
+{
+    /// <summary>
+    /// A class containing the necessary parameters for a block search request.
+    /// </summary>
+    public class SearchByHeightRequest : RequestBase
+    {
+        /// <summary>
+        /// The height of the required block(s).
+        /// </summary>
+        [Required]
+        public int Height { get; set; }
+
+        /// <summary>
+        /// The maximum number of the blocks to return.
+        /// </summary>
+        [Required]
+        public int NumberOfBlocks { get; set; }
+
+        /// <summary>
+        /// A flag that indicates whether to return each block transaction complete with details
+        /// or simply return transaction hashes (TX IDs).
+        /// </summary>
+        /// <remarks>This flag is not used when <see cref="RequestBase.OutputJson"/> is set to false.</remarks>
+        public bool ShowTransactionDetails { get; set; }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusController.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusController.cs
@@ -56,7 +56,7 @@ namespace Stratis.Bitcoin.Features.Consensus
         /// <param name="blockLocator">The list of provided hashes.</param>
         /// <returns>A <see cref="JsonResult"/> derived from a <see cref="HashHeightPair"/> object.</returns>
         [Route("api/[controller]/commonblock")]
-        [HttpGet]
+        [HttpPost]
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
         public IActionResult CommonBlock([FromBody] uint256[] blockLocator)

--- a/src/Stratis.Bitcoin.Features.Consensus/ConsensusController.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/ConsensusController.cs
@@ -51,6 +51,32 @@ namespace Stratis.Bitcoin.Features.Consensus
         }
 
         /// <summary>
+        /// Finds the first block in common with the list of provided hashes. Include the genesis hash.
+        /// </summary>
+        /// <param name="blockLocator">The list of provided hashes.</param>
+        /// <returns>A <see cref="JsonResult"/> derived from a <see cref="HashHeightPair"/> object.</returns>
+        [Route("api/[controller]/commonblock")]
+        [HttpGet]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        public IActionResult CommonBlock([FromBody] uint256[] blockLocator)
+        {
+            try
+            {
+                ChainedHeader commonHeader = this.ChainIndexer.FindFork(blockLocator);
+                if (commonHeader == null)
+                    throw new BlockNotFoundException($"No common block found");
+
+                return this.Json(new HashHeightPair(commonHeader));
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>
         /// Get the threshold states of softforks currently being deployed.
         /// Allowable states are: Defined, Started, LockedIn, Failed, Active.
         /// </summary>

--- a/src/Stratis.Bitcoin.IntegrationTests/RPC/ConsensusActionTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/RPC/ConsensusActionTests.cs
@@ -5,6 +5,9 @@ using Stratis.Bitcoin.Interfaces;
 using Xunit;
 using Stratis.Bitcoin.Base;
 using Stratis.Bitcoin.Tests.Common;
+using Microsoft.AspNetCore.Mvc;
+using Stratis.Bitcoin.Utilities.JsonErrors;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.IntegrationTests.RPC
 {
@@ -48,6 +51,26 @@ namespace Stratis.Bitcoin.IntegrationTests.RPC
 
             Assert.NotNull(isIBDProvider);
             Assert.True(isIBDProvider.IsInitialBlockDownload());
+        }
+
+        [Fact]
+        public void CanCall_CommonBlock()
+        {
+            string dir = CreateTestDir(this);
+
+            IFullNode fullNode = this.BuildServicedNode(dir);
+            var controller = fullNode.NodeController<ConsensusController>();
+
+            IActionResult result = controller.CommonBlock(new[] { uint256.Zero, fullNode.Network.GenesisHash, uint256.One });
+
+            Assert.NotNull(result);
+
+            var jsonResult = Assert.IsType<JsonResult>(result);
+
+            var hashHeightPair = Assert.IsType<HashHeightPair>(jsonResult.Value);
+
+            Assert.Equal(hashHeightPair.Height, 0);
+            Assert.Equal(hashHeightPair.Hash, fullNode.Network.GenesisHash);
         }
     }
 }


### PR DESCRIPTION
Synchronising the blockchain remotely (via API) is currently slow when using `GetBlock` to request one block at a time (based on block hash). Apart from that it requires other per-block API requests, for converting heights to hashes, re-org hash checks, tip checks etc. Two APIs are added to speed up the process:
- `GetBlocks`. Gets a number of blocks from a given height.
- `CommonBlock`. Finds the first local hash when provided with a list of block hashes.

Mostly **only** `GetBlocks` would need to be called. However if blocks received via `GetBlocks` do not match already downloaded blocks on `PrevBlockHash` then build a "block locator" from the local blocks and send that to `CommonBlock`  to determine the last common blocks between node chain and block locator. Then simply rewind local work and continue from there. `CommonBlock` can be called multiple times to achieve more accurate rewinds if desired.