### PR TITLE
Fix GetBlockData

### DIFF
--- a/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
+++ b/src/Stratis.Bitcoin/Consensus/ConsensusManager.cs
@@ -1299,7 +1299,8 @@ namespace Stratis.Bitcoin.Consensus
 
                 for (int i = 0; i < blocks.Length; i++)
                 {
-                    ChainedHeaderBlock chainedHeaderBlock = blocks[i];
+                    // Create the chained header block from the chain indexer if required so that the block can still be picked up from the block store.
+                    ChainedHeaderBlock chainedHeaderBlock = blocks[i] ?? new ChainedHeaderBlock(null, this.chainIndexer[blockHashes[i]]);
                     chainedHeaderBlocks[blockHashes[i]] = chainedHeaderBlock;
                 }
             }


### PR DESCRIPTION
`GetBlockData` may currently fail to retrieve blocks if the `ChainedHeaderBlock` is not present in the `ChainedHeaderTree`.

This PR fixes that by also looking in the `ChainIndexer` (for the header) and subsequently the `BlockStore` (for the block).