### PR TITLE
Delegate node StartTime to NodeStats only

### DIFF
--- a/src/Stratis.Bitcoin/FullNode.cs
+++ b/src/Stratis.Bitcoin/FullNode.cs
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin
         public FullNodeState State { get; private set; }
 
         /// <inheritdoc />
-        public DateTime StartTime { get; set; }
+        public DateTime StartTime => this.NodeStats.NodeStartedOn;
 
         /// <summary>Component responsible for connections to peers in P2P network.</summary>
         public IConnectionManager ConnectionManager { get; set; }
@@ -188,8 +188,6 @@ namespace Stratis.Bitcoin
             this.State = FullNodeState.Initialized;
 
             this.Signals.Publish(new FullNodeEvent() { Message = $"Full node initialized on {this.Network.Name}.", State = this.State.ToString() });
-
-            this.StartTime = this.DateTimeProvider.GetUtcNow();
 
             return this;
         }

--- a/src/Stratis.Bitcoin/Utilities/NodeStats.cs
+++ b/src/Stratis.Bitcoin/Utilities/NodeStats.cs
@@ -38,6 +38,8 @@ namespace Stratis.Bitcoin.Utilities
 
         /// <summary>Collects benchmark stats.</summary>
         string GetBenchmark();
+
+        DateTime NodeStartedOn { get; }
     }
 
     public class NodeStats : INodeStats
@@ -54,9 +56,10 @@ namespace Stratis.Bitcoin.Utilities
         private readonly IDateTimeProvider dateTimeProvider;
         private readonly ILogger logger;
         private readonly NodeSettings nodeSettings;
-        private readonly string nodeStartedOn;
         private List<StatsItem> stats;
         private readonly IVersionProvider versionProvider;
+
+        public DateTime NodeStartedOn { get; private set; }
 
         public NodeStats(IDateTimeProvider dateTimeProvider, NodeSettings nodeSettings, IVersionProvider versionProvider)
         {
@@ -68,7 +71,7 @@ namespace Stratis.Bitcoin.Utilities
             this.stats = new List<StatsItem>();
             this.versionProvider = versionProvider;
 
-            this.nodeStartedOn = this.dateTimeProvider.GetUtcNow().ToString(CultureInfo.InvariantCulture);
+            this.NodeStartedOn = this.dateTimeProvider.GetUtcNow();
         }
 
         /// <inheritdoc />
@@ -169,7 +172,7 @@ namespace Stratis.Bitcoin.Utilities
                 statsBuilder.AppendLine("Agent".PadRight(LoggingConfiguration.ColumnLength, ' ') + $": {this.nodeSettings.Agent}:{this.versionProvider.GetVersion()} ({(int)this.nodeSettings.ProtocolVersion})");
                 statsBuilder.AppendLine("Network".PadRight(LoggingConfiguration.ColumnLength, ' ') + $": {this.nodeSettings.Network.Name}");
                 statsBuilder.AppendLine("Database".PadRight(LoggingConfiguration.ColumnLength, ' ') + $": {this.nodeSettings.ConfigReader.GetOrDefault("dbtype", "leveldb")}");
-                statsBuilder.AppendLine("Node Started".PadRight(LoggingConfiguration.ColumnLength, ' ') + $": {this.nodeStartedOn}");
+                statsBuilder.AppendLine("Node Started".PadRight(LoggingConfiguration.ColumnLength, ' ') + $": {this.NodeStartedOn.ToString(CultureInfo.InvariantCulture)}");
                 statsBuilder.AppendLine("Current Date".PadRight(LoggingConfiguration.ColumnLength, ' ') + $": {currentDateTime}");
 
                 if (this.nodeSettings.ConfigReader.GetOrDefault("displayextendednodestats", false))


### PR DESCRIPTION
Currently the `FullNode` and `NodeStats` record separate (different) node start times.

After this PR only `NodeStats` records the node start time and the `FullNode` gets it start time from there.