### PR TITLE
Add "getverboseaddressesbalances2" with POST API

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreClient.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreClient.cs
@@ -17,7 +17,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         Task<VerboseAddressBalancesResult> GetVerboseAddressesBalancesDataAsync(IEnumerable<string> addresses, CancellationToken cancellation = default);
 
         /// <summary><see cref="BlockStoreController.GetVerboseAddressesBalancesData"/></summary>
-        Task<VerboseAddressBalancesResult> GetVerboseAddressesBalancesData2Async(IEnumerable<string> addresses, CancellationToken cancellation = default);
+        Task<VerboseAddressBalancesResult> VerboseAddressesBalancesDataAsync(IEnumerable<string> addresses, CancellationToken cancellation = default);
     }
 
     /// <inheritdoc cref="IBlockStoreClient"/>
@@ -55,11 +55,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         }
 
         /// <inheritdoc />
-        public Task<VerboseAddressBalancesResult> GetVerboseAddressesBalancesData2Async(IEnumerable<string> addresses, CancellationToken cancellation = default)
+        public Task<VerboseAddressBalancesResult> VerboseAddressesBalancesDataAsync(IEnumerable<string> addresses, CancellationToken cancellation = default)
         {
             string addrString = string.Join(",", addresses);
 
-            return this.SendPostRequestAsync<string, VerboseAddressBalancesResult>(addrString, BlockStoreRouteEndPoint.GetVerboseAddressesBalances2, cancellation);
+            return this.SendPostRequestAsync<string, VerboseAddressBalancesResult>(addrString, BlockStoreRouteEndPoint.VerboseAddressesBalances, cancellation);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreClient.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreClient.cs
@@ -59,8 +59,6 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         {
             string addrString = string.Join(",", addresses);
 
-            string arguments = $"{nameof(addresses)}={addrString}";
-
             return this.SendPostRequestAsync<string, VerboseAddressBalancesResult>(addrString, BlockStoreRouteEndPoint.GetVerboseAddressesBalances2, cancellation);
         }
     }

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreClient.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreClient.cs
@@ -15,6 +15,9 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
 
         /// <summary><see cref="BlockStoreController.GetVerboseAddressesBalancesData"/></summary>
         Task<VerboseAddressBalancesResult> GetVerboseAddressesBalancesDataAsync(IEnumerable<string> addresses, CancellationToken cancellation = default);
+
+        /// <summary><see cref="BlockStoreController.GetVerboseAddressesBalancesData"/></summary>
+        Task<VerboseAddressBalancesResult> GetVerboseAddressesBalancesData2Async(IEnumerable<string> addresses, CancellationToken cancellation = default);
     }
 
     /// <inheritdoc cref="IBlockStoreClient"/>
@@ -49,6 +52,16 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
             string arguments = $"{nameof(addresses)}={addrString}";
 
             return this.SendGetRequestAsync<VerboseAddressBalancesResult>(BlockStoreRouteEndPoint.GetVerboseAddressesBalances, arguments, cancellation);
+        }
+
+        /// <inheritdoc />
+        public Task<VerboseAddressBalancesResult> GetVerboseAddressesBalancesData2Async(IEnumerable<string> addresses, CancellationToken cancellation = default)
+        {
+            string addrString = string.Join(",", addresses);
+
+            string arguments = $"{nameof(addresses)}={addrString}";
+
+            return this.SendPostRequestAsync<string, VerboseAddressBalancesResult>(addrString, BlockStoreRouteEndPoint.GetVerboseAddressesBalances2, cancellation);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreClient.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreClient.cs
@@ -16,7 +16,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         /// <summary><see cref="BlockStoreController.GetVerboseAddressesBalancesData"/></summary>
         Task<VerboseAddressBalancesResult> GetVerboseAddressesBalancesDataAsync(IEnumerable<string> addresses, CancellationToken cancellation = default);
 
-        /// <summary><see cref="BlockStoreController.GetVerboseAddressesBalancesData"/></summary>
+        /// <summary><see cref="BlockStoreController.VerboseAddressesBalancesData"/></summary>
         Task<VerboseAddressBalancesResult> VerboseAddressesBalancesDataAsync(IEnumerable<string> addresses, CancellationToken cancellation = default);
     }
 

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
@@ -23,6 +23,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
     {
         public const string GetAddressesBalances = "getaddressesbalances";
         public const string GetVerboseAddressesBalances = "getverboseaddressesbalances";
+        public const string GetVerboseAddressesBalances2 = "getverboseaddressesbalances2";
         public const string GetAddressIndexerTip = "addressindexertip";
         public const string GetBlock = "block";
         public const string GetBlockCount = "getblockcount";
@@ -246,6 +247,34 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
         public IActionResult GetVerboseAddressesBalancesData(string addresses)
+        {
+            try
+            {
+                string[] addressesArray = addresses?.Split(',') ?? new string[] { };
+
+                this.logger.LogDebug("Asking data for {0} addresses.", addressesArray.Length);
+
+                VerboseAddressBalancesResult result = this.addressIndexer.GetAddressIndexerState(addressesArray);
+
+                return this.Json(result);
+            }
+            catch (Exception e)
+            {
+                this.logger.LogError("Exception occurred: {0}", e.ToString());
+                return ErrorHelpers.BuildErrorResponse(HttpStatusCode.BadRequest, e.Message, e.ToString());
+            }
+        }
+
+        /// <summary>Provides verbose balance data of the given addresses.</summary>
+        /// <param name="addresses">A comma delimited set of addresses that will be queried.</param>
+        /// <returns>A result object containing the balance for each requested address and if so, a message stating why the indexer is not queryable.</returns>
+        /// <response code="200">Returns balances for the requested addresses</response>
+        /// <response code="400">Unexpected exception occurred</response>
+        [Route(BlockStoreRouteEndPoint.GetVerboseAddressesBalances2)]
+        [HttpPost]
+        [ProducesResponseType((int)HttpStatusCode.OK)]
+        [ProducesResponseType((int)HttpStatusCode.BadRequest)]
+        public IActionResult GetVerboseAddressesBalancesData2([FromBody] string addresses)
         {
             try
             {

--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
@@ -23,7 +23,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
     {
         public const string GetAddressesBalances = "getaddressesbalances";
         public const string GetVerboseAddressesBalances = "getverboseaddressesbalances";
-        public const string GetVerboseAddressesBalances2 = "getverboseaddressesbalances2";
+        public const string VerboseAddressesBalances = "verboseaddressesbalances";
         public const string GetAddressIndexerTip = "addressindexertip";
         public const string GetBlock = "block";
         public const string GetBlockCount = "getblockcount";
@@ -270,11 +270,11 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         /// <returns>A result object containing the balance for each requested address and if so, a message stating why the indexer is not queryable.</returns>
         /// <response code="200">Returns balances for the requested addresses</response>
         /// <response code="400">Unexpected exception occurred</response>
-        [Route(BlockStoreRouteEndPoint.GetVerboseAddressesBalances2)]
+        [Route(BlockStoreRouteEndPoint.VerboseAddressesBalances)]
         [HttpPost]
         [ProducesResponseType((int)HttpStatusCode.OK)]
         [ProducesResponseType((int)HttpStatusCode.BadRequest)]
-        public IActionResult GetVerboseAddressesBalancesData2([FromBody] string addresses)
+        public IActionResult VerboseAddressesBalancesData([FromBody] string addresses)
         {
             try
             {

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -179,7 +179,7 @@ namespace Stratis.Features.Collateral
 
             this.logger.LogDebug("Addresses to check {0}.", addressesToCheck.Count);
 
-            VerboseAddressBalancesResult verboseAddressBalanceResult = await this.blockStoreClient.GetVerboseAddressesBalancesDataAsync(addressesToCheck, cancellation).ConfigureAwait(false);
+            VerboseAddressBalancesResult verboseAddressBalanceResult = await this.blockStoreClient.GetVerboseAddressesBalancesData2Async(addressesToCheck, cancellation).ConfigureAwait(false);
 
             if (verboseAddressBalanceResult == null)
             {

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -179,7 +179,7 @@ namespace Stratis.Features.Collateral
 
             this.logger.LogDebug("Addresses to check {0}.", addressesToCheck.Count);
 
-            VerboseAddressBalancesResult verboseAddressBalanceResult = await this.blockStoreClient.GetVerboseAddressesBalancesData2Async(addressesToCheck, cancellation).ConfigureAwait(false);
+            VerboseAddressBalancesResult verboseAddressBalanceResult = await this.blockStoreClient.VerboseAddressesBalancesDataAsync(addressesToCheck, cancellation).ConfigureAwait(false);
 
             if (verboseAddressBalanceResult == null)
             {

--- a/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
+++ b/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
@@ -80,7 +80,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
         private void StartNodeWithMockCounterNodeAPI(CoreNode node)
         {
             var mockClient = new Mock<IBlockStoreClient>();
-            mockClient.Setup(x => x.GetVerboseAddressesBalancesData2Async(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            mockClient.Setup(x => x.VerboseAddressesBalancesDataAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Bitcoin.Controllers.Models.VerboseAddressBalancesResult(100000));
 
             node.Start(() =>

--- a/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
+++ b/src/Stratis.Features.FederatedPeg.IntegrationTests/NodeInitialisationTests.cs
@@ -80,7 +80,7 @@ namespace Stratis.Features.FederatedPeg.IntegrationTests
         private void StartNodeWithMockCounterNodeAPI(CoreNode node)
         {
             var mockClient = new Mock<IBlockStoreClient>();
-            mockClient.Setup(x => x.GetVerboseAddressesBalancesDataAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
+            mockClient.Setup(x => x.GetVerboseAddressesBalancesData2Async(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new Bitcoin.Controllers.Models.VerboseAddressBalancesResult(100000));
 
             node.Start(() =>

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -124,7 +124,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 }
             };
 
-            blockStoreClientMock.Setup(x => x.GetVerboseAddressesBalancesDataAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(collateralData);
+            blockStoreClientMock.Setup(x => x.GetVerboseAddressesBalancesData2Async(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(collateralData);
 
             this.collateralChecker.SetPrivateVariableValue("blockStoreClient", blockStoreClientMock.Object);
 

--- a/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CollateralCheckerTests.cs
@@ -124,7 +124,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 }
             };
 
-            blockStoreClientMock.Setup(x => x.GetVerboseAddressesBalancesData2Async(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(collateralData);
+            blockStoreClientMock.Setup(x => x.VerboseAddressesBalancesDataAsync(It.IsAny<IEnumerable<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(collateralData);
 
             this.collateralChecker.SetPrivateVariableValue("blockStoreClient", blockStoreClientMock.Object);
 


### PR DESCRIPTION
Adds a method identical to "getverboseaddressesbalances" except it takes its arguments in the body and is invoked with POST.