### PR TITLE
Use deposit blocktime for conversions

### DIFF
--- a/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/CrossChainTransferStoreTests.cs
@@ -615,7 +615,7 @@ namespace Stratis.Features.FederatedPeg.Tests
             var counterChainNetwork = new CounterChainNetworkWrapper(CirrusNetwork.NetworksSelector.Testnet());
             var reader = new OpReturnDataReader(counterChainNetwork.CounterChainNetwork);
             var extractor = new DepositExtractor(Substitute.For<IConversionRequestRepository>(), this.federatedPegSettings, this.network, reader, Substitute.For<IBlockStore>());
-            IDeposit deposit = await extractor.ExtractDepositFromTransaction(transaction, 2, 1);
+            IDeposit deposit = await extractor.ExtractDepositFromTransaction(transaction, 2, 1, 0);
 
             Assert.NotNull(deposit);
             Assert.Equal(transaction.GetHash(), deposit.Id);

--- a/src/Stratis.Features.FederatedPeg.Tests/Distribution/RewardClaimerTests.cs
+++ b/src/Stratis.Features.FederatedPeg.Tests/Distribution/RewardClaimerTests.cs
@@ -99,7 +99,7 @@ namespace Stratis.Features.FederatedPeg.Tests.Distribution
                 for (int i = 11; i <= 15; i++)
                 {
                     Transaction rewardTransaction = rewardClaimer.BuildRewardTransaction(false);
-                    IDeposit deposit = await depositExtractor.ExtractDepositFromTransaction(rewardTransaction, i, this.blocks[i].Block.GetHash());
+                    IDeposit deposit = await depositExtractor.ExtractDepositFromTransaction(rewardTransaction, i, this.blocks[i].Block.GetHash(), 0);
                     Assert.NotNull(deposit);
                 }
             }
@@ -130,7 +130,7 @@ namespace Stratis.Features.FederatedPeg.Tests.Distribution
                 Assert.Equal(Money.Coins(90), rewardTransaction.TotalOut);
 
                 var depositExtractor = new DepositExtractor(this.conversionRequestRepository, this.federatedPegSettings, this.network, this.opReturnDataReader, this.blockStore);
-                IDeposit deposit = await depositExtractor.ExtractDepositFromTransaction(rewardTransaction, 30, this.blocks[30].Block.GetHash());
+                IDeposit deposit = await depositExtractor.ExtractDepositFromTransaction(rewardTransaction, 30, this.blocks[30].Block.GetHash(), 0);
                 Assert.Equal(Money.Coins(90), deposit.Amount);
             }
         }

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IDeposit.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IDeposit.cs
@@ -35,5 +35,8 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// <summary>The hash of the block where the source deposit has been persisted.</summary>
         [JsonConverter(typeof(UInt256JsonConverter))]
         uint256 BlockHash { get; }
+
+        /// <summary>Only used for InterFlux STRAX -> wSTRAX transfers, this field is not used by the <see cref="ICrossChainTransferStore"/>.</summary>
+        uint BlockTime { get; set; }
     }
 }

--- a/src/Stratis.Features.FederatedPeg/Interfaces/IDepositExtractor.cs
+++ b/src/Stratis.Features.FederatedPeg/Interfaces/IDepositExtractor.cs
@@ -27,7 +27,8 @@ namespace Stratis.Features.FederatedPeg.Interfaces
         /// <param name="transaction">The transaction to extract deposits from.</param>
         /// <param name="blockHeight">The block height of the block containing the transaction.</param>
         /// <param name="blockHash">The block hash of the block containing the transaction.</param>
+        /// <param name="blockTime">The timestamp of the block containing the transaction.</param>
         /// <returns>The extracted deposit (if any), otherwise <c>null</c>.</returns>
-        Task<IDeposit> ExtractDepositFromTransaction(Transaction transaction, int blockHeight, uint256 blockHash);
+        Task<IDeposit> ExtractDepositFromTransaction(Transaction transaction, int blockHeight, uint256 blockHash, uint blockTime);
     }
 }

--- a/src/Stratis.Features.FederatedPeg/SourceChain/Deposit.cs
+++ b/src/Stratis.Features.FederatedPeg/SourceChain/Deposit.cs
@@ -36,6 +36,8 @@ namespace Stratis.Features.FederatedPeg.SourceChain
         /// <inheritdoc />
         public uint256 BlockHash { get; set; }
 
+        public uint BlockTime { get; set; }
+
         /// <inheritdoc />
         public DepositRetrievalType RetrievalType { get; }
 


### PR DESCRIPTION
This fixes the scenario whereby a Strax deposit (intended for wSTRAX conversion) has a maturing block timestamp that is newer than the Cirrus chain tip, thereby causing the deposit to be ignored.

In order to avoid this, the blocktime of the block the deposit was made in is used instead of the block the deposit matures in. As these conversion deposits never reach the CCTS, the addition of an extra field in the `Deposit` model should not cause problems there.

In order for the `BlockTime` field to be deserialised correctly (but without modifying the `Deposit` constructor throughout the solution), it has been given a public setter.

The return value of `FindApplicableConversionRequestHeader` is additionally explicitly set to `true` or `false` depending on the outcome of the header search.