### PR TITLE
Pass ChainIndexer argument via CachedCoinView constructor

### DIFF
--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinviewTests.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/CoinViews/CoinviewTests.cs
@@ -51,7 +51,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests.CoinViews
 
             this.rewindDataIndexCache = new RewindDataIndexCache(this.dateTimeProvider, this.network, new FinalizedBlockInfoRepository(new HashHeightPair()), new Checkpoints());
 
-            this.cachedCoinView = new CachedCoinView(this.network, this.coindb, this.dateTimeProvider, this.loggerFactory, this.nodeStats, new ConsensusSettings(new NodeSettings(this.network)), this.stakeChainStore, this.rewindDataIndexCache);
+            this.cachedCoinView = new CachedCoinView(this.network, this.coindb, this.dateTimeProvider, this.loggerFactory, this.nodeStats, new ConsensusSettings(new NodeSettings(this.network)), this.chainIndexer, this.stakeChainStore, this.rewindDataIndexCache);
 
             this.rewindDataIndexCache.Initialize(this.chainIndexer.Height, this.cachedCoinView);
 

--- a/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus.Tests/TestChainFactory.cs
@@ -124,7 +124,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Tests
             testChainContext.InitialBlockDownloadState = new InitialBlockDownloadState(testChainContext.ChainState, testChainContext.Network, consensusSettings, new Checkpoints(), testChainContext.DateTimeProvider);
 
             var inMemoryCoinView = new InMemoryCoinView(new HashHeightPair(testChainContext.ChainIndexer.Tip));
-            var cachedCoinView = new CachedCoinView(network, inMemoryCoinView, DateTimeProvider.Default, testChainContext.LoggerFactory, new NodeStats(testChainContext.DateTimeProvider, testChainContext.NodeSettings, new Mock<IVersionProvider>().Object), new ConsensusSettings(testChainContext.NodeSettings));
+            var cachedCoinView = new CachedCoinView(network, inMemoryCoinView, DateTimeProvider.Default, testChainContext.LoggerFactory, new NodeStats(testChainContext.DateTimeProvider, testChainContext.NodeSettings, new Mock<IVersionProvider>().Object), new ConsensusSettings(testChainContext.NodeSettings), testChainContext.ChainIndexer);
 
             var dataFolder = new DataFolder(TestBase.AssureEmptyDir(dataDir).FullName);
             testChainContext.PeerAddressManager =

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -131,11 +131,12 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         private readonly IBlockStore blockStore;
         private readonly CancellationTokenSource cancellationToken;
         private readonly ConsensusSettings consensusSettings;
+        private readonly ChainIndexer chainIndexer;
         private CachePerformanceSnapshot latestPerformanceSnapShot;
 
         private readonly Random random;
 
-        public CachedCoinView(Network network, ICoindb coindb, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory, INodeStats nodeStats, ConsensusSettings consensusSettings, 
+        public CachedCoinView(Network network, ICoindb coindb, IDateTimeProvider dateTimeProvider, ILoggerFactory loggerFactory, INodeStats nodeStats, ConsensusSettings consensusSettings, ChainIndexer chainIndexer, 
             StakeChainStore stakeChainStore = null, IRewindDataIndexCache rewindDataIndexCache = null, IBlockStore blockStore = null, INodeLifetime nodeLifetime = null)
         {
             Guard.NotNull(coindb, nameof(CachedCoinView.coindb));
@@ -145,6 +146,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             this.network = network;
             this.dateTimeProvider = dateTimeProvider;
             this.consensusSettings = consensusSettings;
+            this.chainIndexer = chainIndexer;
             this.stakeChainStore = stakeChainStore;
             this.rewindDataIndexCache = rewindDataIndexCache;
             this.blockStore = blockStore;
@@ -166,7 +168,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <summary>
         /// Remain on-chain.
         /// </summary>
-        public void Sync(ChainIndexer chainIndexer)
+        public void Sync()
         {
             lock (this.lockobj)
             {
@@ -196,11 +198,13 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             }
         }
 
-        public void Initialize(ChainedHeader chainTip, ChainIndexer chainIndexer, IConsensusRuleEngine consensusRuleEngine)
+        public void Initialize(IConsensusRuleEngine consensusRuleEngine)
         {
+            ChainedHeader chainTip = this.chainIndexer.Tip;
+
             this.coindb.Initialize();
 
-            Sync(chainIndexer);
+            Sync();
 
             HashHeightPair coinViewTip = this.coindb.GetTipHash();
 

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -173,17 +173,17 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             lock (this.lockobj)
             {
                 HashHeightPair coinViewTip = this.GetTipHash();
-                if (coinViewTip.Hash == chainIndexer.Tip.HashBlock)
+                if (coinViewTip.Hash == this.chainIndexer.Tip.HashBlock)
                     return;
 
                 Flush();
 
-                ChainedHeader fork = chainIndexer[coinViewTip.Hash];
+                ChainedHeader fork = this.chainIndexer[coinViewTip.Hash];
                 if (fork == null)
                 {
                     // Determine the last usable height.
-                    int height = BinarySearch.BinaryFindFirst(h => (h > chainIndexer.Height) || this.GetRewindData(h).PreviousBlockHash.Hash != chainIndexer[h].Previous.HashBlock, 0, coinViewTip.Height + 1) - 1;
-                    fork = chainIndexer[(height < 0) ? coinViewTip.Height : height];
+                    int height = BinarySearch.BinaryFindFirst(h => (h > this.chainIndexer.Height) || this.GetRewindData(h).PreviousBlockHash.Hash != this.chainIndexer[h].Previous.HashBlock, 0, coinViewTip.Height + 1) - 1;
+                    fork = this.chainIndexer[(height < 0) ? coinViewTip.Height : height];
                 }
 
                 while (coinViewTip.Height != fork.Height)
@@ -218,7 +218,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
                     var coinViewRule = consensusRuleEngine.GetRule<CoinViewRule>();
                     var deploymentsRule = consensusRuleEngine.GetRule<SetActivationDeploymentsFullValidationRule>();
 
-                    foreach ((ChainedHeader chainedHeader, Block block) in this.blockStore.BatchBlocksFrom(chainIndexer[coinViewTip.Hash], chainIndexer, this.cancellationToken, batchSize: 1000))
+                    foreach ((ChainedHeader chainedHeader, Block block) in this.blockStore.BatchBlocksFrom(this.chainIndexer[coinViewTip.Hash], this.chainIndexer, this.cancellationToken, batchSize: 1000))
                     {
                         if (block == null)
                             break;

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CachedCoinView.cs
@@ -198,7 +198,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             }
         }
 
-        public void Initialize(IConsensusRuleEngine consensusRuleEngine)
+        public void Initialize(IConsensusManager consensusManager)
         {
             ChainedHeader chainTip = this.chainIndexer.Tip;
 
@@ -213,6 +213,8 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             {
                 try
                 {
+                    IConsensusRuleEngine consensusRuleEngine = consensusManager.ConsensusRules;
+
                     var loadCoinViewRule = consensusRuleEngine.GetRule<LoadCoinviewRule>();
                     var saveCoinViewRule = consensusRuleEngine.GetRule<SaveCoinviewRule>();
                     var coinViewRule = consensusRuleEngine.GetRule<CoinViewRule>();

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinView.cs
@@ -14,10 +14,9 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <summary>
         /// Initializes the coin view.
         /// </summary>
-        /// <param name="chainTip">The chain tip.</param>
         /// <param name="chainIndexer">The chain indexer.</param>
         /// <param name="consensusRuleEngine">The consensus rule engine.</param>
-        void Initialize(ChainedHeader chainTip, ChainIndexer chainIndexer, IConsensusRuleEngine consensusRuleEngine);
+        void Initialize(IConsensusRuleEngine consensusRuleEngine);
 
         /// <summary>
         /// Retrieves the block hash of the current tip of the coinview.
@@ -46,7 +45,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// Brings the coinview back on-chain if a re-org occurred.
         /// </summary>
         /// <param name="chainIndexer">The current consensus chain.</param>
-        void Sync(ChainIndexer chainIndexer);
+        void Sync();
 
         /// <summary>
         /// Obtains information about unspent outputs.

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/CoinView.cs
@@ -14,9 +14,8 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         /// <summary>
         /// Initializes the coin view.
         /// </summary>
-        /// <param name="chainIndexer">The chain indexer.</param>
-        /// <param name="consensusRuleEngine">The consensus rule engine.</param>
-        void Initialize(IConsensusRuleEngine consensusRuleEngine);
+        /// <param name="consensusManager">The consensus manager.</param>
+        void Initialize(IConsensusManager consensusManager);
 
         /// <summary>
         /// Retrieves the block hash of the current tip of the coinview.

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/InMemoryCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/InMemoryCoinView.cs
@@ -34,7 +34,7 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         }
 
         /// <inheritdoc />
-        public void Initialize(IConsensusRuleEngine consensusRuleEngine)
+        public void Initialize(IConsensusManager consensusManager)
         {
             throw new NotImplementedException();
         }

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/InMemoryCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/InMemoryCoinView.cs
@@ -34,13 +34,13 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
         }
 
         /// <inheritdoc />
-        public void Initialize(ChainedHeader chainTip, ChainIndexer chainIndexer, IConsensusRuleEngine consensusRuleEngine)
+        public void Initialize(IConsensusRuleEngine consensusRuleEngine)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public void Sync(ChainIndexer chainIndexer)
+        public void Sync()
         {
         }
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
@@ -25,7 +25,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             // unless the coinview threshold is reached.
             this.Logger.LogDebug("Saving coinview changes.");
             var utxoRuleContext = context as UtxoRuleContext;
-            this.PowParent.UtxoSet.Sync(this.Parent.ChainIndexer);
+            this.PowParent.UtxoSet.Sync();
             this.PowParent.UtxoSet.SaveChanges(utxoRuleContext.UnspentOutputSet.GetCoins(), new HashHeightPair(oldBlock), new HashHeightPair(nextBlock));
 
             return Task.CompletedTask;

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/PosConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/PosConsensusRuleEngine.cs
@@ -48,9 +48,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
         }
 
         /// <inheritdoc />
-        public override void Initialize(ChainedHeader chainTip)
+        public override void Initialize(ChainedHeader chainTip, IConsensusManager consensusManager)
         {
-            base.Initialize(chainTip);
+            base.Initialize(chainTip, consensusManager);
 
             this.StakeChain.Load();
 

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
@@ -67,7 +67,9 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
         {
             base.Initialize(chainTip);
 
-            this.UtxoSet.Initialize(chainTip, this.ChainIndexer, this);
+            Guard.Assert(chainTip.HashBlock == this.ChainIndexer.Tip.HashBlock);
+
+            this.UtxoSet.Initialize(this);
         }
 
         public override async Task<ValidationContext> FullValidationAsync(ChainedHeader header, Block block)

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/PowConsensusRuleEngine.cs
@@ -63,13 +63,13 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules
         }
 
         /// <inheritdoc />
-        public override void Initialize(ChainedHeader chainTip)
+        public override void Initialize(ChainedHeader chainTip, IConsensusManager consensusManager)
         {
-            base.Initialize(chainTip);
+            base.Initialize(chainTip, consensusManager);
 
             Guard.Assert(chainTip.HashBlock == this.ChainIndexer.Tip.HashBlock);
 
-            this.UtxoSet.Initialize(this);
+            this.UtxoSet.Initialize(consensusManager);
         }
 
         public override async Task<ValidationContext> FullValidationAsync(ChainedHeader header, Block block)

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
@@ -50,13 +50,13 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             this.Set = new UnspentOutputSet();
         }
 
-        public void Initialize(ChainedHeader chainTip, ChainIndexer chainIndexer, IConsensusRuleEngine consensusRuleEngine)
+        public void Initialize(IConsensusRuleEngine consensusRuleEngine)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public void Sync(ChainIndexer chainIndexer)
+        public void Sync()
         {
         }
 

--- a/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
+++ b/src/Stratis.Bitcoin.Features.MemoryPool/MemPoolCoinView.cs
@@ -50,7 +50,7 @@ namespace Stratis.Bitcoin.Features.MemoryPool
             this.Set = new UnspentOutputSet();
         }
 
-        public void Initialize(IConsensusRuleEngine consensusRuleEngine)
+        public void Initialize(IConsensusManager consensusManager)
         {
             throw new NotImplementedException();
         }

--- a/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/CoinViewTests.cs
@@ -73,7 +73,8 @@ namespace Stratis.Bitcoin.IntegrationTests
                 ChainedHeader chained = this.MakeNext(genesisChainedHeader, ctx.Network);
                 var dateTimeProvider = new DateTimeProvider();
 
-                var cacheCoinView = new CachedCoinView(this.network, ctx.Coindb, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, NodeSettings.Default(this.network), new Mock<IVersionProvider>().Object), new ConsensusSettings(new NodeSettings(this.network)));
+                var cacheCoinView = new CachedCoinView(this.network, ctx.Coindb, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, NodeSettings.Default(this.network), 
+                    new Mock<IVersionProvider>().Object), new ConsensusSettings(new NodeSettings(this.network)), new ChainIndexer(this.network));
 
                 cacheCoinView.SaveChanges(new UnspentOutput[] { new UnspentOutput(new OutPoint(genesis.Transactions[0], 0), new Coins(0, genesis.Transactions[0].Outputs.First(), true)) }, new HashHeightPair(genesisChainedHeader), new HashHeightPair(chained));
                 Assert.NotNull(cacheCoinView.FetchCoins(new[] { new OutPoint(genesis.Transactions[0], 0) }).UnspentOutputs.Values.FirstOrDefault().Coins);
@@ -105,7 +106,8 @@ namespace Stratis.Bitcoin.IntegrationTests
             using (NodeContext nodeContext = NodeContext.Create(this))
             {
                 var dateTimeProvider = new DateTimeProvider();
-                var cacheCoinView = new CachedCoinView(this.network, nodeContext.Coindb, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, NodeSettings.Default(this.network), new Mock<IVersionProvider>().Object), new ConsensusSettings(new NodeSettings(this.network)));
+                var cacheCoinView = new CachedCoinView(this.network, nodeContext.Coindb, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, NodeSettings.Default(this.network), 
+                    new Mock<IVersionProvider>().Object), new ConsensusSettings(new NodeSettings(this.network)), new ChainIndexer(this.network));
                 var tester = new CoinViewTester(cacheCoinView);
 
                 List<(Coins, OutPoint)> coinsA = tester.CreateCoins(5);

--- a/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
@@ -35,7 +35,7 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <inheritdoc />
-        public void Initialize(IConsensusRuleEngine consensusRuleEngine)
+        public void Initialize(IConsensusManager consensusManager)
         {
             throw new NotImplementedException();
         }

--- a/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
+++ b/src/Stratis.Bitcoin.Tests/Consensus/TestInMemoryCoinView.cs
@@ -35,13 +35,13 @@ namespace Stratis.Bitcoin.Tests.Consensus
         }
 
         /// <inheritdoc />
-        public void Initialize(ChainedHeader chainTip, ChainIndexer chainIndexer, IConsensusRuleEngine consensusRuleEngine)
+        public void Initialize(IConsensusRuleEngine consensusRuleEngine)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public void Sync(ChainIndexer chainIndexer)
+        public void Sync()
         {
         }
 

--- a/src/Stratis.Bitcoin/Base/BaseFeature.cs
+++ b/src/Stratis.Bitcoin/Base/BaseFeature.cs
@@ -296,7 +296,7 @@ namespace Stratis.Bitcoin.Base
             // node shutdown unexpectedly and the finalized block info needs to be reset.
             this.finalizedBlockInfoRepository.Initialize(this.chainIndexer.Tip);
 
-            this.consensusRules.Initialize(this.chainIndexer.Tip);
+            this.consensusRules.Initialize(this.chainIndexer.Tip, this.consensusManager);
 
             await this.consensusManager.InitializeAsync(this.chainIndexer.Tip).ConfigureAwait(false);
 

--- a/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusRuleEngine.cs
@@ -105,7 +105,7 @@ namespace Stratis.Bitcoin.Consensus
         }
 
         /// <inheritdoc />
-        public virtual void Initialize(ChainedHeader chainTip)
+        public virtual void Initialize(ChainedHeader chainTip, IConsensusManager consensusManager)
         {
             this.SetupRulesEngineParent();
         }

--- a/src/Stratis.Bitcoin/Consensus/IConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/IConsensusRuleEngine.cs
@@ -19,7 +19,7 @@ namespace Stratis.Bitcoin.Consensus
         /// Initialize the rules engine.
         /// </summary>
         /// <param name="chainTip">Last common header between chain repository and block store if it's available.
-        void Initialize(ChainedHeader chainTip);
+        void Initialize(ChainedHeader chainTip, IConsensusManager consensusManager);
 
         /// <summary>
         /// Register a new rule to the engine

--- a/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/PoW/SmartContractMinerTests.cs
@@ -207,7 +207,7 @@ namespace Stratis.SmartContracts.IntegrationTests.PoW
 
                 this.NodeSettings = new NodeSettings(this.network, args: new string[] { "-checkpoints" });
                 var consensusSettings = new ConsensusSettings(this.NodeSettings);
-                this.cachedCoinView = new CachedCoinView(this.network, inMemoryCoinView, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, this.NodeSettings, new Mock<IVersionProvider>().Object), consensusSettings);
+                this.cachedCoinView = new CachedCoinView(this.network, inMemoryCoinView, dateTimeProvider, this.loggerFactory, new NodeStats(dateTimeProvider, this.NodeSettings, new Mock<IVersionProvider>().Object), consensusSettings, this.ChainIndexer);
 
                 var nodeDeployments = new NodeDeployments(this.network, this.ChainIndexer);
 


### PR DESCRIPTION
This PR:
- Adds `ChainIndexer` from the `CachedCoinView` constructor
- Removes `ChainIndexer` and `chainTip` from the `CachedCoinView`'s `Initialize` and `Sync` methods.
- Adds locks to public methods that lack them.