### PR TITLE
Support two levels of smart contract inheritance

### DIFF
--- a/src/Stratis.SmartContracts.CLR.Tests/Loader/ContractAssemblyTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/Loader/ContractAssemblyTests.cs
@@ -128,5 +128,34 @@ namespace Stratis.SmartContracts.CLR.Tests.Loader
             Assert.NotNull(type);
             Assert.Equal("Test", type.Name);
         }
+
+        [Fact]
+        public void GetDeployedType_TwoLevelsOfInheritance_CorrectType()
+        {
+            var code = @"
+using Stratis.SmartContracts;
+
+public class TypeOne : SmartContract
+{
+    public TypeOne(ISmartContractState state) : base(state) {}
+}
+
+[Deploy]
+public class TypeTwo : TypeOne
+{
+    public TypeTwo(ISmartContractState state) : base(state) {}
+}
+";
+            var compilation = ContractCompiler.Compile(code);
+
+            var assemblyLoadResult = this.loader.Load((ContractByteCode)compilation.Compilation);
+
+            var contractAssembly = assemblyLoadResult.Value;
+
+            var type = contractAssembly.DeployedType;
+
+            Assert.NotNull(type);
+            Assert.Equal("TypeTwo", type.Name);
+        }
     }
 }

--- a/src/Stratis.SmartContracts.CLR.Tests/Loader/ContractAssemblyTests.cs
+++ b/src/Stratis.SmartContracts.CLR.Tests/Loader/ContractAssemblyTests.cs
@@ -135,15 +135,15 @@ namespace Stratis.SmartContracts.CLR.Tests.Loader
             var code = @"
 using Stratis.SmartContracts;
 
-public class TypeOne : SmartContract
+public class BaseType : SmartContract
 {
-    public TypeOne(ISmartContractState state) : base(state) {}
+    public BaseType(ISmartContractState state) : base(state) {}
 }
 
 [Deploy]
-public class TypeTwo : TypeOne
+public class InheritedType : BaseType
 {
-    public TypeTwo(ISmartContractState state) : base(state) {}
+    public InheritedType(ISmartContractState state) : base(state) {}
 }
 ";
             var compilation = ContractCompiler.Compile(code);
@@ -155,7 +155,7 @@ public class TypeTwo : TypeOne
             var type = contractAssembly.DeployedType;
 
             Assert.NotNull(type);
-            Assert.Equal("TypeTwo", type.Name);
+            Assert.Equal("InheritedType", type.Name);
         }
     }
 }

--- a/src/Stratis.SmartContracts.CLR/Loader/ContractAssembly.cs
+++ b/src/Stratis.SmartContracts.CLR/Loader/ContractAssembly.cs
@@ -49,12 +49,16 @@ namespace Stratis.SmartContracts.CLR.Loader
                     x.CustomAttributes.Any(y => y.AttributeType == typeof(DeployAttribute)));
         }
 
-        public static bool IsContractType(Type typeDefinition)
+        private static bool IsContractType(Type typeDefinition)
         {
             return typeDefinition.IsClass &&
                    !typeDefinition.IsAbstract &&
-                   typeDefinition.BaseType != null &&
-                   typeDefinition.BaseType == typeof(SmartContract);
+                   InheritsFromType(typeDefinition, typeof(SmartContract));
+        }
+
+        private static bool InheritsFromType(Type subject, Type predicate)
+        {
+            return subject != null && (subject.BaseType == predicate || InheritsFromType(subject.BaseType, predicate));
         }
 
         private Type GetObserverType()

--- a/src/Stratis.SmartContracts.CLR/Loader/ContractAssembly.cs
+++ b/src/Stratis.SmartContracts.CLR/Loader/ContractAssembly.cs
@@ -53,12 +53,7 @@ namespace Stratis.SmartContracts.CLR.Loader
         {
             return typeDefinition.IsClass &&
                    !typeDefinition.IsAbstract &&
-                   InheritsFromType(typeDefinition, typeof(SmartContract));
-        }
-
-        private static bool InheritsFromType(Type subject, Type predicate)
-        {
-            return subject != null && (subject.BaseType == predicate || InheritsFromType(subject.BaseType, predicate));
+                   typeDefinition.IsSubclassOf(typeof(SmartContract));
         }
 
         private Type GetObserverType()


### PR DESCRIPTION
Takes into account indirect inheritance of `SmartContract` when determining the deploy type in a smart contract assembly. This allows contracts to be deployed with an inheritance structure like so:

`NonFungibleTicket` -> `NonFungibleToken` -> `SmartContract`.