### PR TITLE
Descriptive message when awaiting collateral maturation

### DIFF
--- a/src/FederationSetup/FederationSetup.csproj
+++ b/src/FederationSetup/FederationSetup.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>    
   </PropertyGroup>
 

--- a/src/FodyNlogAdapter/FodyNlogAdapter.csproj
+++ b/src/FodyNlogAdapter/FodyNlogAdapter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>FodyNlogAdapter</AssemblyName>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
     <PackageId>Stratis.Utils.FodyNlogAdapter</PackageId>

--- a/src/Stratis.Bitcoin.Cli/Stratis.Bitcoin.Cli.csproj
+++ b/src/Stratis.Bitcoin.Cli/Stratis.Bitcoin.Cli.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
     <Company>Stratis Group Ltd.</Company>
     <Product />

--- a/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
+++ b/src/Stratis.Bitcoin.Features.Api/Stratis.Bitcoin.Features.Api.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>Stratis.Bitcoin.Features.Api</AssemblyName>
     <OutputType>Library</OutputType>
     <PackageId>Stratis.Features.Api</PackageId>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>

--- a/src/Stratis.Bitcoin.Features.BlockStore/Stratis.Bitcoin.Features.BlockStore.csproj
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Stratis.Bitcoin.Features.BlockStore.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.ColdStaking/Stratis.Bitcoin.Features.ColdStaking.csproj
+++ b/src/Stratis.Bitcoin.Features.ColdStaking/Stratis.Bitcoin.Features.ColdStaking.csproj
@@ -7,7 +7,7 @@
 		<GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
 		<GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
 		<GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-		<Version>1.3.1.0</Version>
+		<Version>1.3.2.0</Version>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 		<Authors>Stratis Group Ltd.</Authors>
 	</PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.Consensus/Stratis.Bitcoin.Features.Consensus.csproj
+++ b/src/Stratis.Bitcoin.Features.Consensus/Stratis.Bitcoin.Features.Consensus.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.Dns/Stratis.Bitcoin.Features.Dns.csproj
+++ b/src/Stratis.Bitcoin.Features.Dns/Stratis.Bitcoin.Features.Dns.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.ExternalAPI/Stratis.Bitcoin.Features.ExternalApi.csproj
+++ b/src/Stratis.Bitcoin.Features.ExternalAPI/Stratis.Bitcoin.Features.ExternalApi.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>    
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
     <PackageId>Stratis.Features.ExternalAPI</PackageId>
     <Product>Stratis.Features.ExternalAPI</Product>

--- a/src/Stratis.Bitcoin.Features.Interop/Stratis.Bitcoin.Features.Interop.csproj
+++ b/src/Stratis.Bitcoin.Features.Interop/Stratis.Bitcoin.Features.Interop.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>    
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
     <PackageId>Stratis.Features.Interop</PackageId>
     <Product>Stratis.Features.Interop</Product>

--- a/src/Stratis.Bitcoin.Features.LightWallet/Stratis.Bitcoin.Features.LightWallet.csproj
+++ b/src/Stratis.Bitcoin.Features.LightWallet/Stratis.Bitcoin.Features.LightWallet.csproj
@@ -7,7 +7,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.MemoryPool/Stratis.Bitcoin.Features.MemoryPool.csproj
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/Stratis.Bitcoin.Features.MemoryPool.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <OutputTypeEx>library</OutputTypeEx>
     <Authors>Stratis Group Ltd.</Authors>

--- a/src/Stratis.Bitcoin.Features.Miner/Stratis.Bitcoin.Features.Miner.csproj
+++ b/src/Stratis.Bitcoin.Features.Miner/Stratis.Bitcoin.Features.Miner.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.Notifications/Stratis.Bitcoin.Features.Notifications.csproj
+++ b/src/Stratis.Bitcoin.Features.Notifications/Stratis.Bitcoin.Features.Notifications.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common.csproj
+++ b/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common.csproj
@@ -13,7 +13,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Product />
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.PoA/Stratis.Bitcoin.Features.PoA.csproj
+++ b/src/Stratis.Bitcoin.Features.PoA/Stratis.Bitcoin.Features.PoA.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.RPC/Stratis.Bitcoin.Features.RPC.csproj
+++ b/src/Stratis.Bitcoin.Features.RPC/Stratis.Bitcoin.Features.RPC.csproj
@@ -14,7 +14,7 @@
 		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
 		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
 		<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-		<Version>1.3.1.0</Version>
+		<Version>1.3.2.0</Version>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 		<Authors>Stratis Group Ltd.</Authors>
 	</PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.SignalR/Stratis.Bitcoin.Features.SignalR.csproj
+++ b/src/Stratis.Bitcoin.Features.SignalR/Stratis.Bitcoin.Features.SignalR.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<TargetFramework>netcoreapp3.1</TargetFramework>
-		<Version>1.3.1.0</Version>
+		<Version>1.3.2.0</Version>
 		<PackageId>Stratis.Features.SignalR</PackageId>
 		<Product>Stratis.Features.SignalR</Product>
 		<Authors>Stratis Group Ltd.</Authors>

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Stratis.Bitcoin.Features.SmartContracts.csproj
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Stratis.Bitcoin.Features.SmartContracts.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>    
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
     <PackageId>Stratis.Features.SmartContracts</PackageId>
     <Product>Stratis.Features.SmartContracts</Product>

--- a/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
+++ b/src/Stratis.Bitcoin.Features.Wallet/Stratis.Bitcoin.Features.Wallet.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Features.WatchOnlyWallet/Stratis.Bitcoin.Features.WatchOnlyWallet.csproj
+++ b/src/Stratis.Bitcoin.Features.WatchOnlyWallet/Stratis.Bitcoin.Features.WatchOnlyWallet.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.IntegrationTests.Common/Stratis.Bitcoin.IntegrationTests.Common.csproj
+++ b/src/Stratis.Bitcoin.IntegrationTests.Common/Stratis.Bitcoin.IntegrationTests.Common.csproj
@@ -13,7 +13,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Product />
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Networks/Stratis.Bitcoin.Networks.csproj
+++ b/src/Stratis.Bitcoin.Networks/Stratis.Bitcoin.Networks.csproj
@@ -14,9 +14,9 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <AssemblyVersion>1.3.1.0</AssemblyVersion>
-    <FileVersion>1.3.1.0</FileVersion>
-    <Version>1.3.1.0</Version>
+    <AssemblyVersion>1.3.2.0</AssemblyVersion>
+    <FileVersion>1.3.2.0</FileVersion>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Bitcoin.Tests.Common/Stratis.Bitcoin.Tests.Common.csproj
+++ b/src/Stratis.Bitcoin.Tests.Common/Stratis.Bitcoin.Tests.Common.csproj
@@ -13,7 +13,7 @@
 		<GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
 		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
 		<GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-		<Version>1.3.1.0</Version>
+		<Version>1.3.2.0</Version>
 		<GeneratePackageOnBuild>False</GeneratePackageOnBuild>
 	</PropertyGroup>
 

--- a/src/Stratis.Bitcoin/Properties/AssemblyInfo.cs
+++ b/src/Stratis.Bitcoin/Properties/AssemblyInfo.cs
@@ -32,6 +32,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.1.0")]
-[assembly: AssemblyFileVersion("1.3.1.0")]
+[assembly: AssemblyVersion("1.3.2.0")]
+[assembly: AssemblyFileVersion("1.3.2.0")]
 [assembly: InternalsVisibleTo("Stratis.Bitcoin.Tests")]

--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0-dev</Version>
+    <Version>1.3.2.0-dev</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <CodeAnalysisRuleSet>..\Stratis.ruleset</CodeAnalysisRuleSet>
     <Authors>Stratis Group Ltd.</Authors>

--- a/src/Stratis.CirrusD/Stratis.CirrusD.csproj
+++ b/src/Stratis.CirrusD/Stratis.CirrusD.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
     <Company>Stratis Group Ltd.</Company>
     <Product />

--- a/src/Stratis.CirrusDnsD/Stratis.CirrusDnsD.csproj
+++ b/src/Stratis.CirrusDnsD/Stratis.CirrusDnsD.csproj
@@ -17,7 +17,7 @@
     <PropertyGroup>
         <LangVersion>latest</LangVersion>
         <Authors>Stratis Group Ltd.</Authors>
-        <Version>1.3.1.0</Version>
+        <Version>1.3.2.0</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/Stratis.CirrusMinerD/Stratis.CirrusMinerD.csproj
+++ b/src/Stratis.CirrusMinerD/Stratis.CirrusMinerD.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
     <Company>Stratis Group Ltd.</Company>
     <Product />

--- a/src/Stratis.CirrusPegD/Stratis.CirrusPegD.csproj
+++ b/src/Stratis.CirrusPegD/Stratis.CirrusPegD.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>
 

--- a/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralFullValidationRule.cs
@@ -79,7 +79,7 @@ namespace Stratis.Features.Collateral
             }
 
             IFederationMember federationMember = this.federationHistory.GetFederationMemberForBlock(context.ValidationContext.ChainedHeaderToValidate);
-            if (!this.collateralChecker.CheckCollateral(federationMember, commitmentHeight.Value))
+            if (!this.collateralChecker.CheckCollateral(federationMember, commitmentHeight.Value, context.ValidationContext.ChainedHeaderToValidate.Height))
             {
                 // By setting rejectUntil we avoid banning a peer that provided a block.
                 context.ValidationContext.RejectUntil = this.dateTime.GetUtcNow() + TimeSpan.FromSeconds(this.collateralCheckBanDurationSeconds);

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -285,7 +285,7 @@ namespace Stratis.Features.Collateral
 
                 if (minBalance < member.CollateralAmount.Satoshi)
                 {
-                    this.logger.LogInformation("The collateral should be ready for mining on your next mining turn.");
+                    this.logger.LogInformation("The collateral should be ready for mining in the next mining turn.");
                     return false;
                 }
 

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -282,7 +282,8 @@ namespace Stratis.Features.Collateral
 
                 if (minBalance < member.CollateralAmount.Satoshi)
                 {
-                    this.logger.LogInformation("The collateral should be ready for mining in the next mining turn.");
+                    this.logger.LogInformation("The collateral has to remain above {0} for {1} Strax blocks before a block can be mined.", 
+                        Money.Satoshis(member.CollateralAmount.Satoshi).ToUnit(MoneyUnit.BTC), collateralMaturationPeriod);
                     return false;
                 }
 

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -260,7 +260,7 @@ namespace Stratis.Features.Collateral
 
                 int release1310ActivationHeight = 0;
                 if (this.nodeDeployments?.BIP9.ArraySize > 0  /* Not NoBIP9Deployments */)
-                    release1310ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1300 */].ActivationHeight;
+                    release1310ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[1 /* Release1310 */].ActivationHeight;
 
                 // Checks that the collateral remains valid for at least half a round.
                 if (localChainHeight >= release1310ActivationHeight)

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -263,12 +263,12 @@ namespace Stratis.Features.Collateral
                     return 0 >= member.CollateralAmount;
                 }
 
-                int release1310ActivationHeight = 0;
+                int release1320ActivationHeight = 0;
                 if (this.nodeDeployments?.BIP9.ArraySize > 0  /* Not NoBIP9Deployments */)
-                    release1310ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[1 /* Release1310 */].ActivationHeight;
+                    release1320ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[1 /* Release1320 */].ActivationHeight;
 
                 // Checks that the collateral remains valid for at least half a round.
-                if (localChainHeight >= release1310ActivationHeight)
+                if (localChainHeight >= release1320ActivationHeight)
                 {
                     int roundBlocks = (int)(this.federationHistory.GetFederationForBlock(this.chainIndexer.Tip, localChainHeight - this.chainIndexer.Tip.Height).Count * this.blockRatio);
                     int startHeight = heightToCheckAt - roundBlocks / 2 - 1 /* For rounding */;

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -285,7 +285,7 @@ namespace Stratis.Features.Collateral
 
                 if (minBalance < member.CollateralAmount.Satoshi)
                 {
-                    this.logger.LogInformation("Your collateral should be ready for mining on your next mining turn.");
+                    this.logger.LogInformation("The collateral should be ready for mining on your next mining turn.");
                     return false;
                 }
 

--- a/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
+++ b/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
@@ -87,7 +87,7 @@ namespace Stratis.Features.Collateral
             }
 
             // Check our own collateral at a given commitment height.
-            bool success = this.collateralChecker.CheckCollateral(currentMember, commitmentHeight);
+            bool success = this.collateralChecker.CheckCollateral(currentMember, commitmentHeight, this.chainIndexer[blockTemplate.Block.Header.HashPrevBlock].Height + 1);
 
             if (!success)
             {

--- a/src/Stratis.Features.Collateral/Stratis.Features.Collateral.csproj
+++ b/src/Stratis.Features.Collateral/Stratis.Features.Collateral.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>    
-    <Version>4.0.9.0</Version>
+    <Version>4.0.9.1</Version>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>
 

--- a/src/Stratis.Features.Diagnostic/Stratis.Features.Diagnostic.csproj
+++ b/src/Stratis.Features.Diagnostic/Stratis.Features.Diagnostic.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <CodeAnalysisRuleSet>..\None.ruleset</CodeAnalysisRuleSet>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>
   

--- a/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralFullValidationRuleTests.cs
@@ -97,7 +97,7 @@ namespace Stratis.Features.FederatedPeg.Tests
         [Fact]
         public async Task PassesIfCollateralIsOkAsync()
         {
-            this.collateralCheckerMock.Setup(x => x.CheckCollateral(It.IsAny<IFederationMember>(), It.IsAny<int>())).Returns(true);
+            this.collateralCheckerMock.Setup(x => x.CheckCollateral(It.IsAny<IFederationMember>(), It.IsAny<int>(), It.IsAny<int>())).Returns(true);
             this.collateralCheckerMock.Setup(x => x.GetCounterChainConsensusHeight()).Returns(5000);
 
             await this.rule.RunAsync(this.ruleContext);
@@ -106,7 +106,7 @@ namespace Stratis.Features.FederatedPeg.Tests
         [Fact]
         public async Task ThrowsIfCollateralCheckFailsAsync()
         {
-            this.collateralCheckerMock.Setup(x => x.CheckCollateral(It.IsAny<IFederationMember>(), It.IsAny<int>())).Returns(false);
+            this.collateralCheckerMock.Setup(x => x.CheckCollateral(It.IsAny<IFederationMember>(), It.IsAny<int>(), It.IsAny<int>())).Returns(false);
 
             await Assert.ThrowsAsync<ConsensusErrorException>(() => this.rule.RunAsync(this.ruleContext));
         }

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -78,8 +78,8 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             federationManager.Initialize();
 
-            this.collateralChecker = new CollateralChecker(clientFactory, counterChainSettings, federationManager, signals, network, new CounterChainNetworkWrapper(counterChainSettings.CounterChainNetwork), 
-                asyncMock.Object, new Mock<INodeLifetime>().Object, new NodeDeployments(network, chainIndexerMock.Object), new Mock<IFederationHistory>().Object, chainIndexerMock.Object);
+            this.collateralChecker = new CollateralChecker(clientFactory, counterChainSettings, federationManager, signals, network,
+                asyncMock.Object, new Mock<INodeLifetime>().Object, new NodeDeployments(network, chainIndexerMock.Object));
         }
 
         [Fact]

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using NBitcoin;
 using Stratis.Bitcoin;
 using Stratis.Bitcoin.AsyncWork;
+using Stratis.Bitcoin.Base.Deployments;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Controllers.Models;
 using Stratis.Bitcoin.EventBus;
@@ -77,7 +78,8 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             federationManager.Initialize();
 
-            this.collateralChecker = new CollateralChecker(clientFactory, counterChainSettings, federationManager, signals, network, asyncMock.Object, (new Mock<INodeLifetime>()).Object);
+            this.collateralChecker = new CollateralChecker(clientFactory, counterChainSettings, federationManager, signals, network, new CounterChainNetworkWrapper(counterChainSettings.CounterChainNetwork), 
+                asyncMock.Object, new Mock<INodeLifetime>().Object, new NodeDeployments(network, chainIndexerMock.Object), new Mock<IFederationHistory>().Object, chainIndexerMock.Object);
         }
 
         [Fact]
@@ -128,9 +130,9 @@ namespace Stratis.Features.FederatedPeg.Tests
 
             await this.collateralChecker.InitializeAsync();
 
-            Assert.True(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[0], this.collateralCheckHeight));
-            Assert.True(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[1], this.collateralCheckHeight));
-            Assert.False(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[2], this.collateralCheckHeight));
+            Assert.True(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[0], this.collateralCheckHeight, 0));
+            Assert.True(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[1], this.collateralCheckHeight, 0));
+            Assert.False(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[2], this.collateralCheckHeight, 0));
 
             // Now change what the client returns and make sure collateral check fails after update.
             AddressIndexerData updated = collateralData.BalancesData.First(b => b.Address == this.collateralFederationMembers[0].CollateralMainchainAddress);
@@ -139,7 +141,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             // Wait CollateralUpdateIntervalSeconds + 1 seconds
 
             await Task.Delay(21_000);
-            Assert.False(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[0], this.collateralCheckHeight));
+            Assert.False(this.collateralChecker.CheckCollateral(this.collateralFederationMembers[0], this.collateralCheckHeight, 0));
 
             this.collateralChecker.Dispose();
         }

--- a/src/Stratis.Features.FederatedPeg/Stratis.Features.FederatedPeg.csproj
+++ b/src/Stratis.Features.FederatedPeg/Stratis.Features.FederatedPeg.csproj
@@ -12,7 +12,7 @@
     <DebugType>Full</DebugType>
     <CodeAnalysisRuleSet>..\None.ruleset</CodeAnalysisRuleSet>
     <Authors>Stratis Group Ltd.</Authors>
-    <Version>4.0.9.0</Version>
+    <Version>4.0.9.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Stratis.Features.SQLiteWalletRepository/Stratis.Features.SQLiteWalletRepository.csproj
+++ b/src/Stratis.Features.SQLiteWalletRepository/Stratis.Features.SQLiteWalletRepository.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -107,7 +107,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
+                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", 0, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -107,8 +107,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
-                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", 0, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", CirrusBIP9Deployments.FlagBitRelease1300, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
+                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", CirrusBIP9Deployments.FlagBitRelease1310, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -108,7 +108,7 @@ namespace Stratis.Sidechains.Networks
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", CirrusBIP9Deployments.FlagBitRelease1300, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
-                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", CirrusBIP9Deployments.FlagBitRelease1310, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -198,7 +198,7 @@ namespace Stratis.Sidechains.Networks
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", CirrusBIP9Deployments.FlagBitRelease1300, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 1512 /* 75% Activation Threshold */),
-                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", CirrusBIP9Deployments.FlagBitRelease1310, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 1512 /* 75% Activation Threshold */)
+                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 1512 /* 75% Activation Threshold */)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -197,7 +197,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 1512 /* 75% Activation Threshold */)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 1512 /* 75% Activation Threshold */),
+                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", 0, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 1512 /* 75% Activation Threshold */)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -197,8 +197,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 1512 /* 75% Activation Threshold */),
-                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", 0, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 1512 /* 75% Activation Threshold */)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", CirrusBIP9Deployments.FlagBitRelease1300, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 1512 /* 75% Activation Threshold */),
+                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", CirrusBIP9Deployments.FlagBitRelease1310, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 1512 /* 75% Activation Threshold */)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -127,7 +127,7 @@ namespace Stratis.Sidechains.Networks
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", CirrusBIP9Deployments.FlagBitRelease1300, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
-                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", CirrusBIP9Deployments.FlagBitRelease1310, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -126,7 +126,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
+                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", 0, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -126,8 +126,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
-                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", 0, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", CirrusBIP9Deployments.FlagBitRelease1300, DateTime.Parse("2022-3-22 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
+                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", CirrusBIP9Deployments.FlagBitRelease1310, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -148,8 +148,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-28 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultTestnetThreshold),
-                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", 0, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", CirrusBIP9Deployments.FlagBitRelease1300, DateTime.Parse("2022-3-28 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultTestnetThreshold),
+                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", CirrusBIP9Deployments.FlagBitRelease1310, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -148,7 +148,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-28 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultTestnetThreshold)
+                [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", 0, DateTime.Parse("2022-3-28 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultTestnetThreshold),
+                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", 0, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -149,7 +149,7 @@ namespace Stratis.Sidechains.Networks
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1300] = new BIP9DeploymentsParameters("Release1300", CirrusBIP9Deployments.FlagBitRelease1300, DateTime.Parse("2022-3-28 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultTestnetThreshold),
-                [CirrusBIP9Deployments.Release1310] = new BIP9DeploymentsParameters("Release1310", CirrusBIP9Deployments.FlagBitRelease1310, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
+++ b/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
@@ -9,6 +9,7 @@ namespace Stratis.Sidechains.Networks.Deployments
     {
         // The position of each deployment in the deployments array. Note that this is decoupled from the actual position of the flag bit for the deployment in the block version.
         public const int Release1300 = 0;
+        public const int Release1310 = 0;
 
         // The number of deployments.
         public const int NumberOfDeployments = 1;

--- a/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
+++ b/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
@@ -9,10 +9,10 @@ namespace Stratis.Sidechains.Networks.Deployments
     {
         // The position of each deployment in the deployments array. Note that this is decoupled from the actual position of the flag bit for the deployment in the block version.
         public const int Release1300 = 0;
-        public const int Release1310 = 1;
+        public const int Release1320 = 1;
 
         public const int FlagBitRelease1300 = 0;
-        public const int FlagBitRelease1310 = 1;
+        public const int FlagBitRelease1320 = 1;
 
         // The number of deployments.
         public const int NumberOfDeployments = 2;

--- a/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
+++ b/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
@@ -9,10 +9,13 @@ namespace Stratis.Sidechains.Networks.Deployments
     {
         // The position of each deployment in the deployments array. Note that this is decoupled from the actual position of the flag bit for the deployment in the block version.
         public const int Release1300 = 0;
-        public const int Release1310 = 0;
+        public const int Release1310 = 1;
+
+        public const int FlagBitRelease1300 = 0;
+        public const int FlagBitRelease1310 = 1;
 
         // The number of deployments.
-        public const int NumberOfDeployments = 1;
+        public const int NumberOfDeployments = 2;
 
         /// <summary>
         /// Constructs the BIP9 deployments array.

--- a/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
+++ b/src/Stratis.Sidechains.Networks/Stratis.Sidechains.Networks.csproj
@@ -5,7 +5,7 @@
     
     <DebugType>Full</DebugType>
     <CodeAnalysisRuleSet>..\None.ruleset</CodeAnalysisRuleSet>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
     <PackageId>Stratis.Sidechains.Networks</PackageId>
   </PropertyGroup>

--- a/src/Stratis.StraxD/Stratis.StraxD.csproj
+++ b/src/Stratis.StraxD/Stratis.StraxD.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>
 

--- a/src/Stratis.StraxDnsD/Stratis.StraxDnsD.csproj
+++ b/src/Stratis.StraxDnsD/Stratis.StraxDnsD.csproj
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
-    <Version>1.3.1.0</Version>
+    <Version>1.3.2.0</Version>
     <Authors>Stratis Group Ltd.</Authors>
   </PropertyGroup>
   


### PR DESCRIPTION
Displays `The collateral should be ready for mining in the next mining turn.` when skipping a mining slot solely due to collateral not being mature.