### PR TITLE
Prevent non-ascii characters being omitted from console

### DIFF
--- a/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
+++ b/src/Stratis.Bitcoin/Configuration/Logging/LoggingConfiguration.cs
@@ -172,6 +172,9 @@ namespace Stratis.Bitcoin.Configuration.Logging
                 AutoFlush = true,
             };
 
+            // Ensure non-ascii characters don't get omitted from the console output (e.g. if this defaults to 'OSEncoding').
+            consoleTarget.Encoding = Encoding.UTF8;
+
             consoleTarget.RowHighlightingRules.Add(new ConsoleRowHighlightingRule("level == LogLevel.Info", ConsoleOutputColor.Gray, ConsoleOutputColor.Black));
             consoleTarget.RowHighlightingRules.Add(new ConsoleRowHighlightingRule("level == LogLevel.Warn", ConsoleOutputColor.Gray, ConsoleOutputColor.Black));
             consoleTarget.RowHighlightingRules.Add(new ConsoleRowHighlightingRule("level == LogLevel.Error", ConsoleOutputColor.Gray, ConsoleOutputColor.Black));


### PR DESCRIPTION
From what I've experienced the encoding of the console can, for whatever reason, default to `OSEncoding`. 

![image](https://user-images.githubusercontent.com/29645989/226548681-ce80dc86-ebaa-489c-b312-d05457750446.png)

When this happens the non-ASCII character `·` does not display and leads to a distorted logo:

![image](https://user-images.githubusercontent.com/29645989/226543075-9153a326-72ae-4af9-9ed6-d276e3ba8913.png)

After applying this fix on the problematic instance we see the expected result:

![image](https://user-images.githubusercontent.com/29645989/226543408-f5055101-1945-445d-82f2-7d8fc6b97316.png)



