### PR TITLE
Limit how often the wallet is saved

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
@@ -97,7 +97,8 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// <summary>
         /// Saves the wallet into the file system.
         /// </summary>
-        void SaveWallet();
+        /// <param name="force">If <c>false</c> (default) the wallet is not guaranteed to be saved if saved recently.</param>
+        void SaveWallet(bool force = false);
 
         /// <summary>
         /// Gets some general information about a wallet.

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -881,12 +881,12 @@ namespace Stratis.Features.FederatedPeg.Wallet
         /// <inheritdoc />
         public void SaveWallet(bool force = false)
         {
-            // If this is not a forced save then check that we're not saving to wallet too often.
-            if (!force && ((DateTime.Now - this.lastWalletSave) < TimeSpan.FromMinutes(WalletSavetimeMinIntervalInMinutes)))
-                return;
-
             lock (this.lockObject)
             {
+                // If this is not a forced save then check that we're not saving the wallet too often.
+                if (!force && ((DateTime.Now - this.lastWalletSave) < TimeSpan.FromMinutes(WalletSavetimeMinIntervalInMinutes)))
+                    return;
+
                 if (this.Wallet != null)
                 {
                     this.fileStorage.SaveToFile(this.Wallet, WalletFileName);

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -314,7 +314,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
             lock (this.lockObject)
             {
                 this.asyncLoop?.Dispose();
-                this.SaveWallet();
+                this.SaveWallet(true);
             }
         }
 

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -61,10 +61,17 @@ namespace Stratis.Features.FederatedPeg.Wallet
         /// <summary>Timer for saving wallet files to the file system.</summary>
         private const int WalletSavetimeIntervalInMinutes = 5;
 
+        /// <summary>Minimum time to wait between saving wallet if not forced.</summary>
+        private const int WalletSavetimeMinIntervalInMinutes = 1;
+
         /// <summary>Keep at least this many transactions in the wallet despite the
         /// max reorg age limit for spent transactions. This is so that it never
         /// looks like the wallet has become empty to the user.</summary>
         private const int MinimumRetainedTransactions = 100;
+
+
+        /// <summary>The last time the wallet was saved.</summary>
+        private DateTime lastWalletSave;
 
         /// <summary>The async loop we need to wait upon before we can shut down this manager.</summary>
         private IAsyncLoop asyncLoop;
@@ -170,6 +177,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
             this.isFederationActive = false;
             this.blockStore = blockStore;
             this.signals = signals;
+            this.lastWalletSave = DateTime.Now;
 
             nodeStats.RegisterStats(this.AddComponentStats, StatsType.Component, this.GetType().Name);
             nodeStats.RegisterStats(this.AddInlineStats, StatsType.Inline, this.GetType().Name, 800);
@@ -289,7 +297,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 // save the wallets file every 5 minutes to help against crashes.
                 this.asyncLoop = this.asyncProvider.CreateAndRunAsyncLoop("wallet persist job", token =>
                 {
-                    this.SaveWallet();
+                    this.SaveWallet(true);
                     this.logger.LogInformation("Wallets saved to file at {0}.", this.dateTimeProvider.GetUtcNow());
 
                     return Task.CompletedTask;
@@ -871,16 +879,18 @@ namespace Stratis.Features.FederatedPeg.Wallet
         }
 
         /// <inheritdoc />
-        public void SaveWallet()
+        public void SaveWallet(bool force = false)
         {
+            // If this is not a forced save then check that we're not saving to wallet too often.
+            if (!force && ((DateTime.Now - this.lastWalletSave) < TimeSpan.FromMinutes(WalletSavetimeMinIntervalInMinutes)))
+                return;
+
             lock (this.lockObject)
             {
                 if (this.Wallet != null)
                 {
-                    lock (this.lockObject)
-                    {
-                        this.fileStorage.SaveToFile(this.Wallet, WalletFileName);
-                    }
+                    this.fileStorage.SaveToFile(this.Wallet, WalletFileName);
+                    this.lastWalletSave = DateTime.Now;
                 }
             }
         }


### PR DESCRIPTION
There are scenarios where the wallet saves are occurring almost back-to-back and locks the cross-chain process out during that time. This PR addresses that by ensuring at least a 1 minute gap between such save operations.