### PR TITLE
Don't process deposits prior to already processed deposits

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksSyncManagerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/MaturedBlocksSyncManagerTests.cs
@@ -21,6 +21,7 @@ namespace Stratis.Features.FederatedPeg.Tests
         private readonly ChainIndexer chainIndexer;
         private readonly ICrossChainTransferStore crossChainTransferStore;
         private readonly IFederationGatewayClient federationGatewayClient;
+        private readonly IFederationNodeClient federationNodeClient;
         private IFederationWalletManager federationWalletManager;
         private IInitialBlockDownloadState initialBlockDownloadState;
         private readonly StraxTest network;
@@ -34,6 +35,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.chainIndexer = new ChainIndexer(this.network);
             this.crossChainTransferStore = Substitute.For<ICrossChainTransferStore>();
             this.federationGatewayClient = Substitute.For<IFederationGatewayClient>();
+            this.federationNodeClient = Substitute.For<IFederationNodeClient>();
 
             this.federationWalletManager = Substitute.For<IFederationWalletManager>();
             this.federationWalletManager.IsFederationWalletActive().Returns(true);
@@ -43,7 +45,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.initialBlockDownloadState = Substitute.For<IInitialBlockDownloadState>();
             this.initialBlockDownloadState.IsInitialBlockDownload().Returns(false);
 
-            this.syncManager = new TestOnlyMaturedBlocksSyncManager(this.asyncProvider, this.chainIndexer, this.crossChainTransferStore, this.federationGatewayClient, this.federationWalletManager, this.initialBlockDownloadState, new NodeLifetime());
+            this.syncManager = new TestOnlyMaturedBlocksSyncManager(this.asyncProvider, this.chainIndexer, this.crossChainTransferStore, this.federationGatewayClient, this.federationNodeClient, this.federationWalletManager, this.initialBlockDownloadState, new NodeLifetime());
         }
 
         [Fact]
@@ -82,7 +84,7 @@ namespace Stratis.Features.FederatedPeg.Tests
         {
             this.initialBlockDownloadState = Substitute.For<IInitialBlockDownloadState>();
             this.initialBlockDownloadState.IsInitialBlockDownload().Returns(true);
-            this.syncManager = new TestOnlyMaturedBlocksSyncManager(this.asyncProvider, this.chainIndexer, this.crossChainTransferStore, this.federationGatewayClient, this.federationWalletManager, this.initialBlockDownloadState, new NodeLifetime());
+            this.syncManager = new TestOnlyMaturedBlocksSyncManager(this.asyncProvider, this.chainIndexer, this.crossChainTransferStore, this.federationGatewayClient, this.federationNodeClient, this.federationWalletManager, this.initialBlockDownloadState, new NodeLifetime());
 
             bool delayRequired = await this.syncManager.ExposedSyncBatchOfBlocksAsync();
             Assert.True(delayRequired);
@@ -102,7 +104,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             this.federationWalletManager = Substitute.For<IFederationWalletManager>();
             this.federationWalletManager.WalletTipHeight.Returns(0);
 
-            this.syncManager = new TestOnlyMaturedBlocksSyncManager(this.asyncProvider, this.chainIndexer, this.crossChainTransferStore, this.federationGatewayClient, this.federationWalletManager, this.initialBlockDownloadState, new NodeLifetime());
+            this.syncManager = new TestOnlyMaturedBlocksSyncManager(this.asyncProvider, this.chainIndexer, this.crossChainTransferStore, this.federationGatewayClient, this.federationNodeClient, this.federationWalletManager, this.initialBlockDownloadState, new NodeLifetime());
 
             bool delayRequired = await this.syncManager.ExposedSyncBatchOfBlocksAsync();
             Assert.True(delayRequired);
@@ -115,6 +117,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                 ChainIndexer chainIndexer,
                 ICrossChainTransferStore crossChainTransferStore,
                 IFederationGatewayClient federationGatewayClient,
+                IFederationNodeClient federationNodeClient,
                 IFederationWalletManager federationWalletManager,
                 IInitialBlockDownloadState initialBlockDownloadState,
                 INodeLifetime nodeLifetime)
@@ -122,6 +125,7 @@ namespace Stratis.Features.FederatedPeg.Tests
                       asyncProvider,
                       crossChainTransferStore,
                       federationGatewayClient,
+                      federationNodeClient,
                       federationWalletManager,
                       initialBlockDownloadState,
                       nodeLifetime,

--- a/src/Stratis.Features.FederatedPeg/Controllers/FederationNodeClient.cs
+++ b/src/Stratis.Features.FederatedPeg/Controllers/FederationNodeClient.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using NBitcoin;
+using Stratis.Bitcoin.Controllers;
+using Stratis.Bitcoin.Controllers.Models;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Features.FederatedPeg.Models;
+using Stratis.Features.PoA.Collateral.CounterChain;
+
+namespace Stratis.Features.FederatedPeg.Controllers
+{
+    public interface IFederationNodeClient : IRestApiClientBase
+    {
+        /// <summary><see cref="FederationGatewayController.GetMaturedBlockDeposits"/></summary>
+        /// <param name="depositId">The deposit to retrieve verbose transaction information for.</param>
+        /// <param name="cancellation">Cancellation Token.</param>
+        Task<TransactionVerboseModel> GetDepositTransactionVerboseAsync(uint256 depositId, CancellationToken cancellation = default);
+    }
+
+    /// <inheritdoc cref="IFederationNodeClient"/>
+    public class FederationNodeClient : RestApiClientBase, IFederationNodeClient
+    {
+        /// <summary>
+        /// Currently the <paramref name="url"/> is required as it needs to be configurable for testing.
+        /// <remarks>
+        /// In a production/live scenario the sidechain and mainnet federation nodes should run on the same machine.
+        /// </remarks>
+        /// </summary>
+        public FederationNodeClient(ICounterChainSettings counterChainSettings, IHttpClientFactory httpClientFactory)
+            : base(httpClientFactory, counterChainSettings.CounterChainApiPort, "Node", $"http://{counterChainSettings.CounterChainApiHost}")
+        {
+        }
+
+        public Task<TransactionVerboseModel> GetDepositTransactionVerboseAsync(uint256 depositId, CancellationToken cancellation = default)
+        {
+            return this.SendGetRequestAsync<TransactionVerboseModel>("getrawtransaction", $"trxid={depositId}&verbose=true", cancellation);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
@@ -298,6 +298,7 @@ namespace Stratis.Features.FederatedPeg
                         services.AddSingleton<IPartialTransactionRequester, PartialTransactionRequester>();
                         services.AddSingleton<MempoolCleaner>();
                         services.AddSingleton<IFederationGatewayClient, FederationGatewayClient>();
+                        services.AddSingleton<IFederationNodeClient, FederationNodeClient>();
 
                         services.AddSingleton<IConversionRequestKeyValueStore, ConversionRequestKeyValueStore>();
                         services.AddSingleton<IConversionRequestRepository, ConversionRequestRepository>();

--- a/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransferStore.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/ICrossChainTransferStore.cs
@@ -2,13 +2,14 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using NBitcoin;
+using Stratis.Bitcoin.Utilities;
 using Stratis.Features.FederatedPeg.Models;
 using Stratis.Features.FederatedPeg.TargetChain;
 
 namespace Stratis.Features.FederatedPeg.Interfaces
 {
     /// <summary>Interface for interacting with the cross-chain transfer database.</summary>
-    public interface ICrossChainTransferStore : IDisposable
+    public interface ICrossChainTransferStore : ILockProtected, IDisposable
     {
         /// <summary>Initializes the cross-chain-transfer store.</summary>
         void Initialize();

--- a/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
@@ -209,8 +209,12 @@ namespace Stratis.Features.FederatedPeg.TargetChain
             // If the last confirmed deposit is not known yet then try to find it via the federation wallet.
             uint maturityTimeOfLastConfirmedDeposit = 0;
 
+            FederationWallet wallet = this.federationWalletManager.GetWallet();
+            if (wallet == null)
+                return 0U;
+
             // Query the wallet for the last confirmed deposit.
-            foreach (WithdrawalDetails withdrawal in this.federationWalletManager.GetWallet().MultiSigAddress.Transactions.GetLastWithdrawals())
+            foreach (WithdrawalDetails withdrawal in wallet.MultiSigAddress.Transactions.GetLastWithdrawals())
             {
                 uint256 depositId = withdrawal.MatchingDepositId;
 

--- a/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/MaturedBlocksSyncManager.cs
@@ -216,7 +216,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
 
                 if (!this.blockTimeOfDeposit.TryGetValue(depositId, out uint blockTime))
                 {
-                    TransactionVerboseModel result2 = await this.federationNodeClient.GetDepositTransactionVerboseAsync(depositId);
+                    TransactionVerboseModel result2 = await this.federationNodeClient.GetDepositTransactionVerboseAsync(depositId).ConfigureAwait(false);
                     if (result2 == null)
                         continue;
 

--- a/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/MultiSigTransactions.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using NBitcoin;
+using Org.BouncyCastle.Crypto.Parameters;
 using Stratis.Bitcoin.Utilities;
 using TracerAttributes;
 
@@ -29,6 +30,18 @@ namespace Stratis.Features.FederatedPeg.Wallet
             this.spendableTransactionList = new SortedList<TransactionData, TransactionData>(Comparer<TransactionData>.Create(DeterministicCoinOrdering.CompareTransactionData));
             this.withdrawalsByDepositDict = new Dictionary<uint256, List<TransactionData>>();
             this.spentTransactionsByHeightDict = new SortedDictionary<int, List<TransactionData>>();
+        }
+
+        public IEnumerable<WithdrawalDetails> GetLastWithdrawals()
+        {
+            foreach (int height in this.spentTransactionsByHeightDict.Keys.Reverse())
+            {
+                foreach (TransactionData transactionData in this.spentTransactionsByHeightDict[height])
+                {
+                    if (transactionData.SpendingDetails?.WithdrawalDetails?.MatchingDepositId != null)
+                        yield return transactionData.SpendingDetails.WithdrawalDetails;
+                }
+            }
         }
 
         private void AddWithdrawal(TransactionData transactionData)


### PR DESCRIPTION
The PR does the following:
1) Avoids processing deposits occurring prior to already processed (with confirmed withdrawal) deposits. Adds the `FederationNodeClient` class to resolve deposit block time information.
2) Adds `FindSidechainHeightWithCommitmentBelowOrEqualMainchainHeight` with `BinarySearch` for optimization.
3) Adds another `BinarySearch` to optimize finding the first block on this chain that has a timestamp after the deposit's block time on the counterchain.
4) Adds the `ILockProtected` interface to `CrossChainTransferStore` to avoid deadlock with `MempoolCleaner`.
5) Only allow `NextMatureDepositHeight` to increase. Never decrease. Removed offending code.