### PR TITLE
Add -blockmintxfee setting

### DIFF
--- a/src/Stratis.Bitcoin.Features.Miner/BlockDefinitionOptions.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/BlockDefinitionOptions.cs
@@ -20,11 +20,11 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <summary>Minimum fee rate for transactions to be included in blocks created by miner.</summary>
         public FeeRate BlockMinFeeRate { get; private set; }
 
-        public BlockDefinitionOptions(uint blockMaxWeight, uint blockMaxSize)
+        public BlockDefinitionOptions(uint blockMaxWeight, uint blockMaxSize, uint blockMinTxFee)
         {
             this.BlockMaxWeight = blockMaxWeight;
             this.BlockMaxSize = blockMaxSize;
-            this.BlockMinFeeRate = new FeeRate(PowMining.DefaultBlockMinTxFee); // TODO: Where should this be set, really?
+            this.BlockMinFeeRate = new FeeRate(blockMinTxFee);
         }
 
         /// <summary>
@@ -38,6 +38,8 @@ namespace Stratis.Bitcoin.Features.Miner
             uint minAllowedBlockWeight = MinBlockSize * (uint) network.Consensus.Options.WitnessScaleFactor;
             this.BlockMaxWeight = Math.Max(minAllowedBlockWeight, Math.Min(network.Consensus.Options.MaxBlockWeight, this.BlockMaxWeight));
             this.BlockMaxSize = Math.Max(MinBlockSize, Math.Min(network.Consensus.Options.MaxBlockSerializedSize, this.BlockMaxSize));
+
+            // Note: The minimum fee rate is not a consensus parameter; miners can elect to include low or zero-fee transactions if they wish.
 
             return this;
         }

--- a/src/Stratis.Bitcoin.Features.Miner/MinerSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MinerSettings.cs
@@ -74,6 +74,10 @@ namespace Stratis.Bitcoin.Features.Miner
         private uint BlockMaxWeight { get { return this.blockMaxWeight ?? this.nodeSettings.Network.Consensus.Options.MaxBlockWeight; } set { this.blockMaxWeight = value; } }
         private uint? blockMaxWeight = null;
 
+        [CommandLineOption("blockmintxfee", "Set lowest fee rate (in BTC/kvB) for transactions to be included in block creation.")]
+        private uint BlockMinTxFee { get { return this.blockMinTxFee ?? PowMining.DefaultBlockMinTxFee; } set { this.blockMaxWeight = value; } }
+        private uint? blockMinTxFee = null;
+        
         /// <summary>
         /// Settings for <see cref="BlockDefinition"/>.
         /// </summary>
@@ -85,7 +89,7 @@ namespace Stratis.Bitcoin.Features.Miner
         /// <param name="nodeSettings">The node configuration.</param>
         public MinerSettings(NodeSettings nodeSettings) : base(nodeSettings)
         {
-            this.BlockDefinitionOptions = new BlockDefinitionOptions(this.BlockMaxWeight, this.BlockMaxSize).RestrictForNetwork(nodeSettings.Network);
+            this.BlockDefinitionOptions = new BlockDefinitionOptions(this.BlockMaxWeight, this.BlockMaxSize, this.BlockMinTxFee).RestrictForNetwork(nodeSettings.Network);
 
             if (!this.Mine)
                 this.MineAddress = null;

--- a/src/Stratis.Bitcoin.Features.Miner/MinerSettings.cs
+++ b/src/Stratis.Bitcoin.Features.Miner/MinerSettings.cs
@@ -75,8 +75,7 @@ namespace Stratis.Bitcoin.Features.Miner
         private uint? blockMaxWeight = null;
 
         [CommandLineOption("blockmintxfee", "Set lowest fee rate (in BTC/kvB) for transactions to be included in block creation.")]
-        private uint BlockMinTxFee { get { return this.blockMinTxFee ?? PowMining.DefaultBlockMinTxFee; } set { this.blockMaxWeight = value; } }
-        private uint? blockMinTxFee = null;
+        public uint BlockMinTxFee { get; set; } = PowMining.DefaultBlockMinTxFee;
         
         /// <summary>
         /// Settings for <see cref="BlockDefinition"/>.

--- a/src/Stratis.Bitcoin.Features.SmartContracts.Tests/BlockBufferGeneratorTests.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts.Tests/BlockBufferGeneratorTests.cs
@@ -10,7 +10,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Tests
         public void Buffer_50Kb_For_1MB_BlockSize()
         {
             var network = new SmartContractsRegTest();
-            var optionsFromNetwork = new BlockDefinitionOptions(network.Consensus.Options.MaxBlockWeight, network.Consensus.Options.MaxBlockBaseSize);
+            var optionsFromNetwork = new BlockDefinitionOptions(network.Consensus.Options.MaxBlockWeight, network.Consensus.Options.MaxBlockBaseSize, PowMining.DefaultBlockMinTxFee);
             BlockDefinitionOptions newOptions = new BlockBufferGenerator().GetOptionsWithBuffer(optionsFromNetwork);
 
             Assert.Equal((uint)950_000, newOptions.BlockMaxWeight);

--- a/src/Stratis.Bitcoin.Features.SmartContracts/BlockBufferGenerator.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/BlockBufferGenerator.cs
@@ -7,7 +7,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts
         public BlockDefinitionOptions GetOptionsWithBuffer(BlockDefinitionOptions options)
         {
             uint percentageToBuild = 95; // For 1MB blocks, 50 KB reserved for generated transactions / txouts
-            return new BlockDefinitionOptions(options.BlockMaxSize * percentageToBuild / 100, options.BlockMaxWeight * percentageToBuild / 100);
+            return new BlockDefinitionOptions(options.BlockMaxSize * percentageToBuild / 100, options.BlockMaxWeight * percentageToBuild / 100, (uint)options.BlockMinFeeRate.FeePerK.Satoshi);
         }
     }
 }

--- a/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Controllers/WalletController.cs
@@ -753,7 +753,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Controllers
         {
             return await this.ExecuteAsAsync(request, cancellationToken,
                 (req, token) =>
-                    this.Json(this.walletManager.RetrievePrivateKey(request.Password, request.WalletName, request.Address)));
+                    this.Json(this.walletManager.RetrievePrivateKey(request.WalletName, request.Address, request.Password)));
         }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Interfaces/IWalletManager.cs
@@ -89,11 +89,11 @@ namespace Stratis.Bitcoin.Features.Wallet.Interfaces
         /// <summary>
         /// Gets the private key associated with an address in the wallet.
         /// </summary>
-        /// <param name="password">The user's password.</param>
         /// <param name="walletName">The name of the wallet.</param>
         /// <param name="address">Address to extract the private key of.</param>
+        /// <param name="password">The user's password.</param>
         /// <returns>The private key associated with the given address, in WIF representation.</returns>
-        string RetrievePrivateKey(string password, string walletName, string address);
+        string RetrievePrivateKey(string walletName, string address, string password = null);
 
         /// <summary>
         /// Signs a string message.

--- a/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/WalletRPCController.cs
@@ -12,6 +12,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Stratis.Bitcoin.Consensus;
 using Stratis.Bitcoin.Controllers;
+using Stratis.Bitcoin.Controllers.Models;
 using Stratis.Bitcoin.Features.BlockStore;
 using Stratis.Bitcoin.Features.RPC;
 using Stratis.Bitcoin.Features.RPC.Exceptions;
@@ -23,6 +24,7 @@ using Stratis.Bitcoin.Interfaces;
 using Stratis.Bitcoin.Primitives;
 using Stratis.Bitcoin.Utilities;
 using TracerAttributes;
+using Script = NBitcoin.Script;
 
 namespace Stratis.Bitcoin.Features.Wallet
 {
@@ -140,6 +142,24 @@ namespace Stratis.Bitcoin.Features.Wallet
 
                 uint256 hash = transaction.GetHash();
                 return hash;
+            }
+            catch (SecurityException)
+            {
+                throw new RPCServerException(RPCErrorCode.RPC_WALLET_UNLOCK_NEEDED, "Wallet unlock needed");
+            }
+            catch (WalletException exception)
+            {
+                throw new RPCServerException(RPCErrorCode.RPC_WALLET_ERROR, exception.Message);
+            }
+        }
+
+        [ActionName("dumpprivkey")]
+        [ActionDescription("Reveals the private key corresponding to ‘address’.")]
+        public object DumpPrivKey(string address)
+        {
+            try
+            {
+                return new StringModel(this.walletManager.RetrievePrivateKey(this.GetWallet(), address));
             }
             catch (SecurityException)
             {

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -421,7 +421,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         {
             var commands = JsonDataSerializer.Instance.Deserialize<List<RpcCommandModel>>(this.responseText);
 
-            commands.Count.Should().Be(39);
+            commands.Count.Should().Be(40);
         }
 
         private void status_information_is_returned()

--- a/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletRPCControllerTest.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/Wallet/WalletRPCControllerTest.cs
@@ -56,6 +56,41 @@ namespace Stratis.Bitcoin.IntegrationTests.Wallet
         }
 
         [Fact]
+        public async Task DumpPrivKeyResultGivesCorrectPubkey()
+        {
+            using (NodeBuilder builder = NodeBuilder.Create(this))
+            {
+                CoreNode node = builder.CreateStratisPosNode(this.network).WithWallet().Start();
+
+                RPCClient rpc = node.CreateRPCClient();
+
+                BitcoinAddress address = await rpc.GetNewAddressAsync();
+
+                string apiPubkey = await $"http://localhost:{node.ApiPort}/api"
+                    .AppendPathSegment("Wallet/pubkey")
+                    .PostJsonAsync(new PubKeyRequest() { ExternalAddress = address.ToString(), WalletName = node.WalletName })
+                    .ReceiveJson<string>();
+
+                string apiPrivateKeyWif = await $"http://localhost:{node.ApiPort}/api"
+                    .AppendPathSegment("Wallet/privatekey")
+                    .PostJsonAsync(new RetrievePrivateKeyModel() { Address = address.ToString(), Password = node.WalletPassword, WalletName = node.WalletName })
+                    .ReceiveJson<string>();
+
+                string apiPubkeyFromWif = this.network.Parse<BitcoinSecret>(apiPrivateKeyWif).PubKey.ToHex();
+
+                Assert.Equal(apiPubkey, apiPubkeyFromWif);
+
+                await rpc.WalletPassphraseAsync(node.WalletPassword, 3600);
+
+                BitcoinSecret rpcPrivateKey = await rpc.DumpPrivKeyAsync(address);
+
+                string rpcPubkeyHex = rpcPrivateKey.PubKey.ToHex();
+
+                Assert.Equal(apiPubkey, rpcPubkeyHex);
+            }
+        }
+
+        [Fact]
         public void GetTransactionDoesntExistInWalletOrBlock()
         {
             string txId = "f13effbbfc1b3d556dbfa25129e09209c9c57ed2737457f5080b78984a8c8554";

--- a/src/Stratis.Bitcoin/Controllers/Models/StringModel.cs
+++ b/src/Stratis.Bitcoin/Controllers/Models/StringModel.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using Stratis.Bitcoin.Controllers.Converters;
+
+namespace Stratis.Bitcoin.Controllers.Models
+{
+    /// <summary>
+    /// Temporary workaround; the RPC middleware does not correctly return JSON for a raw string object, so we have to wrap a string response with this model.
+    /// <seealso cref="HexModel">See also how 'getblockheader' returns a hex string.</seealso>
+    /// </summary>
+    [JsonConverter(typeof(ToStringJsonConverter))]
+    public class StringModel
+    {
+        public string Str { get; set; }
+
+        public StringModel(string str)
+        {
+            this.Str = str;
+        }
+
+        public override string ToString()
+        {
+            return this.Str;
+        }
+    }
+}


### PR DESCRIPTION
Currently transactions that fall below the relay fee rate minimum of 0.0001 STRAX per KB can still be mined into blocks. However, the block construction has a further (currently hardcoded) limit of 0.00001 STRAX per KB. Transactions that are below this fee rate will never be included in blocks even if they make it into a node's mempool. This change makes this lower limit configurable, similarly to the `-blockmintxfee` setting in bitcoind. The default value has been kept.

It would have been nice to remove the `PowMining.DefaultBlockMinTxFee` value entirely and base the default minimum fee rate on the node relay policies, but the value gets used in several tests and it was cleaner to keep it for now to tie all the 'magic numbers' together. It is also unclear whether increasing the block fee minimum tenfold to match the relay minimum would have any adverse impact.

The `dumpprivkey` RPC command commits also seem to be missing from the 1.5.0.0 branch, so they have been brought in here.