### PR TITLE
[API] Add gettransactionsigners endpoint

### DIFF
--- a/src/Stratis.Bitcoin.Features.Api/NodeController.cs
+++ b/src/Stratis.Bitcoin.Features.Api/NodeController.cs
@@ -505,7 +505,7 @@ namespace Stratis.Bitcoin.Features.Api
 
         [HttpPost]
         [Route("gettransactionsigners")]
-        public async Task<IActionResult> GetTransactionSignersAsync([FromBody] string trxid, int input)
+        public async Task<IActionResult> GetTransactionSignersAsync([FromBody] string trxid, [FromBody] int input)
         {
             try
             {

--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -21,12 +21,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Compile Remove="Wallet\**" />
-    <EmbeddedResource Remove="Wallet\**" />
-    <None Remove="Wallet\**" />
-  </ItemGroup>
-
-  <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 

--- a/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
+++ b/src/Stratis.Bitcoin/Stratis.Bitcoin.csproj
@@ -21,6 +21,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Wallet\**" />
+    <EmbeddedResource Remove="Wallet\**" />
+    <None Remove="Wallet\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <AdditionalFiles Include="..\stylecop.json" />
   </ItemGroup>
 
@@ -69,10 +75,6 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Wallet\" />
   </ItemGroup>
 
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Adds rudimentary support for determining which pubkey(s) correspond to the private key(s) that signed a given transaction input.

Currently it supports P2PKH and federation multisig transactions. Support for others can be added as needed; it is mostly the scriptPubKey comparisons that need to be amended. We have to take this approach because we don't know what the correct `recId` value is for the pubkey recovery without something to check against (in this case the prevOut's scriptPubKey).

This may also need better handling of the script verify flag values to truly support every transaction type (e.g. cold staking).