### PR TITLE
Support CrosschainLog

### DIFF
--- a/src/Stratis.Bitcoin.Features.Interop/ETHClient/TransferDetails.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/ETHClient/TransferDetails.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Stratis.Bitcoin.Features.Wallet;
 
 namespace Stratis.Bitcoin.Features.Interop.ETHClient
 {
@@ -23,6 +24,10 @@ namespace Stratis.Bitcoin.Features.Interop.ETHClient
 
         public string From { get; set; }
 
+        /// <summary>
+        /// The string is in the format "Destination Address[:Destination Chain]".
+        /// I.e. either just "0x..." OR "0x...:ETH". See <see cref="DestinationChain"/>.
+        /// </summary>
         public string To { get; set; }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Interop/ETHClient/TransferDetails.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/ETHClient/TransferDetails.cs
@@ -1,5 +1,4 @@
 ﻿using System.Numerics;
-using Stratis.Bitcoin.Features.Wallet;
 
 namespace Stratis.Bitcoin.Features.Interop.ETHClient
 {

--- a/src/Stratis.Bitcoin.Features.Interop/ETHClient/TransferDetails.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/ETHClient/TransferDetails.cs
@@ -24,10 +24,6 @@ namespace Stratis.Bitcoin.Features.Interop.ETHClient
 
         public string From { get; set; }
 
-        /// <summary>
-        /// The string is in the format "Destination Address[:Destination Chain]".
-        /// I.e. either just "0x..." OR "0x...:ETH". See <see cref="DestinationChain"/>.
-        /// </summary>
         public string To { get; set; }
 
         /// <summary>

--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -510,6 +510,7 @@ namespace Stratis.Bitcoin.Features.Interop
                         };
 
                         // If its a transfer type then check for a "CrosschainLog".
+                        // TODO: Check that we only overwrite the destination address if it is the multisig address.
                         if (conversionRequestType == ConversionRequestType.Mint)
                         {
                             CirrusLogResponse crosschainLog = receipt.Logs.FirstOrDefault(l => l.Log.Event == "CrosschainLog");

--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -654,8 +654,7 @@ namespace Stratis.Bitcoin.Features.Interop
             if (!log.Log.Data.TryGetValue("metadata", out object metadata))
                 return null;
 
-            // The string is in the format <Destination Address>[:<Destination Chain>].
-            // I.e. either just "0x..." OR "0x...:ETH". See the DestinationChain enumeration.
+            // TODO: Add validation?
             string metadataString = (string)metadata;
 
             if (!log.Log.Data.TryGetValue("amount", out object amount))

--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -654,7 +654,7 @@ namespace Stratis.Bitcoin.Features.Interop
             if (!log.Log.Data.TryGetValue("metadata", out object metadata))
                 return null;
 
-            // TODO: Add validation?
+            // TODO: Check that this string is in an acceptable format?
             string metadataString = (string)metadata;
 
             if (!log.Log.Data.TryGetValue("amount", out object amount))

--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -654,8 +654,8 @@ namespace Stratis.Bitcoin.Features.Interop
             if (!log.Log.Data.TryGetValue("metadata", out object metadata))
                 return null;
 
-            // The string is in the format <Destination Address>:<Destination Chain>.
-            // E.g. "0x...:ETH". See the DestinationChain enumeration.
+            // The string is in the format <Destination Address>[:<Destination Chain>].
+            // I.e. either just "0x..." OR "0x...:ETH". See the DestinationChain enumeration.
             string metadataString = (string)metadata;
 
             if (!log.Log.Data.TryGetValue("amount", out object amount))

--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -478,6 +478,7 @@ namespace Stratis.Bitcoin.Features.Interop
                     }
 
                     // This is a special case, and will be a mint if the transfer is being made to the federation multisig contract.
+                    // TODO: Where is this logic being enforced. Why not filter conversions on that basis within this method???
                     if (watchedErc20Contracts.Contains(receipt.To))
                     {
                         contractType = ContractType.ERC20;

--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -502,6 +502,12 @@ namespace Stratis.Bitcoin.Features.Interop
                             DestinationChain = DestinationChain.ETH,
                         };
 
+                        if (srcDetails.To.Split(':').Length >= 2)
+                        {
+                            request.DestinationAddress = srcDetails.To.Split(':')[0];
+                            request.DestinationChain = Enum.Parse<DestinationChain>(srcDetails.To.Split(':')[1]);
+                        }
+
                         // Save it.
                         lock (this.repositoryLock)
                         {
@@ -527,17 +533,6 @@ namespace Stratis.Bitcoin.Features.Interop
                         KeyValuePair<string, string> contractMapping = this.interopSettings.GetSettingsByChain(DestinationChain.ETH).WatchedErc20Contracts.First(c => c.Value == receipt.To);
                         SupportedContractAddress token = SupportedContractAddresses.ForNetwork(this.network.NetworkType).FirstOrDefault(t => t.NativeNetworkAddress.ToLowerInvariant() == contractMapping.Key.ToLowerInvariant());
                         var tokenString = token == null ? contractMapping.Key : $"{token.TokenName}-{contractMapping.Key}";
-
-                        this.logger.Info($"A transfer request from CRS to '{tokenString}' will be processed.");
-
-                        request.Processed = false;
-                        request.RequestStatus = ConversionRequestStatus.Unprocessed;
-                        request.TokenContract = contractMapping.Key;
-
-                        lock (this.repositoryLock)
-                        {
-                            this.conversionRequestRepository.Save(request);
-                        }
 
                         this.logger.Info($"A transfer request from CRS to '{tokenString}' will be processed.");
 

--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -654,7 +654,8 @@ namespace Stratis.Bitcoin.Features.Interop
             if (!log.Log.Data.TryGetValue("metadata", out object metadata))
                 return null;
 
-            // TODO: Check that this string is in an acceptable format? Maybe it should encode the destination chain as well
+            // The string is in the format <Destination Address>:<Destination Chain>.
+            // E.g. "0x...:ETH". See the DestinationChain enumeration.
             string metadataString = (string)metadata;
 
             if (!log.Log.Data.TryGetValue("amount", out object amount))

--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -478,7 +478,7 @@ namespace Stratis.Bitcoin.Features.Interop
                     }
 
                     // This is a special case, and will be a mint if the transfer is being made to the federation multisig contract.
-                    // TODO: Where is this logic being enforced. Why not filter conversions on that basis within this method???
+                    // TODO: ^ Where is this logic being enforced. Why not filter conversions on that basis within this method???
                     if (watchedErc20Contracts.Contains(receipt.To))
                     {
                         contractType = ContractType.ERC20;


### PR DESCRIPTION
Adds ability to `Interflux` to incorporate destination account and network from a `CrosschainLog`. SC usage is as follows:
```
    public void MintWithMetadataForNetwork(Address account, UInt256 amount, string metadata, string destinationAccount, string destinationNetwork)
    {
        MintWithMetadata(account, amount, metadata);

        // Perform a cross-chain transfer.
        if (TransferFrom(account, Interflux, amount))
        {
            Log(new CrosschainLog()
            {
                Address = destinationAccount,
                Network = destinationNetwork
            });
        }
    }
```