### PR TITLE
Remove non-existing XML comment reference

### DIFF
--- a/src/Stratis.Bitcoin.Features.SmartContracts/Rules/OpSpendRule.cs
+++ b/src/Stratis.Bitcoin.Features.SmartContracts/Rules/OpSpendRule.cs
@@ -7,9 +7,7 @@ namespace Stratis.Bitcoin.Features.SmartContracts.Rules
 {
     /// <summary>
     /// If a transaction's inputs contain an OP_SPEND opcode in the scriptsig, check that the transaction
-    /// that occurs directly before contains OP_CREATE or OP_CALL in its outputs. In conjunction with
-    /// <see cref="MempoolOpSpendRule"/>, ensures that only a contract execution transaction is able to
-    /// create OP_SPEND inputs.
+    /// that occurs directly before contains OP_CREATE or OP_CALL in its outputs.
     /// </summary>
     public class OpSpendRule : FullValidationConsensusRule
     {


### PR DESCRIPTION
Removes reference to non-existing code from XML comment.