### PR TITLE
Stratis.SmartContracts.CLR prerelease version

### DIFF
--- a/src/Stratis.SmartContracts.CLR.Validation/Stratis.SmartContracts.CLR.Validation.csproj
+++ b/src/Stratis.SmartContracts.CLR.Validation/Stratis.SmartContracts.CLR.Validation.csproj
@@ -9,9 +9,12 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
-    <PackageReference Include="Stratis.SCL" Version="2.0.3-PreRelease" />
     <PackageReference Include="Stratis.SmartContracts" Version="2.0.0" />
     <PackageReference Include="Stratis.SmartContracts.Standards" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Stratis.SCL\Stratis.SCL.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Stratis.SmartContracts.CLR.Validation/Stratis.SmartContracts.CLR.Validation.csproj
+++ b/src/Stratis.SmartContracts.CLR.Validation/Stratis.SmartContracts.CLR.Validation.csproj
@@ -9,12 +9,9 @@
 
   <ItemGroup>
     <PackageReference Include="Mono.Cecil" Version="0.11.4" />
+    <PackageReference Include="Stratis.SCL" Version="2.0.3-PreRelease" />
     <PackageReference Include="Stratis.SmartContracts" Version="2.0.0" />
     <PackageReference Include="Stratis.SmartContracts.Standards" Version="2.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Stratis.SCL\Stratis.SCL.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Stratis.SmartContracts.CLR/Compilation/ReferencedAssemblyResolver.cs
+++ b/src/Stratis.SmartContracts.CLR/Compilation/ReferencedAssemblyResolver.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Stratis.SCL;
 using Stratis.SmartContracts.Standards;
 
 namespace Stratis.SmartContracts.CLR.Compilation

--- a/src/Stratis.SmartContracts.CLR/Stratis.SmartContracts.CLR.csproj
+++ b/src/Stratis.SmartContracts.CLR/Stratis.SmartContracts.CLR.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     
-    <AssemblyVersion>2.0.2.0</AssemblyVersion>
-    <FileVersion>2.0.2.0</FileVersion>
-    <Version>2.0.2.0</Version>
+    <AssemblyVersion>2.0.3.0</AssemblyVersion>
+    <FileVersion>2.0.3.0</FileVersion>
+    <Version>2.0.3-PreRelease</Version>
     <Authors>Stratis Group Ltd.</Authors>
     <Product>Stratis.SmartContracts.CLR</Product>
   </PropertyGroup>
@@ -13,12 +13,12 @@
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="1.10.0" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.2.1.6856" />
+    <PackageReference Include="Stratis.SCL" Version="2.0.3-PreRelease" />
     <PackageReference Include="Stratis.SmartContracts.Standards" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Stratis.Bitcoin.Features.PoA\Stratis.Bitcoin.Features.PoA.csproj" />
-    <ProjectReference Include="..\Stratis.SCL\Stratis.SCL.csproj" />
     <ProjectReference Include="..\Stratis.SmartContracts.Core\Stratis.SmartContracts.Core.csproj" />
   </ItemGroup>
 

--- a/src/Stratis.SmartContracts.CLR/Stratis.SmartContracts.CLR.csproj
+++ b/src/Stratis.SmartContracts.CLR/Stratis.SmartContracts.CLR.csproj
@@ -13,12 +13,12 @@
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="1.10.0" />
     <PackageReference Include="ICSharpCode.Decompiler" Version="7.2.1.6856" />
-    <PackageReference Include="Stratis.SCL" Version="2.0.3-PreRelease" />
     <PackageReference Include="Stratis.SmartContracts.Standards" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Stratis.Bitcoin.Features.PoA\Stratis.Bitcoin.Features.PoA.csproj" />
+    <ProjectReference Include="..\Stratis.SCL\Stratis.SCL.csproj" />
     <ProjectReference Include="..\Stratis.SmartContracts.Core\Stratis.SmartContracts.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Creates a pre-release version of Stratis.SmartContracts.CLR for addressing BlockCore's issues.

Note: Ideally BlockCore would be using an official pre-release branch and this would be merged to that branch.

This PR precedes creation of a NuGet pre-release package.