### PR TITLE
Batch receipt searches for NFT indexer

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/ISmartContractTransactionService.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/ISmartContractTransactionService.cs
@@ -26,5 +26,16 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
         /// <param name="toBlock">The block number where searching finishes.</param>
         /// <returns>A list of all matching receipts.</returns>
         List<ReceiptResponse> ReceiptSearch(string contractAddress, string eventName, List<string> topics = null, int fromBlock = 0, int? toBlock = null);
+
+        /// <summary>
+        /// Searches for receipts that match the given filter criteria. Filter criteria are ANDed together.
+        /// </summary>
+        /// <param name="contractAddresses">The contract addresses from which events were raised.</param>
+        /// <param name="eventName">The name of the event raised.</param>
+        /// <param name="topics">The topics to search. All specified topics must be present.</param>
+        /// <param name="fromBlock">The block number from which to start searching.</param>
+        /// <param name="toBlock">The block number where searching finishes.</param>
+        /// <returns>A list of all matching receipts.</returns>
+        List<ReceiptResponse> ReceiptSearch(List<string> contractAddresses, string eventName, List<string> topics = null, int fromBlock = 0, int? toBlock = null);
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractTransactionService.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractTransactionService.cs
@@ -415,18 +415,21 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
         {
             var filteredContractAddresses = new HashSet<string>();
 
-            foreach (string contractAddress in contractAddresses)
+            if (contractAddresses != null)
             {
-                uint160 address = contractAddress.ToUint160(this.network);
-
-                byte[] contractCode = this.stateRoot.GetCode(address);
-
-                if (contractCode == null || !contractCode.Any())
+                foreach (string contractAddress in contractAddresses)
                 {
-                    continue;
-                }
+                    uint160 address = contractAddress.ToUint160(this.network);
 
-                filteredContractAddresses.Add(contractAddress);
+                    byte[] contractCode = this.stateRoot.GetCode(address);
+
+                    if (contractCode == null || !contractCode.Any())
+                    {
+                        continue;
+                    }
+
+                    filteredContractAddresses.Add(contractAddress);
+                }
             }
 
             IEnumerable<byte[]> topicsBytes = topics != null ? topics.Where(topic => topic != null).Select(t => t.HexToByteArray()) : new List<byte[]>();

--- a/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractTransactionService.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Wallet/SmartContractTransactionService.cs
@@ -407,23 +407,35 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Wallet
         /// <inheritdoc />
         public List<ReceiptResponse> ReceiptSearch(string contractAddress, string eventName, List<string> topics = null, int fromBlock = 0, int? toBlock = null)
         {
-            uint160 address = contractAddress.ToUint160(this.network);
+            return ReceiptSearch(new List<string>() { contractAddress }, eventName, topics, fromBlock, toBlock);
+        }
 
-            byte[] contractCode = this.stateRoot.GetCode(address);
+        /// <inheritdoc />
+        public List<ReceiptResponse> ReceiptSearch(List<string> contractAddresses, string eventName, List<string> topics = null, int fromBlock = 0, int? toBlock = null)
+        {
+            var filteredContractAddresses = new HashSet<string>();
 
-            if (contractCode == null || !contractCode.Any())
+            foreach (string contractAddress in contractAddresses)
             {
-                return null;
+                uint160 address = contractAddress.ToUint160(this.network);
+
+                byte[] contractCode = this.stateRoot.GetCode(address);
+
+                if (contractCode == null || !contractCode.Any())
+                {
+                    continue;
+                }
+
+                filteredContractAddresses.Add(contractAddress);
             }
 
             IEnumerable<byte[]> topicsBytes = topics != null ? topics.Where(topic => topic != null).Select(t => t.HexToByteArray()) : new List<byte[]>();
-
-
+            
             var deserializer = new ApiLogDeserializer(this.primitiveSerializer, this.network, this.stateRoot, this.contractAssemblyCache);
 
             var receiptSearcher = new ReceiptSearcher(this.chainIndexer, this.blockStore, this.receiptRepository, this.network);
 
-            List<Receipt> receipts = receiptSearcher.SearchReceipts(contractAddress, eventName, fromBlock, toBlock, topicsBytes);
+            List<Receipt> receipts = receiptSearcher.SearchReceipts(filteredContractAddresses, eventName, fromBlock, toBlock, topicsBytes);
 
             var result = new List<ReceiptResponse>();
 

--- a/src/Stratis.Features.Unity3dApi/Controllers/Unity3dController.cs
+++ b/src/Stratis.Features.Unity3dApi/Controllers/Unity3dController.cs
@@ -582,38 +582,6 @@ namespace Stratis.Features.Unity3dApi.Controllers
             return Task.FromResult(result);
         }
 
-        [Route("watch-nft-contract")]
-        [HttpGet]
-        [ProducesResponseType((int)HttpStatusCode.OK)]
-        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-        public void WatchNFTContract([FromQuery] string contractAddress)
-        {
-            this.NFTTransferIndexer.WatchNFTContract(contractAddress);
-        }
-
-        [Route("watch-nft-contracts")]
-        [HttpPost]
-        [ProducesResponseType((int)HttpStatusCode.OK)]
-        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-        public IActionResult WatchNFTContracts([FromBody] List<string> contractAddresses)
-        {
-            foreach (string contractAddress in contractAddresses)
-            {
-                this.NFTTransferIndexer.WatchNFTContract(contractAddress);
-            }
-
-            return Ok();
-        }
-
-        [Route("unwatch-nft-contract")]
-        [HttpGet]
-        [ProducesResponseType((int)HttpStatusCode.OK)]
-        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-        public void UnwatchNFTContract([FromQuery] string contractAddress)
-        {
-            this.NFTTransferIndexer.UnwatchNFTContract(contractAddress);
-        }
-
         [Route("reindex-all-contracts")]
         [HttpGet]
         [ProducesResponseType((int)HttpStatusCode.OK)]

--- a/src/Stratis.Features.Unity3dApi/LocalCallContract.cs
+++ b/src/Stratis.Features.Unity3dApi/LocalCallContract.cs
@@ -1,0 +1,156 @@
+﻿using System.Collections.Generic;
+using System;
+using System.Linq;
+using NBitcoin;
+using Stratis.Bitcoin.Features.SmartContracts.Models;
+using Stratis.Bitcoin.Features.SmartContracts.Wallet;
+using Stratis.Bitcoin.Features.SmartContracts;
+using Stratis.SmartContracts.CLR.Caching;
+using Stratis.SmartContracts.CLR.Local;
+using Stratis.SmartContracts.CLR.Serialization;
+using Stratis.SmartContracts.CLR;
+using Stratis.SmartContracts;
+
+namespace Stratis.Features.Unity3dApi
+{
+    // TODO: Move this to a more central point once 1.4.0.0 stabilises
+    public interface ILocalCallContract
+    {
+        LocalExecutionResponse LocalCallSmartContract(LocalCallContractRequest request);
+        T LocalCallSmartContract<T>(ulong? blockHeight, string sender, string contractAddress, string methodName, params object[] arguments);
+    }
+
+    public class LocalCallContract : ILocalCallContract
+    {
+        private readonly Network network;
+        private readonly ChainIndexer chainIndexer;
+        private readonly ISmartContractTransactionService smartContractTransactionService;
+        private readonly ILocalExecutor localExecutor;
+        private readonly IContractPrimitiveSerializer primitiveSerializer;
+        private readonly IContractAssemblyCache contractAssemblyCache;
+
+        public LocalCallContract(Network network, ISmartContractTransactionService smartContractTransactionService, ChainIndexer chainIndexer, ILocalExecutor localExecutor)
+        {
+            this.network = network;
+            this.chainIndexer = chainIndexer;
+            this.smartContractTransactionService = smartContractTransactionService;
+            this.localExecutor = localExecutor;
+        }
+
+        public LocalExecutionResponse LocalCallSmartContract(LocalCallContractRequest request)
+        {
+            ContractTxData txData = this.smartContractTransactionService.BuildLocalCallTxData(request);
+
+            var height = request.BlockHeight ?? (ulong)this.chainIndexer.Height;
+
+            ILocalExecutionResult result = this.localExecutor.Execute(
+                height,
+                request.Sender?.ToUint160(this.network) ?? new uint160(),
+                !string.IsNullOrWhiteSpace(request.Amount) ? (Money)request.Amount : 0,
+                txData);
+
+            var deserializer = new ApiLogDeserializer(this.primitiveSerializer, this.network, result.StateRoot, this.contractAssemblyCache);
+
+            var response = new LocalExecutionResponse
+            {
+                InternalTransfers = deserializer.MapTransferInfo(result.InternalTransfers.ToArray()),
+                Logs = deserializer.MapLogResponses(result.Logs.ToArray()),
+                GasConsumed = result.GasConsumed,
+                Revert = result.Revert,
+                ErrorMessage = result.ErrorMessage,
+                Return = result.Return // All return values should be primitives, let default serializer handle.
+            };
+
+            return response;
+        }
+
+        private IEnumerable<string> EncodeParameters(params object[] arguments)
+        {
+            foreach (var parameter in arguments)
+            {
+                switch (parameter)
+                {
+                    case bool boolVal:
+                        yield return $"1#{boolVal}";
+                        break;
+
+                    case byte byteVal:
+                        yield return $"2#{byteVal}";
+                        break;
+
+                    case char charVal:
+                        yield return $"3#{charVal}";
+                        break;
+
+                    case string stringVal:
+                        yield return $"4#{stringVal}";
+                        break;
+
+                    case uint uint32:
+                        yield return $"5#{uint32}";
+                        break;
+
+                    case int int32:
+                        yield return $"6#{int32}";
+                        break;
+
+                    case ulong uint64:
+                        yield return $"7#{uint64}";
+                        break;
+
+                    case long int64:
+                        yield return $"8#{int64}";
+                        break;
+
+                    case Address address:
+                        yield return $"9#{address}";
+                        break;
+
+                    case byte[] byteArr:
+                        yield return $"10#{BitConverter.ToString(byteArr).Replace("-", "")}";
+                        break;
+
+                    case UInt128 uInt128:
+                        yield return $"11#{uInt128}";
+                        break;
+
+                    case UInt256 uInt256:
+                        yield return $"12#{uInt256}";
+                        break;
+
+                    default:
+                        throw new Exception($"Currently unsupported argument type: '{parameter.GetType().Name}'");
+                }
+            }
+        }
+
+        public T LocalCallSmartContract<T>(ulong? blockHeight, string sender, string contractAddress, string methodName, params object[] arguments)
+        {
+            var request = new LocalCallContractRequest
+            {
+                BlockHeight = blockHeight,
+                Amount = "0",
+                ContractAddress = contractAddress,
+                GasLimit = 250_000,
+                GasPrice = 100,
+                MethodName = methodName,
+                Parameters = EncodeParameters(arguments).ToArray(),
+                Sender = sender
+            };
+
+            try
+            {
+                LocalExecutionResponse result = this.LocalCallSmartContract(request);
+
+                if (result.Return == null)
+                    return default(T);
+
+                return (T)result.Return;
+            }
+            catch (Exception)
+            {
+                throw;
+            }
+        }
+    }
+}

--- a/src/Stratis.Features.Unity3dApi/NFTTransferIndexer.cs
+++ b/src/Stratis.Features.Unity3dApi/NFTTransferIndexer.cs
@@ -126,7 +126,7 @@ namespace Stratis.Features.Unity3dApi
 
             if (indexerStateModel == null)
             {
-                indexerStateModel = new IndexerStateModel() { LastProcessedHeight = 0 };
+                indexerStateModel = new IndexerStateModel() { LastProcessedHeight = GetWatchFromHeight() };
             }
 
             return indexerStateModel;
@@ -196,7 +196,7 @@ namespace Stratis.Features.Unity3dApi
 
             this.NFTContractCollection.Upsert(updated);
 
-            this.UpdateLastUpdatedBlock(0);
+            this.UpdateLastUpdatedBlock(GetWatchFromHeight());
 
             this.logger.LogTrace("ReindexAllContracts(-)");
         }
@@ -274,7 +274,7 @@ namespace Stratis.Features.Unity3dApi
                                     break;
                                 }
 
-                                this.logger.LogTrace("Found new NFT contract: " + receiptRes.To);
+                                this.logger.LogDebug("Found new NFT contract: " + receiptRes.To);
 
                                 knownContracts.Add(receiptRes.To);
 

--- a/src/Stratis.Features.Unity3dApi/NftContractLocalCLient.cs
+++ b/src/Stratis.Features.Unity3dApi/NftContractLocalCLient.cs
@@ -1,0 +1,32 @@
+﻿using Stratis.SmartContracts;
+
+namespace Stratis.Features.Unity3dApi
+{
+    public class NftContractLocalClient
+    {
+        public const string SupportsInterfaceMethodName = "SupportsInterface";
+
+        private readonly ILocalCallContract localCallContract;
+        private readonly string senderAddress;
+
+        public NftContractLocalClient(ILocalCallContract localCallContract, string senderAddress)
+        {
+            this.localCallContract = localCallContract;
+            this.senderAddress = senderAddress;
+        }
+
+        public bool SupportsInterface(ulong? blockHeight, string contractAddress, TokenInterface tokenInterfaceId)
+        {
+            return this.localCallContract.LocalCallSmartContract<bool>(blockHeight, this.senderAddress, contractAddress, SupportsInterfaceMethodName, (uint)tokenInterfaceId);
+        }
+    }
+
+    public enum TokenInterface
+    {
+        ISupportsInterface = 1,
+        INonFungibleToken = 2,
+        INonFungibleTokenReceiver = 3,
+        INonFungibleTokenMetadata = 4,
+        INonFungibleTokenEnumerable = 5,
+    }
+}

--- a/src/Stratis.Features.Unity3dApi/Unity3dApiSettings.cs
+++ b/src/Stratis.Features.Unity3dApi/Unity3dApiSettings.cs
@@ -45,6 +45,12 @@ namespace Stratis.Features.Unity3dApi
         public bool UseHttps { get; set; }
 
         /// <summary>
+        /// A wallet address to use for local contract calls.
+        /// </summary>
+        /// <remarks>Can be an arbitrary valid address.</remarks>
+        public string LocalCallSenderAddress { get; set; }
+
+        /// <summary>
         /// Initializes an instance of the object from the node configuration.
         /// </summary>
         /// <param name="nodeSettings">The node configuration.</param>
@@ -102,6 +108,11 @@ namespace Stratis.Features.Unity3dApi
                     Interval = keepAlive * 1000
                 };
             }
+
+            this.LocalCallSenderAddress = config.GetOrDefault("unityapi_localcallsenderaddress", (string)null);
+
+            if (string.IsNullOrWhiteSpace(this.LocalCallSenderAddress))
+                throw new ConfigurationException("The local call sender address must be specified.");
         }
 
         /// <summary>Prints the help information on how to configure the API settings to the logger.</summary>
@@ -116,6 +127,7 @@ namespace Stratis.Features.Unity3dApi
             builder.AppendLine($"-unityapi_keepalive=<seconds>              Keep Alive interval (set in seconds). Default: 0 (no keep alive).");
             builder.AppendLine($"-unityapi_usehttps=<bool>                  Use https protocol on the API. Defaults to false.");
             builder.AppendLine($"-unityapi_certificatefilepath=<string>     Path to the certificate used for https traffic encryption. Defaults to <null>. Password protected files are not supported. On MacOs, only p12 certificates can be used without password.");
+            builder.AppendLine($"-unityapi_localcallsenderaddress=<string>  Arbitrary address to be used for submitting local contract calls (non-monetary).");
 
             var logger = NodeSettings.Default(network).LoggerFactory.CreateLogger(typeof(Unity3dApiSettings).FullName);
             logger.LogInformation(builder.ToString());
@@ -142,6 +154,7 @@ namespace Stratis.Features.Unity3dApi
             builder.AppendLine($"#Path to the file containing the certificate to use for https traffic encryption. Password protected files are not supported. On MacOs, only p12 certificates can be used without password.");
             builder.AppendLine(@"#Please refer to .Net Core documentation for usage: 'https://docs.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2.-ctor?view=netcore-2.1#System_Security_Cryptography_X509Certificates_X509Certificate2__ctor_System_Byte___'.");
             builder.AppendLine($"#unityapi_certificatefilepath=");
+            builder.AppendLine($"#unityapi_localcallsenderaddress=");
         }
     }
 }

--- a/src/Stratis.SmartContracts.Core.Tests/Receipts/ReceiptMatcherTests.cs
+++ b/src/Stratis.SmartContracts.Core.Tests/Receipts/ReceiptMatcherTests.cs
@@ -51,7 +51,7 @@ namespace Stratis.SmartContracts.Core.Tests.Receipts
             // Every receipt should have at least one log like this.
             for (int i = 0; i < 10; i++)
             {
-                List<Receipt> matches = matcher.MatchReceipts(receipts, null, 
+                List<Receipt> matches = matcher.MatchReceipts(receipts, (uint160)null, 
                     new List<byte[]>
                     {
                         Encoding.UTF8.GetBytes("Event" + i)
@@ -59,7 +59,7 @@ namespace Stratis.SmartContracts.Core.Tests.Receipts
 
                 Assert.Single(matches);
 
-                matches = matcher.MatchReceipts(receipts, null,
+                matches = matcher.MatchReceipts(receipts, (uint160)null,
                     new List<byte[]>
                     {
                         Encoding.UTF8.GetBytes("Topic" + i)

--- a/src/Stratis.SmartContracts.Core/Receipts/ReceiptMatcher.cs
+++ b/src/Stratis.SmartContracts.Core/Receipts/ReceiptMatcher.cs
@@ -27,7 +27,6 @@ namespace Stratis.SmartContracts.Core.Receipts
         /// <returns>The list of receipts that were matched.</returns>
         public List<Receipt> MatchReceipts(IEnumerable<Receipt> receipts, HashSet<uint160> addresses, IEnumerable<byte[]> topics)
         {
-            // For each block, get all receipts, and if they match, add to list to return.
             var receiptResponses = new List<Receipt>();
 
             foreach (Receipt storedReceipt in receipts)

--- a/src/Stratis.SmartContracts.Core/Receipts/ReceiptMatcher.cs
+++ b/src/Stratis.SmartContracts.Core/Receipts/ReceiptMatcher.cs
@@ -36,14 +36,9 @@ namespace Stratis.SmartContracts.Core.Receipts
                     continue;
 
                 // Match the receipts where all data passes the filter.
-                foreach (uint160 address in addresses)
+                if (storedReceipt.Logs.Any(log => BloomExtensions.Test(log.GetBloom(), addresses, topics)))
                 {
-                    if (storedReceipt.Logs.Any(log => BloomExtensions.Test(log.GetBloom(), address, topics)))
-                    {
-                        receiptResponses.Add(storedReceipt);
-
-                        break;
-                    }
+                    receiptResponses.Add(storedReceipt);
                 }
             }
 

--- a/src/Stratis.SmartContracts.Core/Receipts/ReceiptMatcher.cs
+++ b/src/Stratis.SmartContracts.Core/Receipts/ReceiptMatcher.cs
@@ -9,11 +9,23 @@ namespace Stratis.SmartContracts.Core.Receipts
         /// <summary>
         /// Matches the given receipts against the supplied address and topics, and returns those that are present in the filter.
         /// </summary>
-        /// <param name="receipts"></param>
-        /// <param name="address"></param>
+        /// <param name="receipts">The list of receipts that need to be evaluated.</param>
+        /// <param name="address">The single address to match receipts against.</param>
         /// <param name="topics"></param>
-        /// <returns></returns>
+        /// <returns>The list of receipts that were matched.</returns>
         public List<Receipt> MatchReceipts(IEnumerable<Receipt> receipts, uint160 address, IEnumerable<byte[]> topics)
+        {
+            return MatchReceipts(receipts, new HashSet<uint160>() { address }, topics);
+        }
+
+        /// <summary>
+        /// Matches the given receipts against the supplied addresses and topics, and returns those that are present in the filter.
+        /// </summary>
+        /// <param name="receipts">The list of receipts that need to be evaluated.</param>
+        /// <param name="addresses">The collection of addresses to match receipts against.</param>
+        /// <param name="topics"></param>
+        /// <returns>The list of receipts that were matched.</returns>
+        public List<Receipt> MatchReceipts(IEnumerable<Receipt> receipts, HashSet<uint160> addresses, IEnumerable<byte[]> topics)
         {
             // For each block, get all receipts, and if they match, add to list to return.
             var receiptResponses = new List<Receipt>();
@@ -24,8 +36,15 @@ namespace Stratis.SmartContracts.Core.Receipts
                     continue;
 
                 // Match the receipts where all data passes the filter.
-                if (storedReceipt.Logs.Any(log => BloomExtensions.Test(log.GetBloom(), address, topics)))
-                    receiptResponses.Add(storedReceipt);
+                foreach (uint160 address in addresses)
+                {
+                    if (storedReceipt.Logs.Any(log => BloomExtensions.Test(log.GetBloom(), address, topics)))
+                    {
+                        receiptResponses.Add(storedReceipt);
+
+                        break;
+                    }
+                }
             }
 
             return receiptResponses;

--- a/src/Stratis.SmartContracts.Core/Receipts/ReceiptSearcher.cs
+++ b/src/Stratis.SmartContracts.Core/Receipts/ReceiptSearcher.cs
@@ -26,6 +26,23 @@ namespace Stratis.SmartContracts.Core.Receipts
             this.matcher = new ReceiptMatcher();
         }
 
+        public List<Receipt> SearchReceipts(string eventName, int fromBlock, int? toBlock, IEnumerable<byte[]> topics)
+        {
+            var topicsList = new List<byte[]>();
+
+            if (!string.IsNullOrWhiteSpace(eventName))
+            {
+                topicsList.Add(Encoding.UTF8.GetBytes(eventName));
+            }
+
+            if (topics != null)
+            {
+                topicsList.AddRange(topics);
+            }
+
+            return this.SearchReceipts((HashSet<string>)null, fromBlock, toBlock, topicsList);
+        }
+
         public List<Receipt> SearchReceipts(string contractAddress, string eventName, int fromBlock, int? toBlock, IEnumerable<byte[]> topics)
         {
             var topicsList = new List<byte[]>();
@@ -70,14 +87,17 @@ namespace Stratis.SmartContracts.Core.Receipts
 
             var addressesUint160 = new HashSet<uint160>();
 
-            foreach (string contractAddress in contractAddresses)
+            if (contractAddresses != null)
             {
-                // Build the bytes we can use to check for this event.
-                // TODO use address.ToUint160 extension when it is in .Core.
-                var addressUint160 = new uint160(new BitcoinPubKeyAddress(contractAddress, this.network).Hash.ToBytes());
+                foreach (string contractAddress in contractAddresses)
+                {
+                    // Build the bytes we can use to check for this event.
+                    // TODO use address.ToUint160 extension when it is in .Core.
+                    var addressUint160 = new uint160(new BitcoinPubKeyAddress(contractAddress, this.network).Hash.ToBytes());
 
-                addressesUint160.Add(addressUint160);
-                filterBloom.Add(addressUint160.ToBytes());
+                    addressesUint160.Add(addressUint160);
+                    filterBloom.Add(addressUint160.ToBytes());
+                }
             }
 
             foreach (byte[] topic in topics)

--- a/src/Stratis.SmartContracts.Core/Receipts/ReceiptSearcher.cs
+++ b/src/Stratis.SmartContracts.Core/Receipts/ReceiptSearcher.cs
@@ -40,22 +40,45 @@ namespace Stratis.SmartContracts.Core.Receipts
                 topicsList.AddRange(topics);
             }
 
-            return this.SearchReceipts(contractAddress, fromBlock, toBlock, topicsList);
+            return this.SearchReceipts(new HashSet<string>() { contractAddress }, fromBlock, toBlock, topicsList);
         }
 
-        public List<Receipt> SearchReceipts(string contractAddress, int fromBlock = 0, int? toBlock = null, IEnumerable<byte[]> topics = null)
+        public List<Receipt> SearchReceipts(HashSet<string> contractAddresses, string eventName, int fromBlock, int? toBlock, IEnumerable<byte[]> topics)
+        {
+            var topicsList = new List<byte[]>();
+
+            if (!string.IsNullOrWhiteSpace(eventName))
+            {
+                topicsList.Add(Encoding.UTF8.GetBytes(eventName));
+            }
+
+            if (topics != null)
+            {
+                topicsList.AddRange(topics);
+            }
+
+            return this.SearchReceipts(contractAddresses, fromBlock, toBlock, topicsList);
+        }
+
+        public List<Receipt> SearchReceipts(HashSet<string> contractAddresses, int fromBlock = 0, int? toBlock = null, IEnumerable<byte[]> topics = null)
         {
             topics = topics?.Where(topic => topic != null) ?? Enumerable.Empty<byte[]>();
 
-            // Build the bytes we can use to check for this event.
-            // TODO use address.ToUint160 extension when it is in .Core.
-            var addressUint160 = new uint160(new BitcoinPubKeyAddress(contractAddress, this.network).Hash.ToBytes());
-            
             // Ensure that we perform the Keccak256 hash calculations only once before entering the loop.
             // This leads to "only" a two-fold speed improvement mostly because the db header retrieval is still slow.
             var filterBloom = new Bloom();
 
-            filterBloom.Add(addressUint160.ToBytes());
+            var addressesUint160 = new HashSet<uint160>();
+
+            foreach (string contractAddress in contractAddresses)
+            {
+                // Build the bytes we can use to check for this event.
+                // TODO use address.ToUint160 extension when it is in .Core.
+                var addressUint160 = new uint160(new BitcoinPubKeyAddress(contractAddress, this.network).Hash.ToBytes());
+
+                addressesUint160.Add(addressUint160);
+                filterBloom.Add(addressUint160.ToBytes());
+            }
 
             foreach (byte[] topic in topics)
             {
@@ -92,7 +115,7 @@ namespace Stratis.SmartContracts.Core.Receipts
             IList<Receipt> receipts = this.receiptRepository.RetrieveMany(transactionHashes);
 
             // For each block, get all receipts, and if they match, add to list to return.
-            return this.matcher.MatchReceipts(receipts, addressUint160, topics);
+            return this.matcher.MatchReceipts(receipts, addressesUint160, topics);
         }
     }
 }


### PR DESCRIPTION
See #1037. 

It may make more sense in future to watch all NFT contracts, rather than to keep having to reindex every time a new one is added.