### PR TITLE
Fix endianness of delete on rewind table

### DIFF
--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -165,8 +165,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             this.consensusManagerMock.Setup(x => x.GetBlocksAfterBlock(It.IsAny<ChainedHeader>(), It.IsAny<int>(), It.IsAny<CancellationTokenSource>())).Returns((ChainedHeader header, int size, CancellationTokenSource token) =>
             {
-                return headers.Select(h => GetChainedHeaderBlock(h.HashBlock)).ToArray();
-
+                return headers.Where(h => h.Height > header.Height).Select(h => GetChainedHeaderBlock(h.HashBlock)).ToArray();
             });
 
             this.consensusManagerMock.Setup(x => x.ConsensusRules).Returns(this.consensusRuleEngine);

--- a/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore.Tests/AddressIndexerTests.cs
@@ -1,15 +1,24 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using LiteDB;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
 using NBitcoin;
 using Stratis.Bitcoin.Configuration;
 using Stratis.Bitcoin.Consensus;
+using Stratis.Bitcoin.Consensus.Rules;
 using Stratis.Bitcoin.Controllers.Models;
+using Stratis.Bitcoin.Database;
 using Stratis.Bitcoin.Features.BlockStore.AddressIndexing;
+using Stratis.Bitcoin.Features.BlockStore.Repositories;
+using Stratis.Bitcoin.Features.Consensus.CoinViews;
+using Stratis.Bitcoin.Features.Consensus.Rules;
+using Stratis.Bitcoin.Features.Consensus.Rules.CommonRules;
+using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Networks;
 using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Tests.Common;
@@ -26,22 +35,33 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
         private readonly Mock<IConsensusManager> consensusManagerMock;
 
+        private readonly ChainIndexer chainIndexer;
+
         private readonly Network network;
+
+        private readonly IConsensusRuleEngine consensusRuleEngine;
 
         private readonly ChainedHeader genesisHeader;
 
         public AddressIndexerTests()
         {
             this.network = new StraxMain();
+            this.chainIndexer = new ChainIndexer(this.network);
+            var nodeSettings = new NodeSettings(this.network, args: new[] { "-addressindex", "-txindex" });
+
             var mockingServices = new ServiceCollection()
                 .AddSingleton(this.network)
-                .AddSingleton(new StoreSettings(NodeSettings.Default(this.network))
-                {
-                    AddressIndex = true,
-                    TxIndex = true
-                })
+                .AddSingleton(nodeSettings)
+                .AddSingleton(nodeSettings.LoggerFactory)
                 .AddSingleton(new DataFolder(TestBase.CreateTestDir(this)))
-                .AddSingleton(new ChainIndexer(this.network))
+                .AddSingleton<IScriptAddressReader, ScriptAddressReader>()
+                .AddSingleton<ConsensusRulesContainer>()
+                .AddSingleton<IConsensusRuleEngine, PosConsensusRuleEngine>()
+                .AddSingleton<IBlockRepository>(typeof(BlockRepository<LevelDb>).GetConstructors().First(c => c.GetParameters().Any(p => p.ParameterType == typeof(DataFolder))))
+                .AddSingleton<IBlockStore, BlockStoreQueue>()
+                .AddSingleton<ICoindb>(typeof(Coindb<LevelDb>).GetConstructors().First(c => c.GetParameters().Any(p => p.ParameterType == typeof(DataFolder))))
+                .AddSingleton<ICoinView, CachedCoinView>()
+                .AddSingleton(this.chainIndexer)
                 .AddSingleton<IDateTimeProvider, DateTimeProvider>()
                 .AddSingleton<IAddressIndexer, AddressIndexer>();
             
@@ -49,7 +69,15 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
 
             this.addressIndexer = mockingContext.GetService<IAddressIndexer>();
             this.genesisHeader = mockingContext.GetService<ChainIndexer>().GetHeader(0);
+
+            var rulesContainer = mockingContext.GetService<ConsensusRulesContainer>();
+            rulesContainer.FullValidationRules.Add(Activator.CreateInstance(typeof(LoadCoinviewRule)) as FullValidationConsensusRule);
+            rulesContainer.FullValidationRules.Add(Activator.CreateInstance(typeof(SaveCoinviewRule)) as FullValidationConsensusRule);
+            rulesContainer.FullValidationRules.Add(Activator.CreateInstance(typeof(StraxCoinviewRule)) as FullValidationConsensusRule);
+            rulesContainer.FullValidationRules.Add(Activator.CreateInstance(typeof(SetActivationDeploymentsFullValidationRule)) as FullValidationConsensusRule);
+
             this.consensusManagerMock = mockingContext.GetService<Mock<IConsensusManager>>();
+            this.consensusRuleEngine = mockingContext.GetService<IConsensusRuleEngine>();
         }
 
         [Fact]
@@ -64,7 +92,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
         [Fact]
         public void CanIndexAddresses()
         {
-            List<ChainedHeader> headers = ChainedHeadersHelper.CreateConsecutiveHeaders(100, null, false, null, this.network);
+            List<ChainedHeader> headers = ChainedHeadersHelper.CreateConsecutiveHeaders(100, null, false, null, this.network, chainIndexer: this.chainIndexer);
             this.consensusManagerMock.Setup(x => x.Tip).Returns(() => headers.Last());
 
             Script p2pk1 = this.GetRandomP2PKScript(out string address1);
@@ -106,7 +134,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             tx.Inputs.Add(new TxIn(new OutPoint(block5.Transactions.First().GetHash(), 0)));
             var block10 = new Block() { Transactions = new List<Transaction>() { tx } };
 
-            this.consensusManagerMock.Setup(x => x.GetBlockData(It.IsAny<uint256>())).Returns((uint256 hash) =>
+            ChainedHeaderBlock GetChainedHeaderBlock(uint256 hash)
             {
                 ChainedHeader header = headers.SingleOrDefault(x => x.HashBlock == hash);
 
@@ -123,8 +151,27 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
                 }
 
                 return new ChainedHeaderBlock(new Block(), header);
+            }
+
+            this.consensusManagerMock.Setup(x => x.GetBlockData(It.IsAny<uint256>())).Returns((uint256 hash) =>
+            {
+                return GetChainedHeaderBlock(hash);
             });
 
+            this.consensusManagerMock.Setup(x => x.GetBlockData(It.IsAny<List<uint256>>())).Returns((List<uint256> hashes) =>
+            {
+                return hashes.Select(h => GetChainedHeaderBlock(h)).ToArray();
+            });
+
+            this.consensusManagerMock.Setup(x => x.GetBlocksAfterBlock(It.IsAny<ChainedHeader>(), It.IsAny<int>(), It.IsAny<CancellationTokenSource>())).Returns((ChainedHeader header, int size, CancellationTokenSource token) =>
+            {
+                return headers.Select(h => GetChainedHeaderBlock(h.HashBlock)).ToArray();
+
+            });
+
+            this.consensusManagerMock.Setup(x => x.ConsensusRules).Returns(this.consensusRuleEngine);
+
+            this.consensusRuleEngine.Initialize(headers.Last(), this.consensusManagerMock.Object);
             this.addressIndexer.Initialize();
 
             TestBase.WaitLoop(() => this.addressIndexer.IndexerTip == headers.Last());
@@ -137,13 +184,18 @@ namespace Stratis.Bitcoin.Features.BlockStore.Tests
             // Now trigger rewind to see if indexer can handle reorgs.
             ChainedHeader forkPoint = headers.Single(x => x.Height == 8);
 
-            List<ChainedHeader> headersFork = ChainedHeadersHelper.CreateConsecutiveHeaders(100, forkPoint, false, null, this.network);
+            List<ChainedHeader> headersFork = ChainedHeadersHelper.CreateConsecutiveHeaders(100, forkPoint, false, null, this.network, chainIndexer: this.chainIndexer);
 
             this.consensusManagerMock.Setup(x => x.GetBlockData(It.IsAny<uint256>())).Returns((uint256 hash) =>
             {
                 ChainedHeader headerFork = headersFork.SingleOrDefault(x => x.HashBlock == hash);
 
                 return new ChainedHeaderBlock(new Block(), headerFork);
+            });
+
+            this.consensusManagerMock.Setup(x => x.GetBlocksAfterBlock(It.IsAny<ChainedHeader>(), It.IsAny<int>(), It.IsAny<CancellationTokenSource>())).Returns((ChainedHeader header, int size, CancellationTokenSource token) =>
+            {
+                return headersFork.Where(h => h.Height > header.Height).Select(h => new ChainedHeaderBlock(new Block(), h)).ToArray();
             });
 
             this.consensusManagerMock.Setup(x => x.Tip).Returns(() => headersFork.Last());

--- a/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
+++ b/src/Stratis.Bitcoin.Features.BlockStore/AddressIndexing/AddressIndexer.cs
@@ -291,7 +291,7 @@ namespace Stratis.Bitcoin.Features.BlockStore.AddressIndexing
                 if (prefetchedBlock != null && prefetchedBlock.ChainedHeader == nextHeader)
                     blockToProcess = prefetchedBlock.Block;
                 else
-                    blockToProcess = this.consensusManager.GetBlockData(nextHeader.HashBlock).Block;
+                    blockToProcess = this.consensusManager.GetBlockData(nextHeader.HashBlock)?.Block;
 
                 if (blockToProcess == null)
                 {

--- a/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/Coindb.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/CoinViews/Coindb/Coindb.cs
@@ -71,8 +71,6 @@ namespace Stratis.Bitcoin.Features.Consensus.CoinViews
             this.coinDb = new T();
             this.coinDb.Open(this.dataFolder);
 
-            EndiannessFix();
-
             EnsureCoinDatabaseIntegrity();
 
             Block genesis = this.network.GetGenesis();

--- a/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
+++ b/src/Stratis.Bitcoin.Features.Consensus/Rules/CommonRules/LoadCoinviewRule.cs
@@ -25,7 +25,6 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
             // unless the coinview threshold is reached.
             this.Logger.LogDebug("Saving coinview changes.");
             var utxoRuleContext = context as UtxoRuleContext;
-            this.PowParent.UtxoSet.Sync();
             this.PowParent.UtxoSet.SaveChanges(utxoRuleContext.UnspentOutputSet.GetCoins(), new HashHeightPair(oldBlock), new HashHeightPair(nextBlock));
 
             return Task.CompletedTask;
@@ -67,7 +66,7 @@ namespace Stratis.Bitcoin.Features.Consensus.Rules.CommonRules
         {
             // Check that the current block has not been reorged.
             // Catching a reorg at this point will not require a rewind.
-            if (context.ValidationContext.BlockToValidate.Header.HashPrevBlock != this.PowParent.UtxoSet.GetTipHash().Hash)
+            if (context.ValidationContext.ChainedHeaderToValidate.Previous.HashBlock != this.PowParent.UtxoSet.GetTipHash().Hash)
             {
                 this.Logger.LogDebug("Reorganization detected.");
                 ConsensusErrors.InvalidPrevTip.Throw();

--- a/src/Stratis.Bitcoin.IntegrationTests/NodeContext.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/NodeContext.cs
@@ -28,7 +28,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             this.FolderName = TestBase.CreateTestDir(caller, name);
             var dateTimeProvider = new DateTimeProvider();
             var serializer = new DBreezeSerializer(this.Network.Consensus.ConsensusFactory);
-            this.Coindb = new Coindb<LevelDb>(network, this.FolderName, dateTimeProvider, new NodeStats(dateTimeProvider, NodeSettings.Default(network), new Mock<IVersionProvider>().Object), serializer);
+            this.Coindb = new Coindb<LevelDb>(network, new DataFolder(this.FolderName), dateTimeProvider, new NodeStats(dateTimeProvider, NodeSettings.Default(network), new Mock<IVersionProvider>().Object), serializer);
             this.Coindb.Initialize();
             this.cleanList = new List<IDisposable> { (IDisposable)this.Coindb };
         }
@@ -66,7 +66,7 @@ namespace Stratis.Bitcoin.IntegrationTests
             this.cleanList.Remove((IDisposable)this.Coindb);
             var dateTimeProvider = new DateTimeProvider();
             var serializer = new DBreezeSerializer(this.Network.Consensus.ConsensusFactory);
-            this.Coindb = new Coindb<LevelDb>(this.Network, this.FolderName, dateTimeProvider, new NodeStats(dateTimeProvider, NodeSettings.Default(this.Network), new Mock<IVersionProvider>().Object), serializer);
+            this.Coindb = new Coindb<LevelDb>(this.Network, new DataFolder(this.FolderName), dateTimeProvider, new NodeStats(dateTimeProvider, NodeSettings.Default(this.Network), new Mock<IVersionProvider>().Object), serializer);
 
             this.Coindb.Initialize();
             this.cleanList.Add((IDisposable)this.Coindb);

--- a/src/Stratis.Bitcoin/Consensus/IConsensusRuleEngine.cs
+++ b/src/Stratis.Bitcoin/Consensus/IConsensusRuleEngine.cs
@@ -19,6 +19,7 @@ namespace Stratis.Bitcoin.Consensus
         /// Initialize the rules engine.
         /// </summary>
         /// <param name="chainTip">Last common header between chain repository and block store if it's available.
+        /// <param name="consensusManager">The consensus manager.</param>
         void Initialize(ChainedHeader chainTip, IConsensusManager consensusManager);
 
         /// <summary>

--- a/src/Stratis.Bitcoin/Database/ReadWriteBatch.cs
+++ b/src/Stratis.Bitcoin/Database/ReadWriteBatch.cs
@@ -41,7 +41,7 @@ namespace Stratis.Bitcoin.Database
         /// <param name="table">The table that will be updated.</param>
         /// <param name="key">The table key that identifies the value to be updated.</param>
         /// <param name="value">The value to be written to the table.</param>
-        /// <returns>This class for fluent operations.</returns>
+        /// <returns>This interface for fluent operations.</returns>
         public IDbBatch Put(byte table, byte[] key, byte[] value)
         {
             this.cache[new byte[] { table }.Concat(key).ToArray()] = value;

--- a/src/Stratis.Bitcoin/Database/ReadWriteBatch.cs
+++ b/src/Stratis.Bitcoin/Database/ReadWriteBatch.cs
@@ -1,0 +1,130 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+
+namespace Stratis.Bitcoin.Database
+{
+    /// <summary>
+    /// A batch that can be used to record changes that can be applied atomically.
+    /// </summary>
+    /// <remarks>The supplied <see cref="Get"/> method will immediately reflect any changes that have 
+    /// been made or retrieve the value from the underlying database. In contrast the database <see cref="IDb.Get"/> method
+    /// will only show the changes after the <see cref="Write"/> method is called.</remarks>
+    public class ReadWriteBatch : IDbBatch
+    {
+        private readonly IDb db;
+        private readonly IDbBatch batch;
+        private Dictionary<byte[], byte[]> cache;
+
+        public ReadWriteBatch(IDb db, params byte[] tables)
+        {
+            this.db = db;
+            this.batch = db.GetWriteBatch(tables);
+            this.cache = new Dictionary<byte[], byte[]>(new ByteArrayComparer());
+        }
+
+        /// <summary>
+        /// Records a value that will be written to the database when the <see cref="Write"/> method is invoked.
+        /// </summary>
+        /// <param name="key">The table key that identifies the value to be updated.</param>
+        /// <param name="value">The value to be written to the table.</param>
+        /// <returns>This class for fluent operations.</returns>
+        public IDbBatch Put(byte[] key, byte[] value)
+        {
+            this.cache[key] = value;
+            return this.batch.Put(key, value);
+        }
+
+        /// <summary>
+        /// Records a value that will be written to the database when the <see cref="Write"/> method is invoked.
+        /// </summary>
+        /// <param name="table">The table that will be updated.</param>
+        /// <param name="key">The table key that identifies the value to be updated.</param>
+        /// <param name="value">The value to be written to the table.</param>
+        /// <returns>This class for fluent operations.</returns>
+        public IDbBatch Put(byte table, byte[] key, byte[] value)
+        {
+            this.cache[new byte[] { table }.Concat(key).ToArray()] = value;
+            return this.batch.Put(table, key, value);
+        }
+
+        /// <summary>
+        /// Records a key that will be deleted from the database when the <see cref="Write"/> method is invoked.
+        /// </summary>
+        /// <param name="key">The table key that will be removed.</param>
+        /// <returns>This interface for fluent operations.</returns>
+        public IDbBatch Delete(byte[] key)
+        {
+            this.cache[key] = null;
+            return this.batch.Delete(key);
+        }
+
+        /// <summary>
+        /// Records a key that will be deleted from the database when the <see cref="Write"/> method is invoked.
+        /// </summary>
+        /// <param name="table">The table that will be updated.</param>
+        /// <param name="key">The table key that will be removed.</param>
+        /// <returns>This interface for fluent operations.</returns>
+        public IDbBatch Delete(byte table, byte[] key)
+        {
+            this.cache[new byte[] { table }.Concat(key).ToArray()] = null;
+            return this.batch.Delete(table, key);
+        }
+
+        /// <summary>
+        /// Returns any changes that have been made to the batch or retrieves the value from the underlying database..
+        /// </summary>
+        /// <param name="key">The table key of the value to retrieve.</param>
+        /// <returns>This interface for fluent operations.</returns>
+        public byte[] Get(byte[] key)
+        {
+            if (this.cache.TryGetValue(key, out byte[] value))
+                return value;
+
+            return this.db.Get(key);
+        }
+
+        /// <summary>
+        /// Returns any changes that have been made to the batch or retrieves the value from the underlying database..
+        /// </summary>
+        /// <param name="table">The table of the value to be retrieved.</param>
+        /// <param name="key">The table key of the value to retrieve.</param>
+        /// <returns>This interface for fluent operations.</returns>
+        public byte[] Get(byte table, byte[] key)
+        {
+            if (this.cache.TryGetValue(new byte[] { table }.Concat(key).ToArray(), out byte[] value))
+                return value;
+
+            return this.db.Get(table, key);
+        }
+
+        /// <summary>
+        /// Writes the recorded changes to the database.
+        /// </summary>
+        public void Write()
+        {
+            this.batch.Write();
+        }
+
+        public void Dispose()
+        {
+            this.batch.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Extension methods that build on the <see cref="IDb"/> interface.
+    /// </summary>
+    public static class IDbExt
+    {
+        /// <summary>
+        /// Gets a <see cref="ReadWriteBatch"/>.
+        /// </summary>
+        /// <param name="db">The database to get the batch for.</param>
+        /// <returns>The <see cref="ReadWriteBatch"/>.</returns>
+        public static ReadWriteBatch GetReadWriteBatch(this IDb db, params byte[] tables)
+        {
+            return new ReadWriteBatch(db, tables);
+        }
+    }
+}


### PR DESCRIPTION
This PR does the following:
- Fixes the endianness of the key used for the delete operation on the rewind table.
- Ensures that coin updates are visible in transaction context by using the new `ReadWriteBatch` (in `CoinDb`).
- Source blocks from `ConsensusManager` instead of `BlockStore` to fully leverage caching.
- Add ability to rebuild the `CoinView` directly from the blocks.
- Update the `AddressIndexer` tests to support the rebuilding.
- Refactor the `BinarySearch`  performed by the `CachedCoinView`'s `Sync` method.

This PR helps reduce the sizes of PR #1031 and PR #1053. It contains the changes not directly related to those PRs.
