### PR TITLE
Optimise ReceiptSearcher

### DIFF
--- a/src/NBitcoin/Bloom.cs
+++ b/src/NBitcoin/Bloom.cs
@@ -96,9 +96,11 @@ namespace NBitcoin
         /// <returns>Whether this data could be contained within the filter.</returns>
         public bool Test(Bloom bloom)
         {
-            var copy = new Bloom(bloom.ToBytes());
-            copy.Or(this);
-            return this.Equals(copy);
+            for (int i = 0; i < BloomLength; i++)
+                if ((this.data[i] & bloom.data[i]) != bloom.data[i])
+                    return false;
+
+            return true;
         }
 
         /// <summary>


### PR DESCRIPTION
Halves the time taken to scan all the headers from 2 minutes to  1 minute (on CirrusTest),