### PR TITLE
Optimise StraxMain/StraxTest dockerfiles

### DIFF
--- a/Docker/README.md
+++ b/Docker/README.md
@@ -31,7 +31,7 @@ docker run --mount source=stratisfullnode,target=/root/.stratisnode -it <contain
 
 ## Optionally forward ports from your localhost to the docker image
 
-When running the image, add a `-p <containerPort>:<localPort>` to formward the ports:
+When running the image, add a `-p <containerPort>:<localPort>` to forward the ports:
 
 ```
 docker run -p 17105:17105 -it <containerId>
@@ -42,20 +42,14 @@ docker run -p 17105:17105 -it <containerId>
 docker build . --no-cache 
 ```
 
-## Run image on the MainNet rather than the TestNet. 
+## Run image with modified configuration options
 
-Modify the Dockerfile to put the conf file in the right location and remove the "-testnet" from the run statement. 
+Modify the Dockerfile to put the conf file in the right location and modify/uncomment the settings as needed.
+The path shown below is for StraxMain, other networks will require a modified path:
 
 ``` 
 ---
 
 COPY strax.conf.docker /root/.stratisnode/strax/StraxMain/strax.conf
 
---- 
-
-CMD ["dotnet", "run"]
-
 ``` 
-
-Also remove `testnet=1` from the `*.docker.conf` file.
-

--- a/Docker/Stratis.StraxD.TestNet/Dockerfile
+++ b/Docker/Stratis.StraxD.TestNet/Dockerfile
@@ -1,11 +1,19 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
 
 ARG APPVERSION=master
 ENV APPVERSION=${APPVERSION}
 
 RUN if [ "$APPVERSION" = "master" ]; then git clone https://github.com/stratisproject/StratisFullNode.git; else git clone https://github.com/stratisproject/StratisFullNode.git -b "release/${APPVERSION}"; fi 
 RUN cd /StratisFullNode/src/Stratis.StraxD && dotnet build
-VOLUME /root/.stratisfullnode
-WORKDIR /StratisFullNode/src/Stratis.StraxD
-EXPOSE 27103 27104 27105
-ENTRYPOINT ["dotnet", "run", "-testnet"]
+
+FROM mcr.microsoft.com/dotnet/aspnet:3.1
+
+COPY --from=build /StratisFullNode/src/Stratis.StraxD/bin/Debug/netcoreapp3.1 .
+
+VOLUME /root/.stratisnode
+
+WORKDIR .
+
+EXPOSE 27102 27103 27104 27105
+
+ENTRYPOINT ["dotnet", "Stratis.StraxD.dll", "-testnet"]

--- a/Docker/Stratis.StraxD/Dockerfile
+++ b/Docker/Stratis.StraxD/Dockerfile
@@ -1,11 +1,19 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
 
 ARG APPVERSION=master
 ENV APPVERSION=${APPVERSION}
 
 RUN if [ "$APPVERSION" = "master" ]; then git clone https://github.com/stratisproject/StratisFullNode.git; else git clone https://github.com/stratisproject/StratisFullNode.git -b "release/${APPVERSION}"; fi 
 RUN cd /StratisFullNode/src/Stratis.StraxD && dotnet build
-VOLUME /root/.stratisfullnode
-WORKDIR /StratisFullNode/src/Stratis.StraxD
-EXPOSE 17105 17104 17103
-ENTRYPOINT ["dotnet", "run"]
+
+FROM mcr.microsoft.com/dotnet/aspnet:3.1
+
+COPY --from=build /StratisFullNode/src/Stratis.StraxD/bin/Debug/netcoreapp3.1 .
+
+VOLUME /root/.stratisnode
+
+WORKDIR .
+
+EXPOSE 17102 17103 17104 17105
+
+ENTRYPOINT ["dotnet", "Stratis.StraxD.dll"]


### PR DESCRIPTION
This results in the images being considerably smaller, by building the daemon in the first stage and then only copying the compiled binaries to the next stage. Since we no longer need the full SDK in the second stage, the resulting image is only about 320mb.

I attempted to build the images using Alpine as well but that introduced several issues for only a modest further space reduction (final image ~200mb).