### PR TITLE
Add collateral height checks to miner and rules

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusErrors.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusErrors.cs
@@ -34,5 +34,7 @@ namespace Stratis.Bitcoin.Features.PoA
         public static ConsensusError CollateralCommitmentHeightMissing => new ConsensusError("collateral-commitment-height-missing", "collateral commitment height missing");
 
         public static ConsensusError InvalidCollateralAmountCommitmentTooNew => new ConsensusError("collateral-commitment-too-new", "collateral commitment too new");
+
+        public static ConsensusError InvalidCollateralAmountCommitmentTooOld => new ConsensusError("collateral-commitment-too-old", "collateral commitment too old");
     }
 }

--- a/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
@@ -39,12 +39,12 @@ namespace Stratis.Features.Collateral
             }
 
             // Check that the commitment height is not less that of the prior block.
-            int release1340ActivationHeight = 0;
+            int release1324ActivationHeight = 0;
             NodeDeployments nodeDeployments = this.Parent.NodeDeployments;
             if (nodeDeployments.BIP9.ArraySize > 0  /* Not NoBIP9Deployments */)
-                release1340ActivationHeight = nodeDeployments.BIP9.ActivationHeightProviders[1 /* Release1340 */].ActivationHeight;
+                release1324ActivationHeight = nodeDeployments.BIP9.ActivationHeightProviders[1 /* Release1324 */].ActivationHeight;
 
-            if (context.ValidationContext.ChainedHeaderToValidate.Height >= release1340ActivationHeight)
+            if (context.ValidationContext.ChainedHeaderToValidate.Height >= release1324ActivationHeight)
             {
                 ChainedHeader prevHeader = context.ValidationContext.ChainedHeaderToValidate.Previous;
                 if (prevHeader.BlockDataAvailability == BlockDataAvailabilityState.BlockAvailable)

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -33,6 +33,8 @@ namespace Stratis.Features.Collateral
         /// <returns><c>True</c> if the collateral requirement is fulfilled and <c>false</c> otherwise.</returns>
         bool CheckCollateral(IFederationMember federationMember, int heightToCheckAt, int localChainHeight);
 
+        Task UpdateCollateralInfoAsync(CancellationToken cancellation);
+
         int GetCounterChainConsensusHeight();
     }
 
@@ -163,7 +165,7 @@ namespace Stratis.Features.Collateral
             }
         }
 
-        private async Task UpdateCollateralInfoAsync(CancellationToken cancellation)
+        public async Task UpdateCollateralInfoAsync(CancellationToken cancellation)
         {
             List<string> addressesToCheck;
 

--- a/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
+++ b/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
@@ -81,8 +81,7 @@ namespace Stratis.Features.Collateral
             }
 
             // Check that the commitment height is not less that of the prior block.
-            ChainedHeader prevHeader = this.chainIndexer[blockTemplate.Block.Header.HashPrevBlock];
-            ChainedHeaderBlock prevBlock = this.consensusManager.GetBlockData(prevHeader.HashBlock);
+            ChainedHeaderBlock prevBlock = this.consensusManager.GetBlockData(blockTemplate.Block.Header.HashPrevBlock);
             (int? commitmentHeightPrev, _) = this.encoder.DecodeCommitmentHeight(prevBlock.Block.Transactions.First());
             if (commitmentHeight < commitmentHeightPrev)
             {

--- a/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
+++ b/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
@@ -83,6 +83,8 @@ namespace Stratis.Features.Collateral
             // Check that the commitment height is not less that of the prior block.
             ChainedHeaderBlock prevBlock = this.consensusManager.GetBlockData(blockTemplate.Block.Header.HashPrevBlock);
             (int? commitmentHeightPrev, _) = this.encoder.DecodeCommitmentHeight(prevBlock.Block.Transactions.First());
+            // If the intended commitment height is less than the previous block's commitment height, update our local
+            // counter chain height and try again.
             if (commitmentHeight < commitmentHeightPrev)
             {
                 this.collateralChecker.UpdateCollateralInfoAsync(this.cancellationSource.Token).GetAwaiter().GetResult();

--- a/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
+++ b/src/Stratis.Features.Collateral/CollateralPoAMiner.cs
@@ -92,7 +92,7 @@ namespace Stratis.Features.Collateral
                 if (commitmentHeight < commitmentHeightPrev)
                 {
                     dropTemplate = true;
-                    this.logger.LogWarning("Counter chain should first advance at least at {0}! Block can't be produced.", commitmentHeightPrev - commitmentHeight);
+                    this.logger.LogWarning("Block can't be produced, the counter chain should first advance at least {0} blocks. ", commitmentHeightPrev - commitmentHeight);
                     this.logger.LogTrace("(-)[LOW_COMMITMENT_HEIGHT]");
                     return;
                 }

--- a/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralCommitmentHeightRuleTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CheckCollateralCommitmentHeightRuleTests.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NBitcoin;
+using Stratis.Bitcoin.Base;
+using Stratis.Bitcoin.Base.Deployments;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Configuration.Logging;
+using Stratis.Bitcoin.Configuration.Settings;
+using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Consensus.Rules;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.Collateral;
+using Stratis.Features.PoA.Collateral;
+using Stratis.Sidechains.Networks;
+using Xunit;
+
+namespace Stratis.Features.FederatedPeg.Tests
+{
+    public class CheckCollateralCommitmentHeightRuleTests
+    {
+        private readonly CheckCollateralCommitmentHeightRule rule;
+        private readonly RuleContext ruleContext;
+        private readonly CollateralHeightCommitmentEncoder commitmentHeightEncoder;
+
+        private void EncodePreviousHeaderCommitmentHeight(int commitmentHeight)
+        {
+            // Setup previous block.
+            var encodedHeight = this.commitmentHeightEncoder.EncodeCommitmentHeight(commitmentHeight);
+            var commitmentHeightData = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(encodedHeight));
+
+            Block prevBlock = this.ruleContext.ValidationContext.ChainedHeaderToValidate.Previous.Block;
+            prevBlock.Transactions = new List<Transaction>();
+            prevBlock.AddTransaction(new Transaction());
+            prevBlock.Transactions[0].AddOutput(Money.Zero, commitmentHeightData);
+        }
+
+        public CheckCollateralCommitmentHeightRuleTests()
+        {
+            this.ruleContext = new RuleContext(new ValidationContext(), DateTimeOffset.Now);
+            var prevHeader = new BlockHeader { Time = 5200 };
+            var prevChainedHeader = new ChainedHeader(prevHeader, prevHeader.GetHash(), int.MaxValue - 1);
+            var prevBlock = new Block(prevHeader);
+            prevChainedHeader.Block = prevBlock;
+            prevChainedHeader.BlockDataAvailability = BlockDataAvailabilityState.BlockAvailable;
+            var header = new BlockHeader() { Time = 5234, HashPrevBlock = prevHeader.GetHash() };
+            this.ruleContext.ValidationContext.BlockToValidate = new Block(header);
+            this.ruleContext.ValidationContext.ChainedHeaderToValidate = new ChainedHeader(header, header.GetHash(), prevChainedHeader);
+
+            Block block = this.ruleContext.ValidationContext.BlockToValidate;
+            block.AddTransaction(new Transaction());
+
+            var loggerFactory = new ExtendedLoggerFactory();
+            ILogger logger = loggerFactory.CreateLogger(this.GetType().FullName);
+
+            this.commitmentHeightEncoder = new CollateralHeightCommitmentEncoder();
+
+            // Setup block.
+            byte[] encodedHeight = this.commitmentHeightEncoder.EncodeCommitmentHeight(1000);
+            var commitmentHeightData = new Script(OpcodeType.OP_RETURN, Op.GetPushOp(encodedHeight));
+            block.Transactions[0].AddOutput(Money.Zero, commitmentHeightData);
+
+            var network = new CirrusMain();
+            var chainIndexer = new ChainIndexer(network);
+
+            var consensusRules = new Mock<ConsensusRuleEngine>(
+                network,
+                loggerFactory,
+                new Mock<IDateTimeProvider>().Object,
+                chainIndexer,
+                new NodeDeployments(network, chainIndexer),
+                new ConsensusSettings(new NodeSettings(network)),
+                new Mock<ICheckpoints>().Object,
+                new Mock<IChainState>().Object,
+                new Mock<IInvalidBlockHashStore>().Object,
+                new Mock<INodeStats>().Object,
+                new ConsensusRulesContainer());
+
+            this.rule = new CheckCollateralCommitmentHeightRule()
+            {
+                Logger = logger,
+                Parent = consensusRules.Object
+            };
+
+            this.rule.Initialize();
+        }
+
+        [Fact]
+        public async Task PassesIfCollateralHeightsAreOrderedAsync()
+        {
+            EncodePreviousHeaderCommitmentHeight(999);
+            await this.rule.RunAsync(this.ruleContext);
+        }
+
+        [Fact]
+        public async Task FailsIfCollateralHeightsAreDisorderedAsync()
+        {
+            EncodePreviousHeaderCommitmentHeight(1001);
+            await Assert.ThrowsAsync<ConsensusErrorException>(() => this.rule.RunAsync(this.ruleContext));
+        }
+    }
+}

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -108,7 +108,7 @@ namespace Stratis.Sidechains.Networks
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
-                [CirrusBIP9Deployments.Release1340] = new BIP9DeploymentsParameters("Release1340", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -107,7 +107,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
+                [CirrusBIP9Deployments.Release1340] = new BIP9DeploymentsParameters("Release1340", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -199,7 +199,7 @@ namespace Stratis.Sidechains.Networks
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 8100 /* 75% Activation Threshold */),
-                [CirrusBIP9Deployments.Release1340] = new BIP9DeploymentsParameters("Release1340", CirrusBIP9Deployments.FlagBitRelease1340, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-3-1 +0").ToUnixTimestamp(), 8100 /* 75% Activation Threshold */)
+                [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1324, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-3-1 +0").ToUnixTimestamp(), 8100 /* 75% Activation Threshold */)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -198,7 +198,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 8100 /* 75% Activation Threshold */)
+                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 8100 /* 75% Activation Threshold */),
+                [CirrusBIP9Deployments.Release1340] = new BIP9DeploymentsParameters("Release1340", CirrusBIP9Deployments.FlagBitRelease1340, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-3-1 +0").ToUnixTimestamp(), 8100 /* 75% Activation Threshold */)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -127,7 +127,7 @@ namespace Stratis.Sidechains.Networks
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
-                [CirrusBIP9Deployments.Release1340] = new BIP9DeploymentsParameters("Release1340", CirrusBIP9Deployments.FlagBitRelease1340, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1324, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -126,7 +126,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
+                [CirrusBIP9Deployments.Release1340] = new BIP9DeploymentsParameters("Release1340", CirrusBIP9Deployments.FlagBitRelease1340, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -150,7 +150,7 @@ namespace Stratis.Sidechains.Networks
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
                 [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
-                [CirrusBIP9Deployments.Release1340] = new BIP9DeploymentsParameters("Release1340", CirrusBIP9Deployments.FlagBitRelease1340, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-3-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1324, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-3-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -149,7 +149,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
+                [CirrusBIP9Deployments.Release1340] = new BIP9DeploymentsParameters("Release1340", CirrusBIP9Deployments.FlagBitRelease1340, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-3-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
+++ b/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
@@ -9,10 +9,10 @@ namespace Stratis.Sidechains.Networks.Deployments
     {
         // The position of each deployment in the deployments array. Note that this is decoupled from the actual position of the flag bit for the deployment in the block version.
         public const int Release1320 = 0;
-        public const int Release1340 = 1;
+        public const int Release1324 = 1;
 
         public const int FlagBitRelease1320 = 1;
-        public const int FlagBitRelease1340 = 2;
+        public const int FlagBitRelease1324 = 2;
 
         // The number of deployments.
         public const int NumberOfDeployments = 2;

--- a/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
+++ b/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
@@ -9,11 +9,13 @@ namespace Stratis.Sidechains.Networks.Deployments
     {
         // The position of each deployment in the deployments array. Note that this is decoupled from the actual position of the flag bit for the deployment in the block version.
         public const int Release1320 = 0;
+        public const int Release1340 = 1;
 
         public const int FlagBitRelease1320 = 1;
+        public const int FlagBitRelease1340 = 2;
 
         // The number of deployments.
-        public const int NumberOfDeployments = 1;
+        public const int NumberOfDeployments = 2;
 
         /// <summary>
         /// Constructs the BIP9 deployments array.


### PR DESCRIPTION
This PR does the following:
1) When mining blocks it checks that the commitment height being encoded is greater or equal to the commitment height encoded for the preceding block.
2) In the `CheckCollateralCommitmentHeightRule` rule it checks that the commitment height encoded for each block is greater or equal to the commitment height of the preceding block.
3) Adds BIP9 activation for 2.