### PR TITLE
Throw error on duplicate withdrawal detected in federation wallet

### DIFF
--- a/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IFederationWalletManager.cs
@@ -97,7 +97,8 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// <summary>
         /// Saves the wallet into the file system.
         /// </summary>
-        void SaveWallet();
+        /// <param name="force">If <c>false</c> (default) the wallet is not guaranteed to be saved if saved recently.</param>
+        void SaveWallet(bool force = false);
 
         /// <summary>
         /// Gets some general information about a wallet.

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -272,6 +272,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 if (this.fileStorage.Exists(WalletFileName))
                 {
                     this.Wallet = this.fileStorage.LoadByFileName(WalletFileName);
+                    Guard.Assert(this.Wallet.MultiSigAddress.Address == this.federatedPegSettings.MultiSigAddress.ToString());
                     this.RemoveUnconfirmedTransactionData();
                 }
                 else
@@ -494,6 +495,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                         {
                             string error = string.Format("Deposit '{0}' last redeemed in transaction '{1}' (height {2}) and then redeemed again in '{3}' (height {4})!.", withdrawal.DepositId, existingWithdrawal.Id, existingWithdrawal.BlockNumber, withdrawal.Id, withdrawal.BlockNumber);
                             this.logger.LogError(error);
+                            this.nodeLifetime.StopApplication();
                             throw new Exception(error);
                         }
                     }

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -881,12 +881,12 @@ namespace Stratis.Features.FederatedPeg.Wallet
         /// <inheritdoc />
         public void SaveWallet(bool force = false)
         {
-            // If this is not a forced save then check that we're not saving to wallet too often.
-            if (!force && ((DateTime.Now - this.lastWalletSave) < TimeSpan.FromMinutes(WalletSavetimeMinIntervalInMinutes)))
-                return;
-
             lock (this.lockObject)
             {
+                // If this is not a forced save then check that we're not saving the wallet too often.
+                if (!force && ((DateTime.Now - this.lastWalletSave) < TimeSpan.FromMinutes(WalletSavetimeMinIntervalInMinutes)))
+                    return;
+
                 if (this.Wallet != null)
                 {
                     this.fileStorage.SaveToFile(this.Wallet, WalletFileName);

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -314,7 +314,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
             lock (this.lockObject)
             {
                 this.asyncLoop?.Dispose();
-                this.SaveWallet();
+                this.SaveWallet(true);
             }
         }
 

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -61,10 +61,17 @@ namespace Stratis.Features.FederatedPeg.Wallet
         /// <summary>Timer for saving wallet files to the file system.</summary>
         private const int WalletSavetimeIntervalInMinutes = 5;
 
+        /// <summary>Minimum time to wait between saving wallet if not forced.</summary>
+        private const int WalletSavetimeMinIntervalInMinutes = 1;
+
         /// <summary>Keep at least this many transactions in the wallet despite the
         /// max reorg age limit for spent transactions. This is so that it never
         /// looks like the wallet has become empty to the user.</summary>
         private const int MinimumRetainedTransactions = 100;
+
+
+        /// <summary>The last time the wallet was saved.</summary>
+        private DateTime lastWalletSave;
 
         /// <summary>The async loop we need to wait upon before we can shut down this manager.</summary>
         private IAsyncLoop asyncLoop;
@@ -170,6 +177,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
             this.isFederationActive = false;
             this.blockStore = blockStore;
             this.signals = signals;
+            this.lastWalletSave = DateTime.Now;
 
             nodeStats.RegisterStats(this.AddComponentStats, StatsType.Component, this.GetType().Name);
             nodeStats.RegisterStats(this.AddInlineStats, StatsType.Inline, this.GetType().Name, 800);
@@ -289,7 +297,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
                 // save the wallets file every 5 minutes to help against crashes.
                 this.asyncLoop = this.asyncProvider.CreateAndRunAsyncLoop("wallet persist job", token =>
                 {
-                    this.SaveWallet();
+                    this.SaveWallet(true);
                     this.logger.LogInformation("Wallets saved to file at {0}.", this.dateTimeProvider.GetUtcNow());
 
                     return Task.CompletedTask;
@@ -871,16 +879,18 @@ namespace Stratis.Features.FederatedPeg.Wallet
         }
 
         /// <inheritdoc />
-        public void SaveWallet()
+        public void SaveWallet(bool force = false)
         {
+            // If this is not a forced save then check that we're not saving to wallet too often.
+            if (!force && ((DateTime.Now - this.lastWalletSave) < TimeSpan.FromMinutes(WalletSavetimeMinIntervalInMinutes)))
+                return;
+
             lock (this.lockObject)
             {
                 if (this.Wallet != null)
                 {
-                    lock (this.lockObject)
-                    {
-                        this.fileStorage.SaveToFile(this.Wallet, WalletFileName);
-                    }
+                    this.fileStorage.SaveToFile(this.Wallet, WalletFileName);
+                    this.lastWalletSave = DateTime.Now;
                 }
             }
         }

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -487,9 +487,9 @@ namespace Stratis.Features.FederatedPeg.Wallet
                     List<(Transaction transaction, IWithdrawal withdrawal)> walletData = this.FindWithdrawalTransactions(withdrawal.DepositId);
 
                     // Already redeemed in a confirmed block?
-                    if (blockHeight != null)
+                    if (walletData.Count != 0 && blockHeight != null)
                     {
-                        (_, IWithdrawal existingWithdrawal) = walletData.LastOrDefault(d => d.withdrawal.BlockNumber != 0);
+                        (_, IWithdrawal existingWithdrawal) = walletData.LastOrDefault(d => d.withdrawal.BlockNumber != 0 && d.withdrawal.Id != withdrawal.Id);
 
                         if (existingWithdrawal != null)
                         {

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -494,13 +494,14 @@ namespace Stratis.Features.FederatedPeg.Wallet
                         if (existingWithdrawal != null)
                         {
                             string error = string.Format("Deposit '{0}' last redeemed in transaction '{1}' (height {2}) and then redeemed again in '{3}' (height {4})!.", withdrawal.DepositId, existingWithdrawal.Id, existingWithdrawal.BlockNumber, withdrawal.Id, withdrawal.BlockNumber);
-                            this.logger.LogError(error);
-                            this.nodeLifetime.StopApplication();
-                            throw new Exception(error);
-                        }
-                    }
 
-                    if ((walletData.Count == 1) && (walletData[0].withdrawal.BlockNumber != 0))
+                            // Just display an error on the console for now.
+                            this.logger.LogError(error);
+
+                            // Fall through and keep the latest withdrawal.
+                        }
+                    } 
+                    else if ((walletData.Count == 1) && (walletData[0].withdrawal.BlockNumber != 0))
                     {
                         this.logger.LogDebug("Deposit '{0}' already included in block.", withdrawal.DepositId);
                         return false;

--- a/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Wallet/FederationWalletManager.cs
@@ -508,7 +508,7 @@ namespace Stratis.Features.FederatedPeg.Wallet
 
                             // Fall through and keep the latest withdrawal.
                         }
-                    } 
+                    }
                     else if ((walletData.Count == 1) && (walletData[0].withdrawal.BlockNumber != 0))
                     {
                         this.logger.LogDebug("Deposit '{0}' already included in block.", withdrawal.DepositId);
@@ -955,7 +955,8 @@ namespace Stratis.Features.FederatedPeg.Wallet
 
                 foreach ((Transaction transaction, IWithdrawal withdrawal) in this.FindWithdrawalTransactions(depositId))
                 {
-                    walletUpdated |= this.RemoveTransaction(transaction);
+                    if (withdrawal.BlockNumber == 0)
+                        walletUpdated |= this.RemoveTransaction(transaction);
                 }
 
                 return walletUpdated;


### PR DESCRIPTION
This federation wallet's transaction processing logic is capable of detecting instances where the wallet already contains withdrawal transactions related to specific deposits. Originally designed to handle transient transactions, it does not currently throw an error when both the existing and new transactions are confirmed withdrawals for the same deposit. This pull request (PR) includes a check for this specific scenario.

It's worth noting that the previous logic would effectively ignore spends from duplicate withdrawals when detecting duplicates. This was based on the assumption that the duplicate transaction would not be a confirmed transaction. However if it is it could result in inputs not being reserved for the duplicate confirmed withdrawal transaction. PR #1124 should shore up the assumption that there would be no duplicate confirmed transactions, but I am adding this check nonetheless.