### PR TITLE
Relax collateral re-use check

### DIFF
--- a/src/Stratis.Features.Collateral/ConsensusRules/VotingRequestFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/ConsensusRules/VotingRequestFullValidationRule.cs
@@ -80,7 +80,7 @@ namespace Stratis.Features.Collateral.ConsensusRules
                 Script script = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(request.CollateralMainchainAddress);
                 string collateralAddress = script.GetDestinationAddress(this.counterChainNetwork).ToString();
                 CollateralFederationMember owner = this.federationManager.CollateralAddressOwner(this.votingManager, VoteKey.AddFederationMember, collateralAddress);
-                if (owner != null)
+                if (owner != null && owner.PubKey != request.PubKey)
                 {
                     this.Logger.LogTrace("(-)[INVALID_COLLATERAL_REUSE]");
                     PoAConsensusErrors.VotingRequestInvalidCollateralReuse.Throw();


### PR DESCRIPTION
The purpose of the `CollateralAddressOwner` method is to determine, from polls and scheduled votes, which is the latest public key associated with a collateral address. However it is used in a way that suggests that the mere existence of ANY owner implies a conflict or re-use situation. This is not true. As long as the owner matches the latest owner being established there is no conflict.