### PR TITLE
Make WalletSyncManager more robust

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletSyncManager.cs
@@ -89,7 +89,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 // state (behind the best chain).
                 ICollection<uint256> locators = this.federationWalletManager.GetWallet().BlockLocator;
                 var blockLocator = new BlockLocator { Blocks = locators.ToList() };
-                ChainedHeader fork = this.chain.FindFork(blockLocator);
+                ChainedHeader fork = this.chain.FindFork(blockLocator) ?? this.chain.Genesis;
                 this.federationWalletManager.RemoveBlocks(fork);
                 this.federationWalletManager.WalletTipHash = fork.HashBlock;
                 this.walletTip = fork;


### PR DESCRIPTION
Addresses the following error:

```
[2023-02-22 04:13:07.9312 8] INFO: Stratis.Features.FederatedPeg.Wallet.FederationWalletSyncManager.Initialize WalletSyncManager initialized. Wallet at block 0.
[2023-02-22 04:13:07.9373 4] INFO: Stratis.Features.FederatedPeg.TargetChain.MaturedBlocksSyncManager.SyncDepositsAsync The CCTS will start processing deposits once the federation wallet has been activated.
[2023-02-22 04:13:07.9373 1] ERROR: Stratis.Bitcoin.Builder.FullNodeFeatureExecutor.LogAndAddException An error occurred starting full node feature 'FederatedPegFeature'.
[2023-02-22 04:13:07.9916 1] ERROR: Stratis.Bitcoin.Builder.FullNodeFeatureExecutor.Initialize An error occurred starting the application: System.AggregateException: One or more errors occurred. (An error occurred starting full node feature 'FederatedPegFeature'.)
	 ---> System.Exception: An error occurred starting full node feature 'FederatedPegFeature'.
	 ---> System.ArgumentNullException: Value cannot be null. (Parameter 'fork')
	   at Stratis.Bitcoin.Utilities.Guard.NotNull[T](T value, String parameterName) in C:\Users\Gustav\Desktop\SidechainMasternode-Latest\src\Stratis.Bitcoin\Utilities\Guard.cs:line 46
	   at Stratis.Features.FederatedPeg.Wallet.FederationWalletManager.RemoveBlocks(ChainedHeader fork) in C:\Users\Gustav\Desktop\SidechainMasternode-Latest\src\Stratis.Features.FederatedPeg\Wallet\FederationWalletManager.cs:line 0
	   at Stratis.Features.FederatedPeg.Wallet.FederationWalletSyncManager.Initialize() in C:\Users\Gustav\Desktop\SidechainMasternode-Latest\src\Stratis.Features.FederatedPeg\Wallet\FederationWalletSyncManager.cs:line 93
	   at Stratis.Features.FederatedPeg.FederatedPegFeature.InitializeAsync() in C:\Users\Gustav\Desktop\SidechainMasternode-Latest\src\Stratis.Features.FederatedPeg\FederatedPegFeature.cs:line 136
	   at Stratis.Bitcoin.Builder.FullNodeFeatureExecutor.<Initialize>b__4_1(IFullNodeFeature feature) in C:\Users\Gustav\Desktop\SidechainMasternode-Latest\src\Stratis.Bitcoin\Builder\FullNodeFeatureExecutor.cs:line 65
	   at Stratis.Bitcoin.Builder.FullNodeFeatureExecutor.Execute(Action`1 callback, Boolean disposing) in C:\Users\Gustav\Desktop\SidechainMasternode-Latest\src\Stratis.Bitcoin\Builder\FullNodeFeatureExecutor.cs:line 139
	   --- End of inner exception stack trace ---
	   --- End of inner exception stack trace ---
	   at Stratis.Bitcoin.Builder.FullNodeFeatureExecutor.Execute(Action`1 callback, Boolean disposing) in C:\Users\Gustav\Desktop\SidechainMasternode-Latest\src\Stratis.Bitcoin\Builder\FullNodeFeatureExecutor.cs:line 158
	   at Stratis.Bitcoin.Builder.FullNodeFeatureExecutor.Initialize() in C:\Users\Gustav\Desktop\SidechainMasternode-Latest\src\Stratis.Bitcoin\Builder\FullNodeFeatureExecutor.cs:line 61
```