### PR TITLE
Fix GatewayPairStarts test-case

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/Controllers/BlockStoreController.cs
@@ -278,7 +278,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Controllers
         {
             try
             {
-                string[] addressesArray = addresses?.Split(',') ?? new string[] { };
+                string[] addressesArray = string.IsNullOrWhiteSpace(addresses) ? new string[] { } : addresses.Split(',');
 
                 this.logger.LogDebug("Asking data for {0} addresses.", addressesArray.Length);
 


### PR DESCRIPTION
This is PR #1070 cherry-picked for version `1.3.2.4`.

This PR fixes the fact that unlike `GET` the `POST` method treats an empty post body as an empty string and not as null.

This fix ensures that an empty string will result in an empty address list instead of an address list containing one empty string.

This issue appears to only affect this particular test case.