### PR TITLE
[InterFlux] Allocate conversion fees based on confirmation participation

### DIFF
--- a/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
+++ b/src/Stratis.Bitcoin.Features.Interop/InteropPoller.cs
@@ -79,6 +79,7 @@ namespace Stratis.Bitcoin.Features.Interop
         private readonly ILogger logger;
         private readonly IMaturedBlocksSyncManager maturedBlocksSyncManager;
         private readonly IReplenishmentKeyValueStore replenishmentKeyValueStore;
+        private readonly IConversionConfirmationTracker conversionConfirmationTracker;
         private readonly Network network;
         private readonly INodeLifetime nodeLifetime;
 
@@ -118,7 +119,8 @@ namespace Stratis.Bitcoin.Features.Interop
             INodeStats nodeStats,
             ICirrusContractClient cirrusClient,
             IMaturedBlocksSyncManager maturedBlocksSyncManager,
-            IReplenishmentKeyValueStore replenishmentKeyValueStore)
+            IReplenishmentKeyValueStore replenishmentKeyValueStore,
+            IConversionConfirmationTracker conversionConfirmationTracker)
         {
             this.interopSettings = interopSettings;
             this.ethClientProvider = ethClientProvider;
@@ -139,6 +141,7 @@ namespace Stratis.Bitcoin.Features.Interop
             this.keyValueRepository = keyValueRepository;
             this.maturedBlocksSyncManager = maturedBlocksSyncManager;
             this.replenishmentKeyValueStore = replenishmentKeyValueStore;
+            this.conversionConfirmationTracker = conversionConfirmationTracker;
 
             this.logger = LogManager.GetCurrentClassLogger();
             this.cirrusClient = cirrusClient;
@@ -994,7 +997,7 @@ namespace Stratis.Bitcoin.Features.Interop
 
             this.logger.Info("There are {0} unprocessed mint requests.", mintRequests.Count);
 
-            var stateMachine = new InteropPollerStateMachine(this.logger, this.externalApiPoller, this.conversionRequestCoordinationService, this.federationManager, this.federatedPegBroadcaster);
+            var stateMachine = new InteropPollerStateMachine(this.logger, this.externalApiPoller, this.conversionRequestCoordinationService, this.federationManager, this.federatedPegBroadcaster, this.conversionConfirmationTracker, this.network);
 
             foreach (ConversionRequest request in mintRequests)
             {
@@ -1278,7 +1281,7 @@ namespace Stratis.Bitcoin.Features.Interop
 
             this.logger.Info("There are {0} unprocessed burn requests.", burnRequests.Count);
 
-            var stateMachine = new InteropPollerStateMachine(this.logger, this.externalApiPoller, this.conversionRequestCoordinationService, this.federationManager, this.federatedPegBroadcaster);
+            var stateMachine = new InteropPollerStateMachine(this.logger, this.externalApiPoller, this.conversionRequestCoordinationService, this.federationManager, this.federatedPegBroadcaster, this.conversionConfirmationTracker, this.network);
 
             foreach (ConversionRequest request in burnRequests)
             {

--- a/src/Stratis.Features.FederatedPeg/Conversion/ConversionConfirmationTracker.cs
+++ b/src/Stratis.Features.FederatedPeg/Conversion/ConversionConfirmationTracker.cs
@@ -1,0 +1,66 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using NBitcoin;
+using Stratis.Bitcoin.Persistence;
+
+namespace Stratis.Features.FederatedPeg.Conversion
+{
+    public interface IConversionConfirmationTracker
+    {
+        List<PubKey> GetParticipants(string requestId);
+
+        void RecordParticipant(string requestId, PubKey participant);
+    }
+
+    public class ConversionConfirmationTracker : IConversionConfirmationTracker
+    {
+        public const string ConversionConfirmationTrackerKey = "ConversionConfirmationTrackerKey";
+
+        private readonly IKeyValueRepository keyValueRepository;
+
+        private readonly Dictionary<string, HashSet<PubKey>> confirmations;
+
+        private object lockObject = new object();
+
+        public ConversionConfirmationTracker(IKeyValueRepository keyValueRepository)
+        {
+            this.keyValueRepository = keyValueRepository;
+
+            lock (this.lockObject)
+            {
+                this.confirmations = this.keyValueRepository.LoadValueJson<Dictionary<string, HashSet<PubKey>>>(ConversionConfirmationTrackerKey);
+
+                if (this.confirmations == null)
+                {
+                    this.confirmations = new Dictionary<string, HashSet<PubKey>>();
+                    this.keyValueRepository.SaveValueJson(ConversionConfirmationTrackerKey, this.confirmations, true);
+                }
+            }
+        }
+
+        public void RecordParticipant(string requestId, PubKey participant)
+        {
+            lock (this.lockObject)
+            {
+                HashSet<PubKey> currentConfirmations = this.confirmations[requestId];
+
+                if (currentConfirmations == null)
+                {
+                    currentConfirmations = new HashSet<PubKey>();
+                }
+
+                currentConfirmations.Add(participant);
+                this.confirmations[requestId] = currentConfirmations;
+                this.keyValueRepository.SaveValueJson(ConversionConfirmationTrackerKey, this.confirmations, true);
+            }
+        }
+
+        public List<PubKey> GetParticipants(string requestId)
+        {
+            lock (this.lockObject)
+            {
+                return this.confirmations[requestId].ToList();
+            }
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Conversion/ConversionRequestRepository.cs
+++ b/src/Stratis.Features.FederatedPeg/Conversion/ConversionRequestRepository.cs
@@ -12,6 +12,9 @@ namespace Stratis.Features.FederatedPeg.Conversion
         /// <summary>Retrieves <see cref="ConversionRequest"/> with specified id.</summary>
         ConversionRequest Get(string requestId);
 
+        /// <summary>Retrieves all conversion requests.</summary>
+        List<ConversionRequest> GetAll(bool onlyUnprocessed);
+
         /// <summary>Retrieves all mint requests.</summary>
         List<ConversionRequest> GetAllMint(bool onlyUnprocessed);
 
@@ -64,6 +67,16 @@ namespace Stratis.Features.FederatedPeg.Conversion
         public ConversionRequest Get(string requestId)
         {
             return this.KeyValueStore.LoadValue<ConversionRequest>(requestId);
+        }
+
+        /// <inheritdoc />
+        public List<ConversionRequest> GetAll(bool onlyUnprocessed)
+        {
+            List<ConversionRequest> requests = this.KeyValueStore.GetAll(ConversionRequestType.Mint, onlyUnprocessed);
+
+            requests.AddRange(this.KeyValueStore.GetAll(ConversionRequestType.Burn, onlyUnprocessed));
+
+            return requests;
         }
 
         /// <inheritdoc />

--- a/src/Stratis.Features.FederatedPeg/Distribution/MultiSigMembers.cs
+++ b/src/Stratis.Features.FederatedPeg/Distribution/MultiSigMembers.cs
@@ -22,19 +22,36 @@ namespace Stratis.Features.FederatedPeg.Distribution
         /// <remarks>TODO: Refactor to make this list dynamic.</remarks>
         public static readonly List<PubKey> InteropMultisigContractPubKeysMainNet = new List<PubKey>()
         {
-            new PubKey("027e793fbf4f6d07de15b0aa8355f88759b8bdf92a9ffb8a65a87fa8ee03baeccd"),//
-            new PubKey("03e8809be396745434ee8c875089e518a3eef40e31ade81869ce9cbef63484996d"),//
-            new PubKey("02f40bd4f662ba20629a104115f0ac9ee5eab695716edfe01b240abf56e05797e2"),//
-            new PubKey("03535a285d0919a9bd71df3b274cecb46e16b78bf50d3bf8b0a3b41028cf8a842d"),//
-            new PubKey("0317abe6a28cc7af44a46de97e7c6120c1ccec78afb83efe18030f5c36e3016b32"),//
-            new PubKey("03eb5db0b1703ea7418f0ad20582bf8de0b4105887d232c7724f43f19f14862488"),//
-            new PubKey("03d8b5580b7ec709c006ef497327db27ea323bd358ca45412171c644214483b74f"),//
-            new PubKey("0323033679aa439a0388f09f2883bf1ca6f50283b41bfeb6be6ddcc4e420144c16"),//
-            new PubKey("025cb67811d0922ca77fa33f19c3e5c37961f9639a1f0a116011b9075f6796abcb"),//
-            new PubKey("028e1d9fd64b84a2ec85fac7185deb2c87cc0dd97270cf2d8adc3aa766dde975a7"),//
-            new PubKey("036437789fac0ab74cda93d98b519c28608a48ef86c3bd5e8227af606c1e025f61"),//
-            new PubKey("03f5de5176e29e1e7d518ae76c1e020b1da18b57a3713ac81b16015026e232748e"),//
+            new PubKey("027e793fbf4f6d07de15b0aa8355f88759b8bdf92a9ffb8a65a87fa8ee03baeccd"),
+            new PubKey("03e8809be396745434ee8c875089e518a3eef40e31ade81869ce9cbef63484996d"),
+            new PubKey("02f40bd4f662ba20629a104115f0ac9ee5eab695716edfe01b240abf56e05797e2"),
+            new PubKey("03535a285d0919a9bd71df3b274cecb46e16b78bf50d3bf8b0a3b41028cf8a842d"),
+            new PubKey("0317abe6a28cc7af44a46de97e7c6120c1ccec78afb83efe18030f5c36e3016b32"),
+            new PubKey("03eb5db0b1703ea7418f0ad20582bf8de0b4105887d232c7724f43f19f14862488"),
+            new PubKey("03d8b5580b7ec709c006ef497327db27ea323bd358ca45412171c644214483b74f"),
+            new PubKey("0323033679aa439a0388f09f2883bf1ca6f50283b41bfeb6be6ddcc4e420144c16"),
+            new PubKey("025cb67811d0922ca77fa33f19c3e5c37961f9639a1f0a116011b9075f6796abcb"),
+            new PubKey("028e1d9fd64b84a2ec85fac7185deb2c87cc0dd97270cf2d8adc3aa766dde975a7"),
+            new PubKey("036437789fac0ab74cda93d98b519c28608a48ef86c3bd5e8227af606c1e025f61"),
+            new PubKey("03f5de5176e29e1e7d518ae76c1e020b1da18b57a3713ac81b16015026e232748e"),
             new PubKey("03a37019d2e010b046ef9d0459e4844a015758007602ddfbdc9702534924a23695")
+        };
+
+        public static readonly Dictionary<PubKey, string> InteropMultisigAccountsMainNet = new Dictionary<PubKey, string>()
+        {
+            {new PubKey("027e793fbf4f6d07de15b0aa8355f88759b8bdf92a9ffb8a65a87fa8ee03baeccd"), ""},
+            {new PubKey("03e8809be396745434ee8c875089e518a3eef40e31ade81869ce9cbef63484996d"), ""},
+            {new PubKey("02f40bd4f662ba20629a104115f0ac9ee5eab695716edfe01b240abf56e05797e2"), ""},
+            {new PubKey("03535a285d0919a9bd71df3b274cecb46e16b78bf50d3bf8b0a3b41028cf8a842d"), ""},
+            {new PubKey("0317abe6a28cc7af44a46de97e7c6120c1ccec78afb83efe18030f5c36e3016b32"), ""},
+            {new PubKey("03eb5db0b1703ea7418f0ad20582bf8de0b4105887d232c7724f43f19f14862488"), ""},
+            {new PubKey("03d8b5580b7ec709c006ef497327db27ea323bd358ca45412171c644214483b74f"), ""},
+            {new PubKey("0323033679aa439a0388f09f2883bf1ca6f50283b41bfeb6be6ddcc4e420144c16"), ""},
+            {new PubKey("025cb67811d0922ca77fa33f19c3e5c37961f9639a1f0a116011b9075f6796abcb"), ""},
+            {new PubKey("028e1d9fd64b84a2ec85fac7185deb2c87cc0dd97270cf2d8adc3aa766dde975a7"), ""},
+            {new PubKey("036437789fac0ab74cda93d98b519c28608a48ef86c3bd5e8227af606c1e025f61"), ""},
+            {new PubKey("03f5de5176e29e1e7d518ae76c1e020b1da18b57a3713ac81b16015026e232748e"), ""},
+            {new PubKey("03a37019d2e010b046ef9d0459e4844a015758007602ddfbdc9702534924a23695"), ""}
         };
 
         /// <summary>
@@ -46,6 +63,13 @@ namespace Stratis.Features.FederatedPeg.Distribution
             new PubKey("03cfc06ef56352038e1169deb3b4fa228356e2a54255cf77c271556d2e2607c28c"), // Cirrus 1
             new PubKey("02fc828e06041ae803ab5378b5ec4e0def3d4e331977a69e1b6ef694d67f5c9c13"), // Cirrus 3
             new PubKey("02fd4f3197c40d41f9f5478d55844f522744258ca4093b5119571de1a5df1bc653"), // Cirrus 4
+        };
+
+        public static readonly Dictionary<PubKey, string> InteropMultisigAccountsTestNet = new Dictionary<PubKey, string>()
+        {
+            {new PubKey("03cfc06ef56352038e1169deb3b4fa228356e2a54255cf77c271556d2e2607c28c"), ""},
+            {new PubKey("02fc828e06041ae803ab5378b5ec4e0def3d4e331977a69e1b6ef694d67f5c9c13"), ""},
+            {new PubKey("02fd4f3197c40d41f9f5478d55844f522744258ca4093b5119571de1a5df1bc653"), ""}
         };
     }
 }

--- a/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
@@ -321,6 +321,7 @@ namespace Stratis.Features.FederatedPeg
                         // The reward distribution manager only runs on the side chain.
                         if (!isMainChain)
                         {
+                            services.AddSingleton<IConversionConfirmationTracker, ConversionConfirmationTracker>();
                             services.AddSingleton<IRewardDistributionManager, RewardDistributionManager>();
                             services.AddSingleton<ICoinbaseSplitter, PremineCoinbaseSplitter>();
                             services.AddSingleton<IBlockBufferGenerator, BlockBufferGenerator>();


### PR DESCRIPTION
Adds the additional constraint that a multisig federation node must be actively participating in the InterFlux confirmation process in order to receive a portion of the fees thereof.

This is achieved by populating a set of the node pubkeys that confirmed a given transaction at the time it is marked as processed. This tracker is available to the FederatedPeg feature without having any smart contract interface logic inside it.

When a fee is about to be distributed, a list of the request IDs of `n` (currently 5, this can be changed) previous processed InterFlux deposits is retrieved. A set of the pubkeys that participated in confirming these deposits is constructed, nodes that are not present in this set do not receive a portion of the fee.

WIP: Still needs the pubkey/account mappings to be populated