### PR TITLE
Clean-up activation heights

### DIFF
--- a/src/NBitcoin/BuriedDeploymentsArray.cs
+++ b/src/NBitcoin/BuriedDeploymentsArray.cs
@@ -4,17 +4,25 @@ namespace NBitcoin
 {
     public class BuriedDeploymentsArray
     {
-        private readonly int[] heights;
+        protected int[] heights;
 
         public BuriedDeploymentsArray()
         {
-            this.heights = new int[Enum.GetValues(typeof(BuriedDeployments)).Length];
+            this.heights = new int[0];
+        }
+
+        protected int EnsureIndex(int index)
+        {
+            if (index >= this.heights.Length)
+                Array.Resize(ref this.heights, index + 1);
+            
+            return index;
         }
 
         public int this[BuriedDeployments index]
         {
-            get => this.heights[(int)index];
-            set => this.heights[(int)index] = value;
+            get => this.heights[EnsureIndex((int)index)];
+            set => this.heights[EnsureIndex((int)index)] = value;
         }
     }
 

--- a/src/NBitcoin/BuriedDeploymentsArray.cs
+++ b/src/NBitcoin/BuriedDeploymentsArray.cs
@@ -11,18 +11,16 @@ namespace NBitcoin
             this.heights = new int[0];
         }
 
-        protected int EnsureIndex(int index)
+        protected void EnsureIndex(int index)
         {
             if (index >= this.heights.Length)
                 Array.Resize(ref this.heights, index + 1);
-            
-            return index;
         }
 
         public int this[BuriedDeployments index]
         {
-            get => this.heights[EnsureIndex((int)index)];
-            set => this.heights[EnsureIndex((int)index)] = value;
+            get { EnsureIndex((int)index); return this.heights[(int)index]; }
+            set { EnsureIndex((int)index); this.heights[(int)index] = value; }
         }
     }
 

--- a/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/TestPoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.IntegrationTests.Common/TestPoANetwork.cs
@@ -48,6 +48,7 @@ namespace Stratis.Bitcoin.Features.PoA.IntegrationTests.Common
                 targetSpacingSeconds: 60,
                 votingEnabled: baseOptions.VotingEnabled,
                 autoKickIdleMembers: false,
+                contractSerializerV2ActivationHeight: 0,
                 federationMemberMaxIdleTimeSeconds: baseOptions.FederationMemberMaxIdleTimeSeconds
             )
             {

--- a/src/Stratis.Bitcoin.Features.PoA.IntegrationTests/EnableVoteKickingTests.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.IntegrationTests/EnableVoteKickingTests.cs
@@ -32,6 +32,7 @@ namespace Stratis.Bitcoin.Features.PoA.IntegrationTests
                     targetSpacingSeconds: 60,
                     votingEnabled: true,
                     autoKickIdleMembers: false,
+                    contractSerializerV2ActivationHeight: 0,
                     federationMemberMaxIdleTimeSeconds: oldOptions.FederationMemberMaxIdleTimeSeconds);
 
                 CoreNode node1 = builder.CreatePoANode(votingNetwork1, votingNetwork1.FederationKey1).Start();
@@ -54,6 +55,7 @@ namespace Stratis.Bitcoin.Features.PoA.IntegrationTests
                     targetSpacingSeconds: 60,
                     votingEnabled: true,
                     autoKickIdleMembers: true,
+                    contractSerializerV2ActivationHeight: 0,
                     federationMemberMaxIdleTimeSeconds: idleTimeSeconds);
 
                 // Restart node 1 to ensure that we have the new network consensus options which reflects

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -189,14 +189,14 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
                 targetSpacingSeconds: 60,
                 votingEnabled: baseOptions.VotingEnabled,
                 autoKickIdleMembers: baseOptions.AutoKickIdleMembers,
+                contractSerializerV2ActivationHeight: 0,
                 federationMemberMaxIdleTimeSeconds: baseOptions.FederationMemberMaxIdleTimeSeconds
             )
             {
                 PollExpiryBlocks = 10
             };
 
-            var activationHeights = ((PoAConsensusOptions)this.Consensus.Options).ActivationHeights;
-            activationHeights[(int)PoAActivationHeights.Release1100] = 10;
+            ((PoABuriedDeploymentsArray)this.Consensus)[PoABuriedDeployments.Release1100] = 10;
 
             this.Consensus.SetPrivatePropertyValue(nameof(this.Consensus.MaxReorgLength), (uint)5);
         }

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -193,7 +193,7 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
             )
             {
                 PollExpiryBlocks = 10,
-                Release1100ActivationHeight = 10
+                ActivationHeights = { [(int)PoAActivationHeights.Release1100] = 10 }
             };
 
             this.Consensus.SetPrivatePropertyValue(nameof(this.Consensus.MaxReorgLength), (uint)5);

--- a/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
+++ b/src/Stratis.Bitcoin.Features.PoA.Tests/PoATestsBase.cs
@@ -192,9 +192,11 @@ namespace Stratis.Bitcoin.Features.PoA.Tests
                 federationMemberMaxIdleTimeSeconds: baseOptions.FederationMemberMaxIdleTimeSeconds
             )
             {
-                PollExpiryBlocks = 10,
-                ActivationHeights = { [(int)PoAActivationHeights.Release1100] = 10 }
+                PollExpiryBlocks = 10
             };
+
+            var activationHeights = ((PoAConsensusOptions)this.Consensus.Options).ActivationHeights;
+            activationHeights[(int)PoAActivationHeights.Release1100] = 10;
 
             this.Consensus.SetPrivatePropertyValue(nameof(this.Consensus.MaxReorgLength), (uint)5);
         }

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -75,7 +75,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 PoAConsensusErrors.InvalidHeaderSignature.Throw();
             }
 
-            if (chainedHeader.Height >= this.consensus.CirrusBuriedDeployments(CirrusBuriedDeployments.GetMiningTimestampV2Strict))
+            if (chainedHeader.Height >= this.consensus.PoABuriedDeployments(PoABuriedDeployments.GetMiningTimestampV2Strict))
             {
                 uint expectedSlot = this.slotsManager.GetMiningTimestamp(chainedHeader.Previous, chainedHeader.Header.Time, pubKey);
 

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -24,7 +24,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
 
         private HashHeightPair lastCheckPoint;
 
-        private PoAConsensusOptions poAConsensusOptions;
+        private IConsensus consensus;
 
         /// <inheritdoc />
         public override void Initialize()
@@ -37,7 +37,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
             this.slotsManager = engine.SlotsManager;
             this.federationHistory = engine.FederationHistory;
             this.validator = engine.PoaHeaderValidator;
-            this.poAConsensusOptions = engine.Network.Consensus.Options as PoAConsensusOptions;
+            this.consensus = engine.Network.Consensus;
 
             KeyValuePair<int, CheckpointInfo> lastCheckPoint = engine.Network.Checkpoints.LastOrDefault();
             this.lastCheckPoint = (lastCheckPoint.Value != null) ? new HashHeightPair(lastCheckPoint.Value.Hash, lastCheckPoint.Key) : null;
@@ -75,7 +75,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 PoAConsensusErrors.InvalidHeaderSignature.Throw();
             }
 
-            if (chainedHeader.Height >= this.poAConsensusOptions.ActivationHeights[(int)PoAActivationHeights.GetMiningTimestampV2Strict])
+            if (chainedHeader.Height >= this.consensus.CirrusBuriedDeployments(CirrusBuriedDeployments.GetMiningTimestampV2Strict))
             {
                 uint expectedSlot = this.slotsManager.GetMiningTimestamp(chainedHeader.Previous, chainedHeader.Header.Time, pubKey);
 

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -75,7 +75,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 PoAConsensusErrors.InvalidHeaderSignature.Throw();
             }
 
-            if (chainedHeader.Height >= this.poAConsensusOptions.ActivationHeights[(int)PoAActivationHeights.GetMiningTimestampV2])
+            if (chainedHeader.Height >= this.poAConsensusOptions.ActivationHeights[(int)PoAActivationHeights.GetMiningTimestampV2Strict])
             {
                 uint expectedSlot = this.slotsManager.GetMiningTimestamp(chainedHeader.Previous, chainedHeader.Header.Time, pubKey);
 

--- a/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/BasePoAFeatureConsensusRules/PoAHeaderSignatureRule.cs
@@ -75,7 +75,7 @@ namespace Stratis.Bitcoin.Features.PoA.BasePoAFeatureConsensusRules
                 PoAConsensusErrors.InvalidHeaderSignature.Throw();
             }
 
-            if (chainedHeader.Height >= this.poAConsensusOptions.GetMiningTimestampV2ActivationStrictHeight)
+            if (chainedHeader.Height >= this.poAConsensusOptions.ActivationHeights[(int)PoAActivationHeights.GetMiningTimestampV2])
             {
                 uint expectedSlot = this.slotsManager.GetMiningTimestamp(chainedHeader.Previous, chainedHeader.Header.Time, pubKey);
 

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -173,7 +173,7 @@ namespace Stratis.Bitcoin.Features.PoA
             IFederationMember[] miners = new IFederationMember[headers.Length];
 
             // Reading chainedHeader's "Header" does not play well with asynchronocity so we will load the block times here.
-            int votingManagerV2ActivationHeight = (this.network.Consensus.Options as PoAConsensusOptions).ActivationHeights[(int)PoAActivationHeights.VotingManagerV2];
+            int votingManagerV2ActivationHeight = this.network.Consensus.CirrusBuriedDeployments(CirrusBuriedDeployments.VotingManagerV2);
 
             int startHeight = lastHeader.Height + 1 - count;
 

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -173,7 +173,7 @@ namespace Stratis.Bitcoin.Features.PoA
             IFederationMember[] miners = new IFederationMember[headers.Length];
 
             // Reading chainedHeader's "Header" does not play well with asynchronocity so we will load the block times here.
-            int votingManagerV2ActivationHeight = (this.network.Consensus.Options as PoAConsensusOptions).VotingManagerV2ActivationHeight;
+            int votingManagerV2ActivationHeight = (this.network.Consensus.Options as PoAConsensusOptions).ActivationHeights[(int)PoAActivationHeights.VotingManagerV2];
 
             int startHeight = lastHeader.Height + 1 - count;
 

--- a/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/FederationHistory.cs
@@ -173,7 +173,7 @@ namespace Stratis.Bitcoin.Features.PoA
             IFederationMember[] miners = new IFederationMember[headers.Length];
 
             // Reading chainedHeader's "Header" does not play well with asynchronocity so we will load the block times here.
-            int votingManagerV2ActivationHeight = this.network.Consensus.CirrusBuriedDeployments(CirrusBuriedDeployments.VotingManagerV2);
+            int votingManagerV2ActivationHeight = this.network.Consensus.PoABuriedDeployments(PoABuriedDeployments.VotingManagerV2);
 
             int startHeight = lastHeader.Height + 1 - count;
 

--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
@@ -5,7 +5,7 @@ using NBitcoin;
 
 namespace Stratis.Bitcoin.Features.PoA
 {
-    public enum CirrusBuriedDeployments
+    public enum PoABuriedDeployments
     {
         /// <summary>
         /// This is the height on the main chain at which the dynamic fees paid to the multsig for interop conversion requests will activate.

--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
@@ -110,6 +110,10 @@ namespace Stratis.Bitcoin.Features.PoA
         /// </summary>
         public int PollExpiryBlocks { get; set; }
 
+        /// <summary>
+        /// Leaving this for now for use by Stratis.SmartContracts.CLR.
+        /// </summary>
+        public int ContractSerializerV2ActivationHeight => this.ActivationHeights[(int)PoAActivationHeights.ContractSerializerV2];
 
         public int[] ActivationHeights { get; set; }
 

--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
@@ -5,7 +5,7 @@ using NBitcoin;
 
 namespace Stratis.Bitcoin.Features.PoA
 {
-    public enum PoAActivationHeights
+    public enum CirrusBuriedDeployments
     {
         /// <summary>
         /// This is the height on the main chain at which the dynamic fees paid to the multsig for interop conversion requests will activate.
@@ -113,9 +113,7 @@ namespace Stratis.Bitcoin.Features.PoA
         /// <summary>
         /// Leaving this for now for use by Stratis.SmartContracts.CLR.
         /// </summary>
-        public int ContractSerializerV2ActivationHeight => this.ActivationHeights[(int)PoAActivationHeights.ContractSerializerV2];
-
-        public int[] ActivationHeights { get; set; }
+        public int ContractSerializerV2ActivationHeight { get; set; }
 
         /// <summary>Initializes values for networks that use block size rules.</summary>
         /// <param name="maxBlockBaseSize">See <see cref="ConsensusOptions.MaxBlockBaseSize"/>.</param>
@@ -128,6 +126,7 @@ namespace Stratis.Bitcoin.Features.PoA
         /// <param name="votingEnabled">See <see cref="VotingEnabled"/>.</param>
         /// <param name="autoKickIdleMembers">See <see cref="AutoKickIdleMembers"/>.</param>
         /// <param name="federationMemberMaxIdleTimeSeconds">See <see cref="FederationMemberMaxIdleTimeSeconds"/>.</param>
+        /// <param name="contractSerializerV2ActivationHeight">See <see cref="ContractSerializerV2ActivationHeight"/>.</param>
         public PoAConsensusOptions(
             uint maxBlockBaseSize,
             int maxStandardVersion,
@@ -138,6 +137,7 @@ namespace Stratis.Bitcoin.Features.PoA
             uint targetSpacingSeconds,
             bool votingEnabled,
             bool autoKickIdleMembers,
+            int contractSerializerV2ActivationHeight,
             uint federationMemberMaxIdleTimeSeconds = 60 * 60 * 24 * 7)
                 : base(maxBlockBaseSize, maxStandardVersion, maxStandardTxWeight, maxBlockSigopsCost, maxStandardTxSigopsCost, witnessScaleFactor: 1)
         {
@@ -146,8 +146,7 @@ namespace Stratis.Bitcoin.Features.PoA
             this.VotingEnabled = votingEnabled;
             this.AutoKickIdleMembers = autoKickIdleMembers;
             this.FederationMemberMaxIdleTimeSeconds = federationMemberMaxIdleTimeSeconds;
-            this.ActivationHeights = new int[((int[])typeof(PoAActivationHeights).GetEnumValues()).Max() + 1];
-            this.ActivationHeights[(int)PoAActivationHeights.InterFluxV2MainChain] = 0;
+            this.ContractSerializerV2ActivationHeight = contractSerializerV2ActivationHeight;
 
             if (this.AutoKickIdleMembers && !this.VotingEnabled)
                 throw new ArgumentException("Voting should be enabled for automatic kicking to work.");

--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -11,9 +11,9 @@ using Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules;
 
 namespace Stratis.Bitcoin.Features.PoA
 {
-    public class CirrusBuriedDeploymentsArray : BuriedDeploymentsArray
+    public class PoABuriedDeploymentsArray : BuriedDeploymentsArray
     {
-        public int this[CirrusBuriedDeployments index]
+        public int this[PoABuriedDeployments index]
         {
             get => this.heights[EnsureIndex((int)index)];
             set => this.heights[EnsureIndex((int)index)] = value;
@@ -22,9 +22,9 @@ namespace Stratis.Bitcoin.Features.PoA
 
     public static class ConsensusExt
     {
-        public static int CirrusBuriedDeployments(this IConsensus consensus, CirrusBuriedDeployments index)
+        public static int PoABuriedDeployments(this IConsensus consensus, PoABuriedDeployments index)
         {
-            return ((CirrusBuriedDeploymentsArray)consensus.BuriedDeployments)[index];
+            return ((PoABuriedDeploymentsArray)consensus.BuriedDeployments)[index];
         }
     }
 
@@ -141,7 +141,7 @@ namespace Stratis.Bitcoin.Features.PoA
                 majorityEnforceBlockUpgrade: 750,
                 majorityRejectBlockOutdated: 950,
                 majorityWindow: 1000,
-                buriedDeployments: new CirrusBuriedDeploymentsArray(),
+                buriedDeployments: new PoABuriedDeploymentsArray(),
                 bip9Deployments: bip9Deployments,
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
                 minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing

--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -11,6 +11,23 @@ using Stratis.Bitcoin.Features.PoA.Voting.ConsensusRules;
 
 namespace Stratis.Bitcoin.Features.PoA
 {
+    public class CirrusBuriedDeploymentsArray : BuriedDeploymentsArray
+    {
+        public int this[CirrusBuriedDeployments index]
+        {
+            get => this.heights[EnsureIndex((int)index)];
+            set => this.heights[EnsureIndex((int)index)] = value;
+        }
+    }
+
+    public static class ConsensusExt
+    {
+        public static int CirrusBuriedDeployments(this IConsensus consensus, CirrusBuriedDeployments index)
+        {
+            return ((CirrusBuriedDeploymentsArray)consensus.BuriedDeployments)[index];
+        }
+    }
+
     /// <summary>
     /// Example network for PoA consensus.
     /// </summary>
@@ -106,17 +123,11 @@ namespace Stratis.Bitcoin.Features.PoA
                 genesisFederationMembers: genesisFederationMembers,
                 targetSpacingSeconds: 16,
                 votingEnabled: true,
+                contractSerializerV2ActivationHeight: 0,
                 autoKickIdleMembers: true
             )
             {
                 PollExpiryBlocks = 450
-            };
-
-            var buriedDeployments = new BuriedDeploymentsArray
-            {
-                [BuriedDeployments.BIP34] = 0,
-                [BuriedDeployments.BIP65] = 0,
-                [BuriedDeployments.BIP66] = 0
             };
 
             var bip9Deployments = new NoBIP9Deployments();
@@ -130,7 +141,7 @@ namespace Stratis.Bitcoin.Features.PoA
                 majorityEnforceBlockUpgrade: 750,
                 majorityRejectBlockOutdated: 950,
                 majorityWindow: 1000,
-                buriedDeployments: buriedDeployments,
+                buriedDeployments: new CirrusBuriedDeploymentsArray(),
                 bip9Deployments: bip9Deployments,
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
                 minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing

--- a/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoANetwork.cs
@@ -15,8 +15,8 @@ namespace Stratis.Bitcoin.Features.PoA
     {
         public int this[PoABuriedDeployments index]
         {
-            get => this.heights[EnsureIndex((int)index)];
-            set => this.heights[EnsureIndex((int)index)] = value;
+            get { EnsureIndex((int)index); return this.heights[(int)index]; }
+            set { EnsureIndex((int)index); this.heights[(int)index] = value; }
         }
     }
 

--- a/src/Stratis.Bitcoin.Features.PoA/SlotsManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/SlotsManager.cs
@@ -76,7 +76,7 @@ namespace Stratis.Bitcoin.Features.PoA
             The miner that mined the last block may no longer exist when the next block is about to be mined. As such
             we may need to look a bit further back to find a "reference miner" that still occurs in the latest federation.
             */
-            if (tip.Height < this.consensus.CirrusBuriedDeployments(CirrusBuriedDeployments.GetMiningTimestampV2))
+            if (tip.Height < this.consensus.PoABuriedDeployments(PoABuriedDeployments.GetMiningTimestampV2))
                 return GetMiningTimestampLegacy(tip, currentTime, currentMiner);
 
             List<IFederationMember> federationMembers = this.federationHistory.GetFederationForBlock(tip, 1);

--- a/src/Stratis.Bitcoin.Features.PoA/SlotsManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/SlotsManager.cs
@@ -73,7 +73,7 @@ namespace Stratis.Bitcoin.Features.PoA
             The miner that mined the last block may no longer exist when the next block is about to be mined. As such
             we may need to look a bit further back to find a "reference miner" that still occurs in the latest federation.
             */
-            if (tip.Height < this.consensusOptions.GetMiningTimestampV2ActivationHeight)
+            if (tip.Height < this.consensusOptions.ActivationHeights[(int)PoAActivationHeights.GetMiningTimestampV2])
                 return GetMiningTimestampLegacy(tip, currentTime, currentMiner);
 
             List<IFederationMember> federationMembers = this.federationHistory.GetFederationForBlock(tip, 1);

--- a/src/Stratis.Bitcoin.Features.PoA/SlotsManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/SlotsManager.cs
@@ -35,6 +35,8 @@ namespace Stratis.Bitcoin.Features.PoA
 
     public class SlotsManager : ISlotsManager
     {
+        private readonly IConsensus consensus;
+
         private readonly PoAConsensusOptions consensusOptions;
 
         private readonly IFederationManager federationManager;
@@ -50,6 +52,7 @@ namespace Stratis.Bitcoin.Features.PoA
             this.federationManager = Guard.NotNull(federationManager, nameof(federationManager));
             this.federationHistory = federationHistory;
             this.chainIndexer = chainIndexer;
+            this.consensus = (network as PoANetwork).Consensus;
             this.consensusOptions = (network as PoANetwork).ConsensusOptions;
         }
 
@@ -73,7 +76,7 @@ namespace Stratis.Bitcoin.Features.PoA
             The miner that mined the last block may no longer exist when the next block is about to be mined. As such
             we may need to look a bit further back to find a "reference miner" that still occurs in the latest federation.
             */
-            if (tip.Height < this.consensusOptions.ActivationHeights[(int)PoAActivationHeights.GetMiningTimestampV2])
+            if (tip.Height < this.consensus.CirrusBuriedDeployments(CirrusBuriedDeployments.GetMiningTimestampV2))
                 return GetMiningTimestampLegacy(tip, currentTime, currentMiner);
 
             List<IFederationMember> federationMembers = this.federationHistory.GetFederationForBlock(tip, 1);

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/PollsRepository.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/PollsRepository.cs
@@ -378,7 +378,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
         private static int GetPollExpiryHeight(Poll poll, PoANetwork network)
         {
-            return Math.Max(poll.PollStartBlockData.Height + network.ConsensusOptions.PollExpiryBlocks, network.ConsensusOptions.Release1100ActivationHeight);
+            return Math.Max(poll.PollStartBlockData.Height + network.ConsensusOptions.PollExpiryBlocks, network.ConsensusOptions.ActivationHeights[(int)PoAActivationHeights.Release1100]);
         }
 
         public static int GetPollExpiryOrExecutionHeight(Poll poll, PoANetwork network)

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/PollsRepository.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/PollsRepository.cs
@@ -378,7 +378,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
 
         private static int GetPollExpiryHeight(Poll poll, PoANetwork network)
         {
-            return Math.Max(poll.PollStartBlockData.Height + network.ConsensusOptions.PollExpiryBlocks, network.ConsensusOptions.ActivationHeights[(int)PoAActivationHeights.Release1100]);
+            return Math.Max(poll.PollStartBlockData.Height + network.ConsensusOptions.PollExpiryBlocks, network.Consensus.PoABuriedDeployments(PoABuriedDeployments.Release1100));
         }
 
         public static int GetPollExpiryOrExecutionHeight(Poll poll, PoANetwork network)

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -606,7 +606,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                                 // Hence, if the poll does not exist then this is not a valid vote.
                                 if (data.Key == VoteKey.AddFederationMember)
                                 {
-                                    if (chBlock.ChainedHeader.Height >= this.poaConsensusOptions.Release1300ActivationHeight)
+                                    if (chBlock.ChainedHeader.Height >= this.poaConsensusOptions.ActivationHeights[(int)PoAActivationHeights.Release1300])
                                         continue;
                                 }
 
@@ -990,7 +990,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                         foreach (Poll poll in pendingPolls.Where(p => !p.IsExecuted && (p.VotingData.Key == VoteKey.AddFederationMember || p.VotingData.Key == VoteKey.KickFederationMember)))
                         {
                             IFederationMember federationMember = ((PoAConsensusFactory)(this.network.Consensus.ConsensusFactory)).DeserializeFederationMember(poll.VotingData.Data);
-                            string expiresIn = $", Expires In = {(Math.Max(this.poaConsensusOptions.Release1100ActivationHeight, poll.PollStartBlockData.Height + this.poaConsensusOptions.PollExpiryBlocks) - tipHeight)}";
+                            string expiresIn = $", Expires In = {(Math.Max(this.poaConsensusOptions.ActivationHeights[(int)PoAActivationHeights.Release1100], poll.PollStartBlockData.Height + this.poaConsensusOptions.PollExpiryBlocks) - tipHeight)}";
                             log.Append($"{poll.VotingData.Key.ToString().PadLeft(22)}, PubKey = { federationMember.PubKey.ToHex() }, In Favor = {poll.PubKeysHexVotedInFavor.Count}{expiresIn}");
                             bool exists = this.federationManager.GetFederationMembers().Any(m => m.PubKey == federationMember.PubKey);
                             if (poll.VotingData.Key == VoteKey.AddFederationMember && exists)

--- a/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/Voting/VotingManager.cs
@@ -606,7 +606,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                                 // Hence, if the poll does not exist then this is not a valid vote.
                                 if (data.Key == VoteKey.AddFederationMember)
                                 {
-                                    if (chBlock.ChainedHeader.Height >= this.poaConsensusOptions.ActivationHeights[(int)PoAActivationHeights.Release1300])
+                                    if (chBlock.ChainedHeader.Height >= this.network.Consensus.PoABuriedDeployments(PoABuriedDeployments.Release1300))
                                         continue;
                                 }
 
@@ -990,7 +990,7 @@ namespace Stratis.Bitcoin.Features.PoA.Voting
                         foreach (Poll poll in pendingPolls.Where(p => !p.IsExecuted && (p.VotingData.Key == VoteKey.AddFederationMember || p.VotingData.Key == VoteKey.KickFederationMember)))
                         {
                             IFederationMember federationMember = ((PoAConsensusFactory)(this.network.Consensus.ConsensusFactory)).DeserializeFederationMember(poll.VotingData.Data);
-                            string expiresIn = $", Expires In = {(Math.Max(this.poaConsensusOptions.ActivationHeights[(int)PoAActivationHeights.Release1100], poll.PollStartBlockData.Height + this.poaConsensusOptions.PollExpiryBlocks) - tipHeight)}";
+                            string expiresIn = $", Expires In = {(Math.Max(this.network.Consensus.PoABuriedDeployments(PoABuriedDeployments.Release1100), poll.PollStartBlockData.Height + this.poaConsensusOptions.PollExpiryBlocks) - tipHeight)}";
                             log.Append($"{poll.VotingData.Key.ToString().PadLeft(22)}, PubKey = { federationMember.PubKey.ToHex() }, In Favor = {poll.PubKeysHexVotedInFavor.Count}{expiresIn}");
                             bool exists = this.federationManager.GetFederationMembers().Any(m => m.PubKey == federationMember.PubKey);
                             if (poll.VotingData.Key == VoteKey.AddFederationMember && exists)

--- a/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
@@ -39,7 +39,7 @@ namespace Stratis.Features.Collateral
             }
 
             // Check that the commitment height is not less that of the prior block.
-            int release1324ActivationHeight = this.Parent.Network.Consensus.CirrusBuriedDeployments(CirrusBuriedDeployments.Release1324);
+            int release1324ActivationHeight = this.Parent.Network.Consensus.PoABuriedDeployments(PoABuriedDeployments.Release1324);
 
             if (context.ValidationContext.ChainedHeaderToValidate.Height >= release1324ActivationHeight)
             {

--- a/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
@@ -39,7 +39,7 @@ namespace Stratis.Features.Collateral
             }
 
             // Check that the commitment height is not less that of the prior block.
-            int release1324ActivationHeight = ((PoAConsensusOptions)this.Parent.Network.Consensus.Options).ActivationHeights[(int)PoAActivationHeights.Release1324];
+            int release1324ActivationHeight = this.Parent.Network.Consensus.CirrusBuriedDeployments(CirrusBuriedDeployments.Release1324);
 
             if (context.ValidationContext.ChainedHeaderToValidate.Height >= release1324ActivationHeight)
             {

--- a/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
+++ b/src/Stratis.Features.Collateral/CheckCollateralCommitmentHeightRule.cs
@@ -39,10 +39,7 @@ namespace Stratis.Features.Collateral
             }
 
             // Check that the commitment height is not less that of the prior block.
-            int release1324ActivationHeight = 0;
-            NodeDeployments nodeDeployments = this.Parent.NodeDeployments;
-            if (nodeDeployments.BIP9.ArraySize > 0  /* Not NoBIP9Deployments */)
-                release1324ActivationHeight = nodeDeployments.BIP9.ActivationHeightProviders[1 /* Release1324 */].ActivationHeight;
+            int release1324ActivationHeight = ((PoAConsensusOptions)this.Parent.Network.Consensus.Options).ActivationHeights[(int)PoAActivationHeights.Release1324];
 
             if (context.ValidationContext.ChainedHeaderToValidate.Height >= release1324ActivationHeight)
             {

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -79,7 +79,7 @@ namespace Stratis.Features.Collateral
 
         private readonly NodeDeployments nodeDeployments;
 
-        private readonly PoAConsensusOptions poAConsensusOptions;
+        private readonly IConsensus consensus;
 
         private Task updateCollateralContinuouslyTask;
 
@@ -99,7 +99,7 @@ namespace Stratis.Features.Collateral
             this.logger = LogManager.GetCurrentClassLogger();
             this.blockStoreClient = new BlockStoreClient(httpClientFactory, $"http://{settings.CounterChainApiHost}", settings.CounterChainApiPort);
             this.nodeDeployments = nodeDeployments;
-            this.poAConsensusOptions = (PoAConsensusOptions)network.Consensus.Options;
+            this.consensus = network.Consensus;
         }
 
         public async Task InitializeAsync()
@@ -274,7 +274,7 @@ namespace Stratis.Features.Collateral
                     return false;
                 }
 
-                int release1320ActivationHeight = this.poAConsensusOptions.ActivationHeights[(int)PoAActivationHeights.Release1320];
+                int release1320ActivationHeight = this.consensus.CirrusBuriedDeployments(CirrusBuriedDeployments.Release1320);
 
                 // Legacy behavior before activation.
                 if (localChainHeight < release1320ActivationHeight)

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -274,7 +274,7 @@ namespace Stratis.Features.Collateral
                     return false;
                 }
 
-                int release1320ActivationHeight = this.consensus.CirrusBuriedDeployments(CirrusBuriedDeployments.Release1320);
+                int release1320ActivationHeight = this.consensus.PoABuriedDeployments(PoABuriedDeployments.Release1320);
 
                 // Legacy behavior before activation.
                 if (localChainHeight < release1320ActivationHeight)

--- a/src/Stratis.Features.Collateral/CollateralChecker.cs
+++ b/src/Stratis.Features.Collateral/CollateralChecker.cs
@@ -79,6 +79,8 @@ namespace Stratis.Features.Collateral
 
         private readonly NodeDeployments nodeDeployments;
 
+        private readonly PoAConsensusOptions poAConsensusOptions;
+
         private Task updateCollateralContinuouslyTask;
 
         private bool collateralUpdated;
@@ -97,6 +99,7 @@ namespace Stratis.Features.Collateral
             this.logger = LogManager.GetCurrentClassLogger();
             this.blockStoreClient = new BlockStoreClient(httpClientFactory, $"http://{settings.CounterChainApiHost}", settings.CounterChainApiPort);
             this.nodeDeployments = nodeDeployments;
+            this.poAConsensusOptions = (PoAConsensusOptions)network.Consensus.Options;
         }
 
         public async Task InitializeAsync()
@@ -271,9 +274,7 @@ namespace Stratis.Features.Collateral
                     return false;
                 }
 
-                int release1320ActivationHeight = 0;
-                if (this.nodeDeployments?.BIP9.ArraySize > 0  /* Not NoBIP9Deployments */)
-                    release1320ActivationHeight = this.nodeDeployments.BIP9.ActivationHeightProviders[0 /* Release1320 */].ActivationHeight;
+                int release1320ActivationHeight = this.poAConsensusOptions.ActivationHeights[(int)PoAActivationHeights.Release1320];
 
                 // Legacy behavior before activation.
                 if (localChainHeight < release1320ActivationHeight)

--- a/src/Stratis.Features.Collateral/ConsensusRules/VotingRequestFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/ConsensusRules/VotingRequestFullValidationRule.cs
@@ -75,7 +75,7 @@ namespace Stratis.Features.Collateral.ConsensusRules
             }
 
             // Prohibit re-use of collateral addresses.
-            if (height >= ((PoAConsensusOptions)(this.network.Consensus.Options)).ActivationHeights[(int)PoAActivationHeights.Release1100])
+            if (height >= this.network.Consensus.PoABuriedDeployments(PoABuriedDeployments.Release1100))
             {
                 Script script = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(request.CollateralMainchainAddress);
                 string collateralAddress = script.GetDestinationAddress(this.counterChainNetwork).ToString();

--- a/src/Stratis.Features.Collateral/ConsensusRules/VotingRequestFullValidationRule.cs
+++ b/src/Stratis.Features.Collateral/ConsensusRules/VotingRequestFullValidationRule.cs
@@ -75,7 +75,7 @@ namespace Stratis.Features.Collateral.ConsensusRules
             }
 
             // Prohibit re-use of collateral addresses.
-            if (height >= ((PoAConsensusOptions)(this.network.Consensus.Options)).Release1100ActivationHeight)
+            if (height >= ((PoAConsensusOptions)(this.network.Consensus.Options)).ActivationHeights[(int)PoAActivationHeights.Release1100])
             {
                 Script script = PayToPubkeyHashTemplate.Instance.GenerateScriptPubKey(request.CollateralMainchainAddress);
                 string collateralAddress = script.GetDestinationAddress(this.counterChainNetwork).ToString();

--- a/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
+++ b/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
@@ -113,7 +113,7 @@ namespace Stratis.Features.Collateral
                         Data = federationMemberBytes
                     };
 
-                    if (blockConnectedData.ConnectedBlock.ChainedHeader.Height >= ((PoAConsensusOptions)this.network.Consensus.Options).Release1300ActivationHeight)
+                    if (blockConnectedData.ConnectedBlock.ChainedHeader.Height >= ((PoAConsensusOptions)this.network.Consensus.Options).ActivationHeights[(int)PoAActivationHeights.Release1300])
                     {
                         // If we are executing this from the miner, there will be no transaction present.
                         if (blockConnectedData.PollsRepositoryTransaction == null)

--- a/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
+++ b/src/Stratis.Features.Collateral/JoinFederationRequestMonitor.cs
@@ -113,7 +113,7 @@ namespace Stratis.Features.Collateral
                         Data = federationMemberBytes
                     };
 
-                    if (blockConnectedData.ConnectedBlock.ChainedHeader.Height >= ((PoAConsensusOptions)this.network.Consensus.Options).ActivationHeights[(int)PoAActivationHeights.Release1300])
+                    if (blockConnectedData.ConnectedBlock.ChainedHeader.Height >= this.network.Consensus.PoABuriedDeployments(PoABuriedDeployments.Release1300))
                     {
                         // If we are executing this from the miner, there will be no transaction present.
                         if (blockConnectedData.PollsRepositoryTransaction == null)

--- a/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksProviderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksProviderTests.cs
@@ -56,7 +56,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.mainChainNetwork = new StraxRegTest();
 
             // TODO: Upgrade these tests to conform with release 1.3.0.0 activation.
-            ((PoAConsensusOptions)this.network.Consensus.Options).ActivationHeights[(int)PoAActivationHeights.Release1300] = int.MaxValue;
+            ((PoABuriedDeploymentsArray)this.network.Consensus.BuriedDeployments)[PoABuriedDeployments.Release1300] = int.MaxValue;
 
             this.opReturnDataReader = Substitute.For<IOpReturnDataReader>();
             this.opReturnDataReader.TryGetTargetAddress(null, out string address).Returns(callInfo => { callInfo[1] = null; return false; });

--- a/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksProviderTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksProviderTests.cs
@@ -56,7 +56,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.mainChainNetwork = new StraxRegTest();
 
             // TODO: Upgrade these tests to conform with release 1.3.0.0 activation.
-            ((PoAConsensusOptions)this.network.Consensus.Options).Release1300ActivationHeight = int.MaxValue;
+            ((PoAConsensusOptions)this.network.Consensus.Options).ActivationHeights[(int)PoAActivationHeights.Release1300] = int.MaxValue;
 
             this.opReturnDataReader = Substitute.For<IOpReturnDataReader>();
             this.opReturnDataReader.TryGetTargetAddress(null, out string address).Returns(callInfo => { callInfo[1] = null; return false; });

--- a/src/Stratis.Features.FederatedPeg/Distribution/RewardDistributionManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Distribution/RewardDistributionManager.cs
@@ -144,7 +144,7 @@ namespace Stratis.Features.FederatedPeg.Distribution
                 }
             }
 
-            if (this.chainIndexer.Tip.Height >= (this.network.Consensus.Options as PoAConsensusOptions).Release1400ActivationHeight)
+            if (this.chainIndexer.Tip.Height >= (this.network.Consensus.Options as PoAConsensusOptions).ActivationHeights[(int)PoAActivationHeights.Release1400])
                 return multiSigRecipients.OrderBy(m => m.ScriptPubKey.ToHex()).ToList();
 
             return multiSigRecipients;

--- a/src/Stratis.Features.FederatedPeg/Distribution/RewardDistributionManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Distribution/RewardDistributionManager.cs
@@ -144,7 +144,7 @@ namespace Stratis.Features.FederatedPeg.Distribution
                 }
             }
 
-            if (this.chainIndexer.Tip.Height >= (this.network.Consensus.Options as PoAConsensusOptions).ActivationHeights[(int)PoAActivationHeights.Release1400])
+            if (this.chainIndexer.Tip.Height >= this.network.Consensus.PoABuriedDeployments(PoABuriedDeployments.Release1400))
                 return multiSigRecipients.OrderBy(m => m.ScriptPubKey.ToHex()).ToList();
 
             return multiSigRecipients;

--- a/src/Stratis.Features.FederatedPeg/SourceChain/RetrievalTypeConfirmations.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/RetrievalTypeConfirmations.cs
@@ -115,7 +115,7 @@ namespace Stratis.Features.FederatedPeg.SourceChain
                 if (this.federatedPegSettings.IsMainChain)
                     return ((PosConsensusOptions)this.network.Consensus.Options).Release1300ActivationHeight;
 
-                return ((PoAConsensusOptions)this.network.Consensus.Options).Release1300ActivationHeight;
+                return ((PoAConsensusOptions)this.network.Consensus.Options).ActivationHeights[(int)PoAActivationHeights.Release1300];
             }
         }
     }

--- a/src/Stratis.Features.FederatedPeg/SourceChain/RetrievalTypeConfirmations.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/RetrievalTypeConfirmations.cs
@@ -115,7 +115,7 @@ namespace Stratis.Features.FederatedPeg.SourceChain
                 if (this.federatedPegSettings.IsMainChain)
                     return ((PosConsensusOptions)this.network.Consensus.Options).Release1300ActivationHeight;
 
-                return ((PoAConsensusOptions)this.network.Consensus.Options).ActivationHeights[(int)PoAActivationHeights.Release1300];
+                return this.network.Consensus.PoABuriedDeployments(PoABuriedDeployments.Release1300);
             }
         }
     }

--- a/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
@@ -45,7 +45,6 @@ namespace Stratis.Features.FederatedPeg.TargetChain
     /// <inheritdoc cref="IMaturedBlocksSyncManager"/>
     public class MaturedBlocksSyncManager : IMaturedBlocksSyncManager
     {
-        private const string Release1320DeploymentNameLower = "release1320";
         private readonly IAsyncProvider asyncProvider;
         private readonly ICrossChainTransferStore crossChainTransferStore;
         private readonly IFederationGatewayClient federationGatewayClient;
@@ -239,7 +238,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                         continue;
                     }
 
-                    var interFluxV2MainChainActivationHeight = ((PoAConsensusOptions)this.network.Consensus.Options).InterFluxV2MainChainActivationHeight;
+                    var interFluxV2MainChainActivationHeight = ((PoAConsensusOptions)this.network.Consensus.Options).ActivationHeights[(int)PoAActivationHeights.InterFluxV2MainChain];
                     if (interFluxV2MainChainActivationHeight != 0 && maturedBlockDeposit.BlockInfo.BlockHeight < interFluxV2MainChainActivationHeight)
                     {
                         this.logger.LogWarning("Conversion transactions '{0}' will not be processed below the main chain activation height of {1}.", potentialConversionTransaction.Id, interFluxV2MainChainActivationHeight);

--- a/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
@@ -238,7 +238,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                         continue;
                     }
 
-                    var interFluxV2MainChainActivationHeight = ((PoAConsensusOptions)this.network.Consensus.Options).ActivationHeights[(int)PoAActivationHeights.InterFluxV2MainChain];
+                    var interFluxV2MainChainActivationHeight = this.network.Consensus.PoABuriedDeployments(PoABuriedDeployments.InterFluxV2MainChain);
                     if (interFluxV2MainChainActivationHeight != 0 && maturedBlockDeposit.BlockInfo.BlockHeight < interFluxV2MainChainActivationHeight)
                     {
                         this.logger.LogWarning("Conversion transactions '{0}' will not be processed below the main chain activation height of {1}.", potentialConversionTransaction.Id, interFluxV2MainChainActivationHeight);

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -98,13 +98,6 @@ namespace Stratis.Sidechains.Networks
                 PollExpiryBlocks = 10
             };
 
-            var buriedDeployments = new BuriedDeploymentsArray
-            {
-                [BuriedDeployments.BIP34] = 0,
-                [BuriedDeployments.BIP65] = 0,
-                [BuriedDeployments.BIP66] = 0
-            };
-
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
@@ -121,7 +114,7 @@ namespace Stratis.Sidechains.Networks
                 majorityEnforceBlockUpgrade: 750,
                 majorityRejectBlockOutdated: 950,
                 majorityWindow: 1000,
-                buriedDeployments: buriedDeployments,
+                buriedDeployments: new PoABuriedDeploymentsArray(),
                 bip9Deployments: bip9Deployments,
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
                 minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -107,8 +107,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
-                [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                // Example:
+                // [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusDev.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusDev.cs
@@ -91,7 +91,8 @@ namespace Stratis.Sidechains.Networks
                 genesisFederationMembers: genesisFederationMembers,
                 targetSpacingSeconds: 16,
                 votingEnabled: true,
-                autoKickIdleMembers: true
+                autoKickIdleMembers: true,
+                contractSerializerV2ActivationHeight: 0
             )
             {
                 PollExpiryBlocks = 10

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -178,16 +178,20 @@ namespace Stratis.Sidechains.Networks
                 EnforceMinProtocolVersionAtBlockHeight = 384675, // setting the value to zero makes the functionality inactive
                 EnforcedMinProtocolVersion = ProtocolVersion.CIRRUS_VERSION, // minimum protocol version which will be enforced at block height defined in EnforceMinProtocolVersionAtBlockHeight
                 FederationMemberActivationTime = 1605862800, // Friday, November 20, 2020 9:00:00 AM
-                InterFluxV2MainChainActivationHeight = 460_000,
-                VotingManagerV2ActivationHeight = 1_683_000, // Tuesday, 12 January 2021 9:00:00 AM (Estimated)
-                Release1100ActivationHeight = 3_426_950, // Monday, 20 December 2021 10:00:00 AM (Estimated)
                 PollExpiryBlocks = 50_000, // Roughly 9 days
-                GetMiningTimestampV2ActivationHeight = 3_709_000, // Monday 14 February 00:00:00 (Estimated)
-                GetMiningTimestampV2ActivationStrictHeight = 3_783_000, // Monday 28 February 07:00:00 (London Time) (Estimated)
-                ContractSerializerV2ActivationHeight = 3_386_335, // Monday 13 December 16:00:00 (Estimated)
-                Release1300ActivationHeight = 4_334_400,
-                Release1400ActivationHeight = 0,
             };
+
+            var activationHeights = consensusOptions.ActivationHeights;
+            activationHeights[(int)PoAActivationHeights.InterFluxV2MainChain] = 460_000;
+            activationHeights[(int)PoAActivationHeights.VotingManagerV2] = 1_683_000; // Tuesday, 12 January 2021 9:00:00 AM (Estimated)
+            activationHeights[(int)PoAActivationHeights.ContractSerializerV2] = 3_386_335; // Monday 13 December 16:00:00 (Estimated)
+            activationHeights[(int)PoAActivationHeights.Release1100] = 3_426_950; // Monday, 20 December 2021 10:00:00 AM (Estimated)
+            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2] = 3_709_000; // Monday 14 February 00:00:00 (Estimated)
+            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2Strict] = 3_783_000; // Monday 28 February 07:00:00 (London Time) (Estimated)
+            activationHeights[(int)PoAActivationHeights.Release1300] = 4_334_400;
+            activationHeights[(int)PoAActivationHeights.Release1320] = 4_665_600;
+            activationHeights[(int)PoAActivationHeights.Release1324] = 5_086_800;
+            activationHeights[(int)PoAActivationHeights.Release1400] = 0;
 
             var buriedDeployments = new BuriedDeploymentsArray
             {
@@ -199,8 +203,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), 8100 /* 75% Activation Threshold */),
-                [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1324, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-3-1 +0").ToUnixTimestamp(), 8100 /* 75% Activation Threshold */)
+                // Example:
+                // [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1324, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-3-1 +0").ToUnixTimestamp(), 8100 /* 75% Activation Threshold */)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -162,18 +162,18 @@ namespace Stratis.Sidechains.Networks
                 new PubKey("03f5de5176e29e1e7d518ae76c1e020b1da18b57a3713ac81b16015026e232748e"),
             };
 
-            var buriedDeployments = new CirrusBuriedDeploymentsArray
+            var buriedDeployments = new PoABuriedDeploymentsArray
             {
-                [CirrusBuriedDeployments.InterFluxV2MainChain] = 460_000,
-                [CirrusBuriedDeployments.VotingManagerV2] = 1_683_000, // Tuesday, 12 January 2021 9:00:00 AM (Estimated)
-                [CirrusBuriedDeployments.ContractSerializerV2] = 3_386_335, // Monday 13 December 16:00:00 (Estimated)
-                [CirrusBuriedDeployments.Release1100] = 3_426_950, // Monday, 20 December 2021 10:00:00 AM (Estimated)
-                [CirrusBuriedDeployments.GetMiningTimestampV2] = 3_709_000, // Monday 14 February 00:00:00 (Estimated)
-                [CirrusBuriedDeployments.GetMiningTimestampV2Strict] = 3_783_000, // Monday 28 February 07:00:00 (London Time) (Estimated)
-                [CirrusBuriedDeployments.Release1300] = 4_334_400,
-                [CirrusBuriedDeployments.Release1320] = 4_665_600,
-                [CirrusBuriedDeployments.Release1324] = 5_086_800,
-                [CirrusBuriedDeployments.Release1400] = 5_345_325 // 7 December 2022 (Estimated)
+                [PoABuriedDeployments.InterFluxV2MainChain] = 460_000,
+                [PoABuriedDeployments.VotingManagerV2] = 1_683_000, // Tuesday, 12 January 2021 9:00:00 AM (Estimated)
+                [PoABuriedDeployments.ContractSerializerV2] = 3_386_335, // Monday 13 December 16:00:00 (Estimated)
+                [PoABuriedDeployments.Release1100] = 3_426_950, // Monday, 20 December 2021 10:00:00 AM (Estimated)
+                [PoABuriedDeployments.GetMiningTimestampV2] = 3_709_000, // Monday 14 February 00:00:00 (Estimated)
+                [PoABuriedDeployments.GetMiningTimestampV2Strict] = 3_783_000, // Monday 28 February 07:00:00 (London Time) (Estimated)
+                [PoABuriedDeployments.Release1300] = 4_334_400,
+                [PoABuriedDeployments.Release1320] = 4_665_600,
+                [PoABuriedDeployments.Release1324] = 5_086_800,
+                [PoABuriedDeployments.Release1400] = 5_345_325 // 7 December 2022 (Estimated)
             };
 
             var consensusOptions = new PoAConsensusOptions(
@@ -186,7 +186,7 @@ namespace Stratis.Sidechains.Networks
                 targetSpacingSeconds: 16,
                 votingEnabled: true,
                 autoKickIdleMembers: true,
-                contractSerializerV2ActivationHeight: buriedDeployments[CirrusBuriedDeployments.ContractSerializerV2],
+                contractSerializerV2ActivationHeight: buriedDeployments[PoABuriedDeployments.ContractSerializerV2],
                 federationMemberMaxIdleTimeSeconds: 60 * 60 * 24 * 2 // 2 days
             )
             {

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -162,6 +162,20 @@ namespace Stratis.Sidechains.Networks
                 new PubKey("03f5de5176e29e1e7d518ae76c1e020b1da18b57a3713ac81b16015026e232748e"),
             };
 
+            var buriedDeployments = new CirrusBuriedDeploymentsArray
+            {
+                [CirrusBuriedDeployments.InterFluxV2MainChain] = 460_000,
+                [CirrusBuriedDeployments.VotingManagerV2] = 1_683_000, // Tuesday, 12 January 2021 9:00:00 AM (Estimated)
+                [CirrusBuriedDeployments.ContractSerializerV2] = 3_386_335, // Monday 13 December 16:00:00 (Estimated)
+                [CirrusBuriedDeployments.Release1100] = 3_426_950, // Monday, 20 December 2021 10:00:00 AM (Estimated)
+                [CirrusBuriedDeployments.GetMiningTimestampV2] = 3_709_000, // Monday 14 February 00:00:00 (Estimated)
+                [CirrusBuriedDeployments.GetMiningTimestampV2Strict] = 3_783_000, // Monday 28 February 07:00:00 (London Time) (Estimated)
+                [CirrusBuriedDeployments.Release1300] = 4_334_400,
+                [CirrusBuriedDeployments.Release1320] = 4_665_600,
+                [CirrusBuriedDeployments.Release1324] = 5_086_800,
+                [CirrusBuriedDeployments.Release1400] = 5_345_325 // 7 December 2022 (Estimated)
+            };
+
             var consensusOptions = new PoAConsensusOptions(
                 maxBlockBaseSize: 1_000_000,
                 maxStandardVersion: 2,
@@ -172,6 +186,7 @@ namespace Stratis.Sidechains.Networks
                 targetSpacingSeconds: 16,
                 votingEnabled: true,
                 autoKickIdleMembers: true,
+                contractSerializerV2ActivationHeight: buriedDeployments[CirrusBuriedDeployments.ContractSerializerV2],
                 federationMemberMaxIdleTimeSeconds: 60 * 60 * 24 * 2 // 2 days
             )
             {
@@ -179,25 +194,6 @@ namespace Stratis.Sidechains.Networks
                 EnforcedMinProtocolVersion = ProtocolVersion.CIRRUS_VERSION, // minimum protocol version which will be enforced at block height defined in EnforceMinProtocolVersionAtBlockHeight
                 FederationMemberActivationTime = 1605862800, // Friday, November 20, 2020 9:00:00 AM
                 PollExpiryBlocks = 50_000, // Roughly 9 days
-            };
-
-            var activationHeights = consensusOptions.ActivationHeights;
-            activationHeights[(int)PoAActivationHeights.InterFluxV2MainChain] = 460_000;
-            activationHeights[(int)PoAActivationHeights.VotingManagerV2] = 1_683_000; // Tuesday, 12 January 2021 9:00:00 AM (Estimated)
-            activationHeights[(int)PoAActivationHeights.ContractSerializerV2] = 3_386_335; // Monday 13 December 16:00:00 (Estimated)
-            activationHeights[(int)PoAActivationHeights.Release1100] = 3_426_950; // Monday, 20 December 2021 10:00:00 AM (Estimated)
-            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2] = 3_709_000; // Monday 14 February 00:00:00 (Estimated)
-            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2Strict] = 3_783_000; // Monday 28 February 07:00:00 (London Time) (Estimated)
-            activationHeights[(int)PoAActivationHeights.Release1300] = 4_334_400;
-            activationHeights[(int)PoAActivationHeights.Release1320] = 4_665_600;
-            activationHeights[(int)PoAActivationHeights.Release1324] = 5_086_800;
-            activationHeights[(int)PoAActivationHeights.Release1400] = 5_345_325; // 7 December 2022 (Estimated)
-
-            var buriedDeployments = new BuriedDeploymentsArray
-            {
-                [BuriedDeployments.BIP34] = 0,
-                [BuriedDeployments.BIP65] = 0,
-                [BuriedDeployments.BIP66] = 0
             };
 
             var bip9Deployments = new CirrusBIP9Deployments()

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -111,10 +111,12 @@ namespace Stratis.Sidechains.Networks
                 votingEnabled: true,
                 autoKickIdleMembers: true)
             {
-                GetMiningTimestampV2ActivationHeight = 100,
-                GetMiningTimestampV2ActivationStrictHeight = 100,
                 PollExpiryBlocks = 450 // 2 hours
             };
+
+            var activationHeights = consensusOptions.ActivationHeights;
+            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2] = 100;
+            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2Strict] = 100;
 
             var buriedDeployments = new BuriedDeploymentsArray
             {
@@ -126,8 +128,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
-                [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1324, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                // Example:
+                // [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1324, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Now.AddDays(50).ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -100,6 +100,12 @@ namespace Stratis.Sidechains.Networks
             // Use the new keys as the old keys should never be used by the new opcode.
             this.Federations.RegisterFederation(new Federation(newFederationPubKeys.ToArray()));
 
+            var buriedDeployments = new CirrusBuriedDeploymentsArray
+            {
+                [CirrusBuriedDeployments.GetMiningTimestampV2] = 100,
+                [CirrusBuriedDeployments.GetMiningTimestampV2Strict] = 100
+            };
+
             var consensusOptions = new PoAConsensusOptions(
                 maxBlockBaseSize: 1_000_000,
                 maxStandardVersion: 2,
@@ -109,20 +115,10 @@ namespace Stratis.Sidechains.Networks
                 genesisFederationMembers: genesisFederationMembers,
                 targetSpacingSeconds: 16,
                 votingEnabled: true,
+                contractSerializerV2ActivationHeight: buriedDeployments[CirrusBuriedDeployments.ContractSerializerV2],
                 autoKickIdleMembers: true)
             {
                 PollExpiryBlocks = 450 // 2 hours
-            };
-
-            var activationHeights = consensusOptions.ActivationHeights;
-            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2] = 100;
-            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2Strict] = 100;
-
-            var buriedDeployments = new BuriedDeploymentsArray
-            {
-                [BuriedDeployments.BIP34] = 0,
-                [BuriedDeployments.BIP65] = 0,
-                [BuriedDeployments.BIP66] = 0
             };
 
             var bip9Deployments = new CirrusBIP9Deployments()

--- a/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusRegTest.cs
@@ -100,10 +100,10 @@ namespace Stratis.Sidechains.Networks
             // Use the new keys as the old keys should never be used by the new opcode.
             this.Federations.RegisterFederation(new Federation(newFederationPubKeys.ToArray()));
 
-            var buriedDeployments = new CirrusBuriedDeploymentsArray
+            var buriedDeployments = new PoABuriedDeploymentsArray
             {
-                [CirrusBuriedDeployments.GetMiningTimestampV2] = 100,
-                [CirrusBuriedDeployments.GetMiningTimestampV2Strict] = 100
+                [PoABuriedDeployments.GetMiningTimestampV2] = 100,
+                [PoABuriedDeployments.GetMiningTimestampV2Strict] = 100
             };
 
             var consensusOptions = new PoAConsensusOptions(
@@ -115,7 +115,7 @@ namespace Stratis.Sidechains.Networks
                 genesisFederationMembers: genesisFederationMembers,
                 targetSpacingSeconds: 16,
                 votingEnabled: true,
-                contractSerializerV2ActivationHeight: buriedDeployments[CirrusBuriedDeployments.ContractSerializerV2],
+                contractSerializerV2ActivationHeight: buriedDeployments[PoABuriedDeployments.ContractSerializerV2],
                 autoKickIdleMembers: true)
             {
                 PollExpiryBlocks = 450 // 2 hours

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -115,6 +115,20 @@ namespace Stratis.Sidechains.Networks
                 new PubKey("03382ceb0a59b9b922aca6be9959ae51dabda159e79465393a308ee267ecebcaa5"),//Node8
             };
 
+            var buriedDeployments = new CirrusBuriedDeploymentsArray
+            {
+                [CirrusBuriedDeployments.InterFluxV2MainChain] = 500_000,
+                [CirrusBuriedDeployments.VotingManagerV2] = 1_999_500,
+                [CirrusBuriedDeployments.ContractSerializerV2] = 2_842_681,
+                [CirrusBuriedDeployments.Release1100] = 2_796_000,
+                [CirrusBuriedDeployments.GetMiningTimestampV2] = 3_000_000, // 15 January 2022
+                [CirrusBuriedDeployments.GetMiningTimestampV2Strict] = 3_121_500, // 17 January 2022
+                [CirrusBuriedDeployments.Release1300] = 3_280_032,
+                [CirrusBuriedDeployments.Release1320] = 3_588_480,
+                [CirrusBuriedDeployments.Release1324] = 3_951_360,
+                [CirrusBuriedDeployments.Release1400] = 4_074_250
+            };
+
             var consensusOptions = new PoAConsensusOptions(
                 maxBlockBaseSize: 1_000_000,
                 maxStandardVersion: 2,
@@ -125,31 +139,13 @@ namespace Stratis.Sidechains.Networks
                 targetSpacingSeconds: 16,
                 votingEnabled: true,
                 autoKickIdleMembers: true,
+                contractSerializerV2ActivationHeight: buriedDeployments[CirrusBuriedDeployments.ContractSerializerV2],
                 federationMemberMaxIdleTimeSeconds: 60 * 30 // 30 minutes
             )
             {
                 EnforceMinProtocolVersionAtBlockHeight = 505900, // setting the value to zero makes the functionality inactive
                 EnforcedMinProtocolVersion = ProtocolVersion.CIRRUS_VERSION, // minimum protocol version which will be enforced at block height defined in EnforceMinProtocolVersionAtBlockHeight
                 PollExpiryBlocks = 450
-            };
-
-            var activationHeights = consensusOptions.ActivationHeights;
-            activationHeights[(int)PoAActivationHeights.InterFluxV2MainChain] = 500_000;
-            activationHeights[(int)PoAActivationHeights.VotingManagerV2] = 1_999_500;
-            activationHeights[(int)PoAActivationHeights.ContractSerializerV2] = 2_842_681;
-            activationHeights[(int)PoAActivationHeights.Release1100] = 2_796_000;
-            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2] = 3_000_000; // 15 January 2022
-            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2Strict] = 3_121_500; // 17 January 2022
-            activationHeights[(int)PoAActivationHeights.Release1300] = 3_280_032;
-            activationHeights[(int)PoAActivationHeights.Release1320] = 3_588_480;
-            activationHeights[(int)PoAActivationHeights.Release1324] = 3_951_360;
-            activationHeights[(int)PoAActivationHeights.Release1400] = 4_074_250;
-
-            var buriedDeployments = new BuriedDeploymentsArray
-            {
-                [BuriedDeployments.BIP34] = 0,
-                [BuriedDeployments.BIP65] = 0,
-                [BuriedDeployments.BIP66] = 0
             };
 
             var bip9Deployments = new CirrusBIP9Deployments()

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -115,18 +115,18 @@ namespace Stratis.Sidechains.Networks
                 new PubKey("03382ceb0a59b9b922aca6be9959ae51dabda159e79465393a308ee267ecebcaa5"),//Node8
             };
 
-            var buriedDeployments = new CirrusBuriedDeploymentsArray
+            var buriedDeployments = new PoABuriedDeploymentsArray
             {
-                [CirrusBuriedDeployments.InterFluxV2MainChain] = 500_000,
-                [CirrusBuriedDeployments.VotingManagerV2] = 1_999_500,
-                [CirrusBuriedDeployments.ContractSerializerV2] = 2_842_681,
-                [CirrusBuriedDeployments.Release1100] = 2_796_000,
-                [CirrusBuriedDeployments.GetMiningTimestampV2] = 3_000_000, // 15 January 2022
-                [CirrusBuriedDeployments.GetMiningTimestampV2Strict] = 3_121_500, // 17 January 2022
-                [CirrusBuriedDeployments.Release1300] = 3_280_032,
-                [CirrusBuriedDeployments.Release1320] = 3_588_480,
-                [CirrusBuriedDeployments.Release1324] = 3_951_360,
-                [CirrusBuriedDeployments.Release1400] = 4_074_250
+                [PoABuriedDeployments.InterFluxV2MainChain] = 500_000,
+                [PoABuriedDeployments.VotingManagerV2] = 1_999_500,
+                [PoABuriedDeployments.ContractSerializerV2] = 2_842_681,
+                [PoABuriedDeployments.Release1100] = 2_796_000,
+                [PoABuriedDeployments.GetMiningTimestampV2] = 3_000_000, // 15 January 2022
+                [PoABuriedDeployments.GetMiningTimestampV2Strict] = 3_121_500, // 17 January 2022
+                [PoABuriedDeployments.Release1300] = 3_280_032,
+                [PoABuriedDeployments.Release1320] = 3_588_480,
+                [PoABuriedDeployments.Release1324] = 3_951_360,
+                [PoABuriedDeployments.Release1400] = 4_074_250
             };
 
             var consensusOptions = new PoAConsensusOptions(
@@ -139,7 +139,7 @@ namespace Stratis.Sidechains.Networks
                 targetSpacingSeconds: 16,
                 votingEnabled: true,
                 autoKickIdleMembers: true,
-                contractSerializerV2ActivationHeight: buriedDeployments[CirrusBuriedDeployments.ContractSerializerV2],
+                contractSerializerV2ActivationHeight: buriedDeployments[PoABuriedDeployments.ContractSerializerV2],
                 federationMemberMaxIdleTimeSeconds: 60 * 30 // 30 minutes
             )
             {

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -141,6 +141,8 @@ namespace Stratis.Sidechains.Networks
             activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2] = 3_000_000; // 15 January 2022
             activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2Strict] = 3_121_500; // 17 January 2022
             activationHeights[(int)PoAActivationHeights.Release1300] = 3_280_032;
+            activationHeights[(int)PoAActivationHeights.Release1320] = 3_588_480;
+            activationHeights[(int)PoAActivationHeights.Release1324] = 3_951_360;
             activationHeights[(int)PoAActivationHeights.Release1400] = 4_074_250;
 
             var buriedDeployments = new BuriedDeploymentsArray

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using NBitcoin;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
@@ -127,18 +128,20 @@ namespace Stratis.Sidechains.Networks
                 federationMemberMaxIdleTimeSeconds: 60 * 30 // 30 minutes
             )
             {
-                InterFluxV2MainChainActivationHeight = 500_000,
                 EnforceMinProtocolVersionAtBlockHeight = 505900, // setting the value to zero makes the functionality inactive
                 EnforcedMinProtocolVersion = ProtocolVersion.CIRRUS_VERSION, // minimum protocol version which will be enforced at block height defined in EnforceMinProtocolVersionAtBlockHeight
-                VotingManagerV2ActivationHeight = 1_999_500,
-                Release1100ActivationHeight = 2_796_000,
-                PollExpiryBlocks = 450,
-                GetMiningTimestampV2ActivationHeight = 3_000_000, // 15 January 2022
-                GetMiningTimestampV2ActivationStrictHeight = 3_121_500, // 17 January 2022
-                ContractSerializerV2ActivationHeight = 2_842_681,
-                Release1300ActivationHeight = 3_280_032,
-                Release1400ActivationHeight = 4_074_250,
+                PollExpiryBlocks = 450
             };
+
+            var activationHeights = consensusOptions.ActivationHeights;
+            activationHeights[(int)PoAActivationHeights.InterFluxV2MainChain] = 500_000;
+            activationHeights[(int)PoAActivationHeights.VotingManagerV2] = 1_999_500;
+            activationHeights[(int)PoAActivationHeights.ContractSerializerV2] = 2_842_681;
+            activationHeights[(int)PoAActivationHeights.Release1100] = 2_796_000;
+            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2] = 3_000_000; // 15 January 2022
+            activationHeights[(int)PoAActivationHeights.GetMiningTimestampV2Strict] = 3_121_500; // 17 January 2022
+            activationHeights[(int)PoAActivationHeights.Release1300] = 3_280_032;
+            activationHeights[(int)PoAActivationHeights.Release1400] = 4_074_250;
 
             var buriedDeployments = new BuriedDeploymentsArray
             {
@@ -150,8 +153,8 @@ namespace Stratis.Sidechains.Networks
             var bip9Deployments = new CirrusBIP9Deployments()
             {
                 // Deployment will go active once 75% of nodes are on 1.3.0.0 or later.
-                [CirrusBIP9Deployments.Release1320] = new BIP9DeploymentsParameters("Release1320", CirrusBIP9Deployments.FlagBitRelease1320, DateTime.Parse("2022-6-15 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-1-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold),
-                [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1324, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-3-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
+                // Example:
+                // [CirrusBIP9Deployments.Release1324] = new BIP9DeploymentsParameters("Release1324", CirrusBIP9Deployments.FlagBitRelease1324, DateTime.Parse("2022-10-10 +0").ToUnixTimestamp() /* Activation date lower bound */, DateTime.Parse("2023-3-1 +0").ToUnixTimestamp(), BIP9DeploymentsParameters.DefaultRegTestThreshold)
             };
 
             this.Consensus = new Consensus(

--- a/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
+++ b/src/Stratis.Sidechains.Networks/Deployments/CirrusBIP9Deployments.cs
@@ -8,14 +8,14 @@ namespace Stratis.Sidechains.Networks.Deployments
     public class CirrusBIP9Deployments : BIP9DeploymentsArray
     {
         // The position of each deployment in the deployments array. Note that this is decoupled from the actual position of the flag bit for the deployment in the block version.
-        public const int Release1320 = 0;
-        public const int Release1324 = 1;
+        //public const int Release1320 = 0;
+        //public const int Release1324 = 1;
 
-        public const int FlagBitRelease1320 = 1;
-        public const int FlagBitRelease1324 = 2;
+        //public const int FlagBitRelease1320 = 1;
+        //public const int FlagBitRelease1324 = 2;
 
         // The number of deployments.
-        public const int NumberOfDeployments = 2;
+        public const int NumberOfDeployments = 0;
 
         /// <summary>
         /// Constructs the BIP9 deployments array.

--- a/src/Stratis.SmartContracts.CLR/Serialization/ContractPrimitiveSerializer.cs
+++ b/src/Stratis.SmartContracts.CLR/Serialization/ContractPrimitiveSerializer.cs
@@ -26,7 +26,7 @@ namespace Stratis.SmartContracts.CLR.Serialization
 
         public override object Deserialize(Type type, byte[] stream)
         {
-            if (this.network.Consensus.Options is PoAConsensusOptions poaConsensusOptions && this.chainIndexer.Tip.Height <= poaConsensusOptions.ActivationHeights[(int)PoAActivationHeights.ContractSerializerV2])
+            if (this.network.Consensus.Options is PoAConsensusOptions poaConsensusOptions && this.chainIndexer.Tip.Height <= this.network.Consensus.PoABuriedDeployments(PoABuriedDeployments.ContractSerializerV2))
                 return this.serializerV1.Deserialize(type, stream);
 
             return base.Deserialize(type, stream);

--- a/src/Stratis.SmartContracts.CLR/Serialization/ContractPrimitiveSerializer.cs
+++ b/src/Stratis.SmartContracts.CLR/Serialization/ContractPrimitiveSerializer.cs
@@ -26,7 +26,7 @@ namespace Stratis.SmartContracts.CLR.Serialization
 
         public override object Deserialize(Type type, byte[] stream)
         {
-            if (this.network.Consensus.Options is PoAConsensusOptions poaConsensusOptions && this.chainIndexer.Tip.Height <= poaConsensusOptions.ContractSerializerV2ActivationHeight)
+            if (this.network.Consensus.Options is PoAConsensusOptions poaConsensusOptions && this.chainIndexer.Tip.Height <= poaConsensusOptions.ActivationHeights[(int)PoAActivationHeights.ContractSerializerV2])
                 return this.serializerV1.Deserialize(type, stream);
 
             return base.Deserialize(type, stream);

--- a/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
+++ b/src/Stratis.SmartContracts.Networks/SmartContractsPoARegTest.cs
@@ -65,17 +65,11 @@ namespace Stratis.SmartContracts.Networks
                 genesisFederationMembers: genesisFederationMembers,
                 targetSpacingSeconds: 60,
                 votingEnabled: true,
-                autoKickIdleMembers: false
+                autoKickIdleMembers: false,
+                contractSerializerV2ActivationHeight: 0
             )
             {
                 PollExpiryBlocks = 450
-            };
-
-            var buriedDeployments = new BuriedDeploymentsArray
-            {
-                [BuriedDeployments.BIP34] = 0,
-                [BuriedDeployments.BIP65] = 0,
-                [BuriedDeployments.BIP66] = 0
             };
 
             var bip9Deployments = new NoBIP9Deployments();
@@ -89,7 +83,7 @@ namespace Stratis.SmartContracts.Networks
                 majorityEnforceBlockUpgrade: 750,
                 majorityRejectBlockOutdated: 950,
                 majorityWindow: 1000,
-                buriedDeployments: buriedDeployments,
+                buriedDeployments: new PoABuriedDeploymentsArray(),
                 bip9Deployments: bip9Deployments,
                 bip34Hash: new uint256("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
                 minerConfirmationWindow: 2016, // nPowTargetTimespan / nPowTargetSpacing


### PR DESCRIPTION
This PR:
- Removes the legacy BIP 9's and replaces them with hard-coded heights
- Moves the activation heights into the `PoABuriedDeploymentsArray`. Some advantages to this:
   - The `PoAConsensusOptions` class-definition will remain static instead of changing with almost every release.