### PR TITLE
Refactor WhitelistedHashesRepository

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA.Tests/VotingManagerTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/VotingManagerTests.cs
@@ -24,8 +24,8 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             this.changesApplied = new List<VotingData>();
             this.changesReverted = new List<VotingData>();
 
-            this.resultExecutorMock.Setup(x => x.ApplyChange(It.IsAny<VotingData>())).Callback((VotingData data) => this.changesApplied.Add(data));
-            this.resultExecutorMock.Setup(x => x.RevertChange(It.IsAny<VotingData>())).Callback((VotingData data) => this.changesReverted.Add(data));
+            this.resultExecutorMock.Setup(x => x.ApplyChange(It.IsAny<VotingData>(), It.IsAny<int>())).Callback((VotingData data, int _) => this.changesApplied.Add(data));
+            this.resultExecutorMock.Setup(x => x.RevertChange(It.IsAny<VotingData>(), It.IsAny<int>())).Callback((VotingData data, int _) => this.changesReverted.Add(data));
         }
 
         [Fact]

--- a/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAFeature.cs
@@ -137,7 +137,7 @@ namespace Stratis.Bitcoin.Features.PoA
             }
 
             this.federationManager.Initialize();
-            this.whitelistedHashesRepository.Initialize();
+            this.whitelistedHashesRepository.Initialize(this.votingManager);
 
             if (!this.votingManager.Synchronize(this.chainIndexer.Tip))
                 throw new System.OperationCanceledException();

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/PollResultExecutor.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/PollResultExecutor.cs
@@ -8,11 +8,13 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
     {
         /// <summary>Applies effect of <see cref="VotingData"/>.</summary>
         /// <param name="data">See <see cref="VotingData"/>.</param>
-        void ApplyChange(VotingData data);
+        /// <param name="executionHeight">The height from which the change should take effect.</param>
+        void ApplyChange(VotingData data, int executionHeight);
 
         /// <summary>Reverts effect of <see cref="VotingData"/>.</summary>
         /// <param name="data">See <see cref="VotingData"/>.</param>
-        void RevertChange(VotingData data);
+        /// <param name="executionHeight">The height from which the change should take effect.</param>
+        void RevertChange(VotingData data, int executionHeight);
 
         /// <summary>Converts <see cref="VotingData"/> to a human readable format.</summary>
         /// <param name="data">See <see cref="VotingData"/>.</param>
@@ -40,7 +42,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         }
 
         /// <inheritdoc />
-        public void ApplyChange(VotingData data)
+        public void ApplyChange(VotingData data, int executionHeight)
         {
             switch (data.Key)
             {
@@ -53,17 +55,17 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     break;
 
                 case VoteKey.WhitelistHash:
-                    this.AddHash(data.Data);
+                    this.AddHash(data.Data, executionHeight);
                     break;
 
                 case VoteKey.RemoveHash:
-                    this.RemoveHash(data.Data);
+                    this.RemoveHash(data.Data, executionHeight);
                     break;
             }
         }
 
         /// <inheritdoc />
-        public void RevertChange(VotingData data)
+        public void RevertChange(VotingData data, int executionHeight)
         {
             switch (data.Key)
             {
@@ -76,11 +78,11 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     break;
 
                 case VoteKey.WhitelistHash:
-                    this.RemoveHash(data.Data);
+                    this.RemoveHash(data.Data, executionHeight);
                     break;
 
                 case VoteKey.RemoveHash:
-                    this.AddHash(data.Data);
+                    this.AddHash(data.Data, executionHeight);
                     break;
             }
         }
@@ -118,13 +120,13 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             this.federationManager.RemoveFederationMember(federationMember);
         }
 
-        private void AddHash(byte[] hashBytes)
+        private void AddHash(byte[] hashBytes, int executionHeight)
         {
             try
             {
                 var hash = new uint256(hashBytes);
 
-                this.whitelistedHashesRepository.AddHash(hash);
+                this.whitelistedHashesRepository.AddHash(hash, executionHeight);
             }
             catch (FormatException e)
             {
@@ -132,13 +134,13 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
             }
         }
 
-        private void RemoveHash(byte[] hashBytes)
+        private void RemoveHash(byte[] hashBytes, int executionHeight)
         {
             try
             {
                 var hash = new uint256(hashBytes);
 
-                this.whitelistedHashesRepository.RemoveHash(hash);
+                this.whitelistedHashesRepository.RemoveHash(hash, executionHeight);
             }
             catch (FormatException e)
             {

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -547,7 +547,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                         else
                         {
                             this.logger.LogDebug("Applying poll '{0}'.", poll);
-                            this.pollResultExecutor.ApplyChange(poll.VotingData);
+                            this.pollResultExecutor.ApplyChange(poll.VotingData, chBlock.ChainedHeader.Height);
 
                             this.polls.AdjustPoll(poll, poll => poll.PollExecutedBlockData = new HashHeightPair(chBlock.ChainedHeader));
                             transaction.UpdatePoll(poll);
@@ -694,7 +694,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 foreach (Poll poll in this.polls.Where(x => !x.IsPending && x.PollExecutedBlockData?.Hash == chBlock.ChainedHeader.HashBlock).ToList())
                 {
                     this.logger.LogDebug("Reverting poll execution '{0}'.", poll);
-                    this.pollResultExecutor.RevertChange(poll.VotingData);
+                    this.pollResultExecutor.RevertChange(poll.VotingData, chBlock.ChainedHeader.Height);
 
                     this.polls.AdjustPoll(poll, poll => poll.PollExecutedBlockData = null);
                     transaction.UpdatePoll(poll);

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -531,9 +531,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                 {
                     this.signals.Publish(new VotingManagerProcessBlock(chBlock, transaction));
 
-                    bool pollsRepositoryModified = false;
-
-                    foreach (Poll poll in this.polls.GetPollsToExecuteOrExpire(chBlock.ChainedHeader.Height))
+                    foreach (Poll poll in this.polls.GetPollsToExecuteOrExpire(chBlock.ChainedHeader.Height).OrderBy(p => p.Id))
                     {
                         if (!poll.IsApproved)
                         {

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -689,7 +689,10 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         {
             lock (this.locker)
             {
-                foreach (Poll poll in this.polls.Where(x => !x.IsPending && x.PollExecutedBlockData?.Hash == chBlock.ChainedHeader.HashBlock).ToList())
+                foreach (Poll poll in this.polls
+                    .Where(x => !x.IsPending && x.PollExecutedBlockData?.Hash == chBlock.ChainedHeader.HashBlock)
+                    .OrderByDescending(p => p.Id)
+                    .ToList())
                 {
                     this.logger.LogDebug("Reverting poll execution '{0}'.", poll);
                     this.pollResultExecutor.RevertChange(poll.VotingData, chBlock.ChainedHeader.Height);
@@ -698,7 +701,10 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     transaction.UpdatePoll(poll);
                 }
 
-                foreach (Poll poll in this.polls.Where(x => x.IsExpired && !PollsRepository.IsPollExpiredAt(x, chBlock.ChainedHeader.Height - 1, this.network as PoANetwork)).ToList())
+                foreach (Poll poll in this.polls
+                    .Where(x => x.IsExpired && !PollsRepository.IsPollExpiredAt(x, chBlock.ChainedHeader.Height - 1, this.network as PoANetwork))
+                    .OrderByDescending(p => p.Id)
+                    .ToList())
                 {
                     this.logger.LogDebug("Reverting poll expiry '{0}'.", poll);
 

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/WhitelistedHashesRepository.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/WhitelistedHashesRepository.cs
@@ -19,12 +19,12 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
         // Dictionary of hash histories. Even list entries are additions and odd entries are removals.
         private Dictionary<uint256, int[]> whitelistedHashes;
 
-        public WhitelistedHashesRepository(ILoggerFactory loggerFactory, PoAConsensusOptions poaConsensusOptions)
+        public WhitelistedHashesRepository(ILoggerFactory loggerFactory, Network network)
         {
             this.locker = new object();
 
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
-            this.poaConsensusOptions = poaConsensusOptions;
+            this.poaConsensusOptions = network.Consensus.Options as PoAConsensusOptions;
         }
 
         private void GetWhitelistedHashesFromExecutedPolls(VotingManager votingManager)

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/WhitelistedHashesRepository.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/WhitelistedHashesRepository.cs
@@ -42,7 +42,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                     {
                         this.AddHash(hash, poll.PollExecutedBlockData.Height);
                     }
-                    else if (poll.VotingData.Key == VoteKey.KickFederationMember)
+                    else if (poll.VotingData.Key == VoteKey.RemoveHash)
                     {
                         this.RemoveHash(hash, poll.PollExecutedBlockData.Height);
                     }

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/WhitelistedHashesRepository.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/WhitelistedHashesRepository.cs
@@ -1,93 +1,149 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 using NBitcoin;
-using Stratis.Bitcoin.Persistence;
+using Stratis.Bitcoin.Utilities;
 
 namespace Stratis.Bitcoin.Features.PoA.Voting
 {
     public class WhitelistedHashesRepository : IWhitelistedHashesRepository
     {
-        private const string dbKey = "hashesList";
-
-        private readonly IKeyValueRepository kvRepository;
-
         /// <summary>Protects access to <see cref="whitelistedHashes"/>.</summary>
         private readonly object locker;
 
         private readonly ILogger logger;
 
-        private List<uint256> whitelistedHashes;
+        private readonly PoAConsensusOptions poaConsensusOptions;
 
-        public WhitelistedHashesRepository(ILoggerFactory loggerFactory, IKeyValueRepository kvRepository)
+        // Dictionary of hash histories. Even list entries are additions and odd entries are removals.
+        private Dictionary<uint256, int[]> whitelistedHashes;
+
+        public WhitelistedHashesRepository(ILoggerFactory loggerFactory, PoAConsensusOptions poaConsensusOptions)
         {
-            this.kvRepository = kvRepository;
             this.locker = new object();
 
             this.logger = loggerFactory.CreateLogger(this.GetType().FullName);
-
-            // Load this before initialize to ensure its available to when the Mempool feature initializes.
-            lock (this.locker)
-            {
-                this.whitelistedHashes = this.kvRepository.LoadValueJson<List<uint256>>(dbKey) ?? new List<uint256>();
-            }
+            this.poaConsensusOptions = poaConsensusOptions;
         }
 
-        public void Initialize()
-        {
-        }
-
-        private void SaveHashes()
+        private void GetWhitelistedHashesFromExecutedPolls(VotingManager votingManager)
         {
             lock (this.locker)
             {
-                this.kvRepository.SaveValueJson(dbKey, this.whitelistedHashes);
-            }
-        }
+                var federation = new List<IFederationMember>(this.poaConsensusOptions.GenesisFederationMembers);
 
-        public void AddHash(uint256 hash)
-        {
-            lock (this.locker)
-            {
-                if (this.whitelistedHashes.Contains(hash))
+                IEnumerable<Poll> executedPolls = votingManager.GetExecutedPolls().WhitelistPolls();
+                foreach (Poll poll in executedPolls.OrderBy(a => a.PollExecutedBlockData.Height))
                 {
-                    this.logger.LogTrace("(-)[ALREADY_EXISTS]");
+                    var hash = new uint256(poll.VotingData.Data);
+
+                    if (poll.VotingData.Key == VoteKey.WhitelistHash)
+                    {
+                        this.AddHash(hash, poll.PollExecutedBlockData.Height);
+                    }
+                    else if (poll.VotingData.Key == VoteKey.KickFederationMember)
+                    {
+                        this.RemoveHash(hash, poll.PollExecutedBlockData.Height);
+                    }
+                }
+            }
+        }
+
+        public void Initialize(VotingManager votingManager)
+        {
+            // TODO: Must call Initialize before the Mempool rules try to use this class.
+            lock (this.locker)
+            {
+                this.whitelistedHashes = new Dictionary<uint256, int[]>();
+                this.GetWhitelistedHashesFromExecutedPolls(votingManager);
+            }
+        }
+
+        public void AddHash(uint256 hash, int executionHeight)
+        {
+            lock (this.locker)
+            {
+                // Retrieve the whitelist history for this hash.
+                if (!this.whitelistedHashes.TryGetValue(hash, out int[] history))
+                {
+                    this.whitelistedHashes[hash] = new int[] { executionHeight };
                     return;
                 }
 
-                this.whitelistedHashes.Add(hash);
+                // Keep all history up to and including the executionHeight.
+                int keep = BinarySearch.BinaryFindFirst((k) => k == history.Length || history[k] > executionHeight, 0, history.Length + 1);
+                Array.Resize(ref history, keep | 1);
+                this.whitelistedHashes[hash] = history;
 
-                this.SaveHashes();
+                // If the history is an even length then add the addition height to signify addition.
+                if ((keep % 2) == 0)
+                {
+                    // Add an even indexed entry to signify an addition.
+                    history[keep] = executionHeight;
+                    return;
+                }
+
+                this.logger.LogTrace("(-)[HASH_ALREADY_EXISTS]");
+                return;
             }
         }
 
-        public void RemoveHash(uint256 hash)
+        public void RemoveHash(uint256 hash, int executionHeight)
         {
             lock (this.locker)
             {
-                bool removed = this.whitelistedHashes.Remove(hash);
+                // Retrieve the whitelist history for this hash.
+                if (this.whitelistedHashes.TryGetValue(hash, out int[] history))
+                {
+                    // Keep all history up to and including the executionHeight.
+                    int keep = BinarySearch.BinaryFindFirst((k) => k == history.Length || history[k] >= executionHeight, 0, history.Length + 1);
+                    Array.Resize(ref history, (keep + 1) & ~1);
+                    this.whitelistedHashes[hash] = history;
 
-                if (removed)
-                    this.SaveHashes();
+                    // If the history is an odd length then add the removal height to signify removal.
+                    if ((keep % 2) != 0)
+                    {
+                        history[keep] = executionHeight;
+                        return;
+                    }
+                }
+
+                this.logger.LogTrace("(-)[HASH_DOESNT_EXIST]");
+                return;
             }
         }
 
-        public List<uint256> GetHashes()
+        private bool ExistsHash(uint256 hash, int blockHeight)
         {
             lock (this.locker)
             {
-                return new List<uint256>(this.whitelistedHashes);
+                // Retrieve the whitelist history for this hash.
+                if (!this.whitelistedHashes.TryGetValue(hash, out int[] history))
+                    return false;
+
+                int keep = BinarySearch.BinaryFindFirst((k) => k == history.Length || history[k] > blockHeight, 0, history.Length + 1);
+                return (keep % 2) != 0;
+            }
+        }
+
+        public List<uint256> GetHashes(int blockHeight = int.MaxValue)
+        {
+            lock (this.locker)
+            {
+                return this.whitelistedHashes.Where(k => ExistsHash(k.Key, blockHeight)).Select(k => k.Key).ToList();
             }
         }
     }
 
     public interface IWhitelistedHashesRepository
     {
-        void AddHash(uint256 hash);
+        void AddHash(uint256 hash, int executionHeight);
 
-        void RemoveHash(uint256 hash);
+        void RemoveHash(uint256 hash, int executionHeight);
 
-        List<uint256> GetHashes();
+        List<uint256> GetHashes(int blockHeight = int.MaxValue);
 
-        void Initialize();
+        void Initialize(VotingManager votingManager);
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/AllowedCodeHashLogicTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/Consensus/Rules/AllowedCodeHashLogicTests.cs
@@ -30,15 +30,15 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             byte[] hash = HashHelper.Keccak256(code);
 
             this.hashingStrategy.Setup(h => h.Hash(code)).Returns(hash);
-            this.hashChecker.Setup(h => h.CheckHashWhitelisted(hash)).Returns(true);
+            this.hashChecker.Setup(h => h.CheckHashWhitelisted(hash, 0)).Returns(true);
 
-            var tx = new ContractTxData(1, 1000, (Gas) 10000, code);
+            var tx = new ContractTxData(1, 1000, (Gas)10000, code);
 
             var sut = new AllowedCodeHashLogic(this.hashChecker.Object, this.hashingStrategy.Object);
 
             sut.CheckContractTransaction(tx, 0);
 
-            this.hashChecker.Verify(h => h.CheckHashWhitelisted(hash), Times.Once);
+            this.hashChecker.Verify(h => h.CheckHashWhitelisted(hash, 0), Times.Once);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             byte[] hash = HashHelper.Keccak256(code);
 
             this.hashingStrategy.Setup(h => h.Hash(code)).Returns(hash);
-            this.hashChecker.Setup(h => h.CheckHashWhitelisted(hash)).Returns(false);
+            this.hashChecker.Setup(h => h.CheckHashWhitelisted(hash, 0)).Returns(false);
 
             var sut = new AllowedCodeHashLogic(this.hashChecker.Object, this.hashingStrategy.Object);
 
@@ -57,7 +57,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
 
             Assert.Throws<ConsensusErrorException>(() => sut.CheckContractTransaction(tx, 0));
 
-            this.hashChecker.Verify(h => h.CheckHashWhitelisted(hash), Times.Once);
+            this.hashChecker.Verify(h => h.CheckHashWhitelisted(hash, 0), Times.Once);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests.Consensus.Rules
             sut.CheckContractTransaction(callTx, 0);
 
             this.hashingStrategy.Verify(h => h.Hash(It.IsAny<byte[]>()), Times.Never);
-            this.hashChecker.Verify(h => h.CheckHashWhitelisted(It.IsAny<byte[]>()), Times.Never);
+            this.hashChecker.Verify(h => h.CheckHashWhitelisted(It.IsAny<byte[]>(), It.IsAny<int>()), Times.Never);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/WhitelistHashCheckerTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/WhitelistHashCheckerTests.cs
@@ -16,11 +16,11 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             var repository = new Mock<IWhitelistedHashesRepository>();
 
-            repository.Setup(r => r.GetHashes()).Returns(new List<uint256>());
+            repository.Setup(r => r.GetHashes(It.IsAny<int>())).Returns(new List<uint256>());
 
             var strategy = new WhitelistedHashChecker(repository.Object);
 
-            Assert.False(strategy.CheckHashWhitelisted(hash));
+            Assert.False(strategy.CheckHashWhitelisted(hash, 0));
         }
 
         [Fact]
@@ -30,11 +30,11 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
 
             var repository = new Mock<IWhitelistedHashesRepository>();
 
-            repository.Setup(r => r.GetHashes()).Returns(new List<uint256> { new uint256(hash) });
+            repository.Setup(r => r.GetHashes(It.IsAny<int>())).Returns(new List<uint256> { new uint256(hash) });
 
             var strategy = new WhitelistedHashChecker(repository.Object);
 
-            Assert.True(strategy.CheckHashWhitelisted(hash));
+            Assert.True(strategy.CheckHashWhitelisted(hash, 0));
         }
 
         [Fact]
@@ -42,14 +42,14 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         {
             var repository = new Mock<IWhitelistedHashesRepository>();
 
-            repository.Setup(r => r.GetHashes()).Returns(new List<uint256>());
+            repository.Setup(r => r.GetHashes(It.IsAny<int>())).Returns(new List<uint256>());
 
             var strategy = new WhitelistedHashChecker(repository.Object);
 
             // uint256 must be 256 bytes wide
             var invalidUint256Bytes = new byte[] { };
 
-            Assert.False(strategy.CheckHashWhitelisted(invalidUint256Bytes));
+            Assert.False(strategy.CheckHashWhitelisted(invalidUint256Bytes, 0));
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/AllowedCodeHashLogic.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/Rules/AllowedCodeHashLogic.cs
@@ -27,7 +27,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA.Rules
 
             byte[] hashedCode = this.hashingStrategy.Hash(txData.ContractExecutionCode);
 
-            if (!this.whitelistedHashChecker.CheckHashWhitelisted(hashedCode))
+            if (!this.whitelistedHashChecker.CheckHashWhitelisted(hashedCode, blockHeight))
             {
                 ThrowInvalidCode();
             }

--- a/src/Stratis.Bitcoin.Features.SmartContracts/PoA/WhitelistedHashChecker.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/PoA/WhitelistedHashChecker.cs
@@ -21,7 +21,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA
         /// </summary>
         /// <param name="hash">The bytes of the hash to check.</param>
         /// <returns>True if the hash was found in the whitelisted hashes repository.</returns>
-        public bool CheckHashWhitelisted(byte[] hash)
+        public bool CheckHashWhitelisted(byte[] hash, int blockHeight)
         {
             if (hash.Length != 32)
             {
@@ -29,7 +29,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA
                 return false;
             }
 
-            List<uint256> allowedHashes = this.whitelistedHashesRepository.GetHashes();
+            List<uint256> allowedHashes = this.whitelistedHashesRepository.GetHashes(blockHeight);
 
             // Now that we've checked the width of the byte array, we don't expect the uint256 constructor to throw any exceptions.
             var hash256 = new uint256(hash);
@@ -40,6 +40,6 @@ namespace Stratis.Bitcoin.Features.SmartContracts.PoA
 
     public interface IWhitelistedHashChecker
     {
-        bool CheckHashWhitelisted(byte[] hash);
+        bool CheckHashWhitelisted(byte[] hash, int blockHeight);
     }
 }

--- a/src/Stratis.SmartContracts.IntegrationTests/WhitelistNodeExtensions.cs
+++ b/src/Stratis.SmartContracts.IntegrationTests/WhitelistNodeExtensions.cs
@@ -15,7 +15,7 @@ namespace Stratis.SmartContracts.IntegrationTests
             {
                 var hasher = node.CoreNode.FullNode.NodeService<IContractCodeHashingStrategy>();
                 var hash = new uint256(hasher.Hash(code));
-                node.CoreNode.FullNode.NodeService<IWhitelistedHashesRepository>().AddHash(hash);
+                node.CoreNode.FullNode.NodeService<IWhitelistedHashesRepository>().AddHash(hash, 0);
             }
         }
 


### PR DESCRIPTION
This repository is fairly loose wrt tracking its own "tip" - i.e. the information in the repository is ill-defined as to how up-to-date it is wrt which tip. It is not capable of rewind on start-up despite scenarios where the other components may be rewinding. 

After the overhaul we re-build, the now in-memory repo, from a potentially rewound polls repository on startup. 

Some feature we now have with the new repository:
- a detailed and exact history of when hashes were active due to qualifying existence checks with height parameters. 
- the ability to register hashes (with their activation height) even before they become active which will assist in future performance improvements (e.g. PR #933).
