### PR TITLE
[RPC] Add createrawtransaction RPC method

### DIFF
--- a/src/Stratis.Bitcoin.Features.RPC/ModelBinders/CreateRawTransactionModelBinder.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/ModelBinders/CreateRawTransactionModelBinder.cs
@@ -1,0 +1,41 @@
+﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Stratis.Bitcoin.Features.RPC.Models;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Bitcoin.Features.RPC.ModelBinders
+{
+    public class CreateRawTransactionInputBinder : IModelBinder, IModelBinderProvider
+    {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
+            if (bindingContext.ModelType != typeof(CreateRawTransactionInput[]))
+            {
+                return Task.CompletedTask;
+            }
+
+            ValueProviderResult val = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+
+            string key = val.FirstValue;
+
+            if (key == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            CreateRawTransactionInput[] inputs = Serializer.ToObject<CreateRawTransactionInput[]>(key);
+
+            bindingContext.Result = ModelBindingResult.Success(inputs);
+
+            return Task.CompletedTask;
+        }
+
+        public IModelBinder GetBinder(ModelBinderProviderContext context)
+        {
+            if (context.Metadata.ModelType == typeof(CreateRawTransactionInput[]))
+                return this;
+
+            return null;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.RPC/ModelBinders/CreateRawTransactionOutputBinder.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/ModelBinders/CreateRawTransactionOutputBinder.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json.Linq;
+using Stratis.Bitcoin.Features.RPC.Models;
+
+public class CreateRawTransactionOutputBinder : IModelBinder, IModelBinderProvider
+{
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        if (bindingContext.ModelType != typeof(CreateRawTransactionOutput[]))
+        {
+            return Task.CompletedTask;
+        }
+
+        ValueProviderResult val = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+
+        string raw = val.FirstValue;
+
+        if (raw == null)
+        {
+            return Task.CompletedTask;
+        }
+
+        JArray outerArray = JArray.Parse(raw);
+
+        var model = new List<CreateRawTransactionOutput>();
+
+        foreach (var item in outerArray.Children<JObject>())
+        {
+            foreach (JProperty property in item.Properties())
+            {
+                string addressOrData = property.Name;
+                string value = property.Value.ToString();
+
+                model.Add(new CreateRawTransactionOutput() { Key = addressOrData, Value = value });
+            }
+        }
+
+        bindingContext.Result = ModelBindingResult.Success(model.ToArray());
+
+        return Task.CompletedTask;
+    }
+
+    public IModelBinder GetBinder(ModelBinderProviderContext context)
+    {
+        if (context.Metadata.ModelType == typeof(CreateRawTransactionOutput[]))
+            return this;
+
+        return null;
+    }
+}

--- a/src/Stratis.Bitcoin.Features.RPC/Models/CreateRawTransactionModels.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Models/CreateRawTransactionModels.cs
@@ -1,0 +1,42 @@
+﻿using NBitcoin;
+using Newtonsoft.Json;
+
+namespace Stratis.Bitcoin.Features.RPC.Models
+{
+    /// <summary>
+    /// Used for storing the data that represents desired transaction inputs for the createrawtransaction RPC call.
+    /// </summary>
+    public class CreateRawTransactionInput
+    {
+        [JsonProperty(PropertyName = "txid")]
+        public uint256 TxId { get; set; }
+
+        [JsonProperty(PropertyName = "vout")]
+        public int VOut { get; set; }
+
+        [JsonProperty(PropertyName = "sequence")]
+        public int Sequence { get; set; }
+    }
+
+    /// <summary>
+    /// Used for storing the key-value pairs that represent desired transaction outputs for the createrawtransaction RPC call.
+    /// </summary>
+    /// <remarks>The key and value properties are populated by a custom model binder and therefore never appear with those names in the raw JSON.</remarks>
+    public class CreateRawTransactionOutput
+    {
+            [JsonProperty]
+            public string Key { get; set; }
+
+            [JsonProperty]
+            public string Value { get; set; }
+    }
+
+    public class CreateRawTransactionResponse
+    {
+        [JsonProperty(PropertyName = "hex")]
+        public Transaction Transaction
+        {
+            get; set;
+        }
+    }
+}

--- a/src/Stratis.Bitcoin.Features.RPC/Models/CreateRawTransactionModels.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Models/CreateRawTransactionModels.cs
@@ -37,9 +37,6 @@ namespace Stratis.Bitcoin.Features.RPC.Models
     public class CreateRawTransactionResponse
     {
         [JsonProperty(PropertyName = "hex")]
-        public Transaction Transaction
-        {
-            get; set;
-        }
+        public Transaction Transaction { get; set; }
     }
 }

--- a/src/Stratis.Bitcoin.Features.RPC/Models/CreateRawTransactionModels.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/Models/CreateRawTransactionModels.cs
@@ -12,10 +12,13 @@ namespace Stratis.Bitcoin.Features.RPC.Models
         public uint256 TxId { get; set; }
 
         [JsonProperty(PropertyName = "vout")]
-        public int VOut { get; set; }
+        public uint VOut { get; set; }
 
+        /// <summary>
+        /// If not provided, the sequence in the created transaction will be set to uint.MaxValue by default.
+        /// </summary>
         [JsonProperty(PropertyName = "sequence")]
-        public int Sequence { get; set; }
+        public uint? Sequence { get; set; }
     }
 
     /// <summary>

--- a/src/Stratis.Bitcoin.Features.RPC/RPCClient.Wallet.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCClient.Wallet.cs
@@ -6,6 +6,7 @@ using NBitcoin;
 using NBitcoin.DataEncoders;
 using NBitcoin.Protocol;
 using Newtonsoft.Json.Linq;
+using Stratis.Bitcoin.Features.RPC.Models;
 
 namespace Stratis.Bitcoin.Features.RPC
 {
@@ -52,7 +53,7 @@ namespace Stratis.Bitcoin.Features.RPC
         wallet             signmessage
         wallet             walletlock
         wallet             walletpassphrasechange
-        wallet             walletpassphrase            yes
+        wallet             walletpassphrase            Yes
     */
     public partial class RPCClient
     {
@@ -134,6 +135,44 @@ namespace Stratis.Bitcoin.Features.RPC
         {
             RPCResponse response = SendCommand(RPCOperations.getaddressesbyaccount, account);
             return response.Result.Select(t => this.Network.Parse<BitcoinAddress>((string)t));
+        }
+
+        public CreateRawTransactionResponse CreateRawTransaction(CreateRawTransactionInput[] inputs, List<KeyValuePair<string,string>> outputs, int locktime = 0, bool replaceable = false)
+        {
+            return CreateRawTransactionAsync(inputs, outputs, locktime, replaceable).GetAwaiter().GetResult();
+        }
+
+        public async Task<CreateRawTransactionResponse> CreateRawTransactionAsync(CreateRawTransactionInput[] inputs, List<KeyValuePair<string, string>> outputs, int locktime = 0, bool replaceable = false)
+        {
+            var jOutputs = new JArray();
+
+            /* Need the layout of the output array to look like the following, per bitcoind documentation:
+
+                [
+                  {                       (json object)
+                    "address": amount,    (numeric or string, required) A key-value pair. The key (string) is the bitcoin address, the value (float or string) is the amount in BTC
+                  },
+                  {                       (json object)
+                    "data": "hex",        (string, required) A key-value pair. The key must be "data", the value is hex-encoded data
+                  },
+                  ...
+                ]
+            */
+            foreach (KeyValuePair<string, string> kv in outputs)
+            {
+                var temp = new JObject();
+                temp.Add(new JProperty(kv.Key, kv.Value));
+                jOutputs.Add(temp);
+            }
+
+            RPCResponse response = await SendCommandAsync(RPCOperations.createrawtransaction, inputs, jOutputs, locktime, replaceable).ConfigureAwait(false);
+
+            var r = (JObject)response.Result;
+
+            return new CreateRawTransactionResponse()
+            {
+                Transaction = this.network.CreateTransaction(r["hex"].Value<string>())
+            };
         }
 
         public FundRawTransactionResponse FundRawTransaction(Transaction transaction, FundRawTransactionOptions options = null, bool? isWitness = null)

--- a/src/Stratis.Bitcoin.Features.RPC/RPCClient.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCClient.cs
@@ -104,7 +104,7 @@ namespace Stratis.Bitcoin.Features.RPC
         generating         generate
 
         ------------------ Raw transactions
-        rawtransactions    createrawtransaction
+        rawtransactions    createrawtransaction         Yes
         rawtransactions    decoderawtransaction         Yes
         rawtransactions    decodescript
         rawtransactions    getrawtransaction            Yes

--- a/src/Stratis.Bitcoin.Features.RPC/RPCOperations.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/RPCOperations.cs
@@ -16,6 +16,7 @@
         importpubkey,
         dumpwallet,
         importwallet,
+        setwallet,
 
         getgenerate,
         setgenerate,

--- a/src/Stratis.Bitcoin.Features.RPC/WebHostExtensions.cs
+++ b/src/Stratis.Bitcoin.Features.RPC/WebHostExtensions.cs
@@ -18,6 +18,8 @@ namespace Stratis.Bitcoin.Features.RPC
                     o.ModelBinderProviders.Insert(0, new DestinationModelBinder());
                     o.ModelBinderProviders.Insert(0, new MoneyModelBinder());
                     o.ModelBinderProviders.Insert(0, new FundRawTransactionOptionsBinder());
+                    o.ModelBinderProviders.Insert(0, new CreateRawTransactionInputBinder());
+                    o.ModelBinderProviders.Insert(0, new CreateRawTransactionOutputBinder());
                 });
 
                 // Include all feature assemblies for action discovery otherwise RPC actions will not execute

--- a/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
+++ b/src/Stratis.Bitcoin.Features.Wallet/Models/RequestModels.cs
@@ -445,6 +445,7 @@ namespace Stratis.Bitcoin.Features.Wallet.Models
         /// <summary>
         /// Whether to send the change to a P2WPKH (segwit bech32) addresses, or a regular P2PKH address
         /// </summary>
+        [DefaultValue(false)]
         public bool SegwitChangeAddress { get; set; }
 
         /// <inheritdoc />

--- a/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
+++ b/src/Stratis.Bitcoin.IntegrationTests/API/ApiSteps.cs
@@ -419,7 +419,7 @@ namespace Stratis.Bitcoin.IntegrationTests.API
         {
             var commands = JsonDataSerializer.Instance.Deserialize<List<RpcCommandModel>>(this.responseText);
 
-            commands.Count.Should().Be(38);
+            commands.Count.Should().Be(39);
         }
 
         private void status_information_is_returned()

--- a/src/Stratis.Bitcoin/Utilities/JsonConverters/Serializer.cs
+++ b/src/Stratis.Bitcoin/Utilities/JsonConverters/Serializer.cs
@@ -1,5 +1,6 @@
 ﻿using NBitcoin;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 
 namespace Stratis.Bitcoin.Utilities.JsonConverters
@@ -37,7 +38,9 @@ namespace Stratis.Bitcoin.Utilities.JsonConverters
             {
                 Formatting = Formatting.Indented
             };
+
             RegisterFrontConverters(settings, network);
+
             return JsonConvert.DeserializeObject<T>(data, settings);
         }
 
@@ -47,8 +50,22 @@ namespace Stratis.Bitcoin.Utilities.JsonConverters
             {
                 Formatting = Formatting.Indented
             };
+
             RegisterFrontConverters(settings, network);
+
             return JsonConvert.SerializeObject(response, settings);
+        }
+
+        public static JToken ToToken<T>(T response, Network network = null)
+        {
+            var settings = new JsonSerializerSettings
+            {
+                Formatting = Formatting.Indented
+            };
+
+            RegisterFrontConverters(settings, network);
+
+            return JToken.FromObject(response, JsonSerializer.Create(settings));
         }
     }
 }


### PR DESCRIPTION
This is a somewhat messy RPC to support as the JSON for specifying outputs does not lend itself to conventional models:

```
[
  {                       (json object)
    "address": amount,    (numeric or string, required) A key-value pair. The key (string) is the bitcoin address, the value (float or string) is the amount in BTC
  },
  {                       (json object)
    "data": "hex",        (string, required) A key-value pair. The key must be "data", the value is hex-encoded data
  },
  ...
]
```

It was also found that the RPC client's request handling did not properly support serialising complex models; this has been amended for this RPC call and may make it easier to support others with complex parameters in the future.