### PR TITLE
[Federation] Modify reward distribution algorithm

### DIFF
--- a/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
+++ b/src/Stratis.Bitcoin.Features.PoA/PoAConsensusOptions.cs
@@ -67,6 +67,14 @@ namespace Stratis.Bitcoin.Features.PoA
         public int Release1400ActivationHeight { get; set; }
 
         /// <summary>
+        /// The height at which Release 1.5.0.0 became active.
+        /// <para>
+        /// This was primarily used for activating flexible epoch reward distribution.
+        /// </para>
+        /// </summary>
+        public int Release1500ActivationHeight { get; set; }
+
+        /// <summary>
         /// The height at which inituitive mining slots become active.
         /// Legacy mining slots are determined by mining_slot = block_height % number_of_federation_members.
         /// Once the specified height is reached there should no longer be a shift in mining slots when new federation members are added/removed.

--- a/src/Stratis.Features.FederatedPeg/Conversion/ConversionRequestCoordinationVote.cs
+++ b/src/Stratis.Features.FederatedPeg/Conversion/ConversionRequestCoordinationVote.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Numerics;
+using NBitcoin;
+using Stratis.Bitcoin.Persistence;
+
+namespace Stratis.Features.FederatedPeg.Conversion
+{
+    public class ConversionRequestCoordinationVote : IBitcoinSerializable
+    {
+        public string RequestId { get { return this.requestId; } set { this.requestId = value; } }
+
+        public BigInteger TransactionId { get { return BigInteger.Parse(this.transactionId); } set { this.transactionId = value.ToString(); } }
+
+        public PubKey PubKey { get { return this.pubKey; } set { this.pubKey = value; } }
+
+        private string requestId;
+
+        // BigInteger is not IBitcoinSerializable so we store its string representation instead.
+        private string transactionId;
+
+        private PubKey pubKey;
+
+        public void ReadWrite(BitcoinStream stream)
+        {
+            stream.ReadWrite(ref this.requestId);
+            stream.ReadWrite(ref this.transactionId);
+            stream.ReadWrite(ref this.pubKey);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Conversion/ConversionRequestCoordinationVoteKeyValueStore.cs
+++ b/src/Stratis.Features.FederatedPeg/Conversion/ConversionRequestCoordinationVoteKeyValueStore.cs
@@ -1,0 +1,183 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using LevelDB;
+using NBitcoin;
+using Stratis.Bitcoin.Configuration;
+using Stratis.Bitcoin.Persistence;
+using Stratis.Bitcoin.Utilities;
+using Stratis.Bitcoin.Utilities.JsonConverters;
+
+namespace Stratis.Features.FederatedPeg.Conversion
+{
+    public interface IConversionRequestCoordinationVoteKeyValueStore : IKeyValueRepository
+    {
+        List<ConversionRequestCoordinationVote> GetAll();
+
+        List<ConversionRequestCoordinationVote> GetAll(string requestId);
+
+        List<ConversionRequestCoordinationVote> GetAll(PubKey pubKey);
+    
+        void Delete(string key);
+    }
+
+    public class ConversionRequestCoordinationVoteKeyValueStore : IConversionRequestCoordinationVoteKeyValueStore
+    {
+        /// <summary>Access to database.</summary>
+        private readonly DB leveldb;
+
+        private readonly DBreezeSerializer dBreezeSerializer;
+
+        public ConversionRequestCoordinationVoteKeyValueStore(DataFolder dataFolder, DBreezeSerializer dBreezeSerializer) : this(dataFolder.InteropRepositoryPath, dBreezeSerializer)
+        {
+        }
+
+        public ConversionRequestCoordinationVoteKeyValueStore(string folder, DBreezeSerializer dBreezeSerializer)
+        {
+            Directory.CreateDirectory(folder);
+            this.dBreezeSerializer = dBreezeSerializer;
+
+            // Open a connection to a new DB and create if not found.
+            var options = new Options { CreateIfMissing = true };
+            this.leveldb = new DB(options, folder);
+        }
+
+        public List<ConversionRequestCoordinationVote> GetAll()
+        {
+            var values = new List<ConversionRequestCoordinationVote>();
+            IEnumerator<KeyValuePair<byte[], byte[]>> enumerator = this.leveldb.GetEnumerator();
+
+            while (enumerator.MoveNext())
+            {
+                (byte[] key, byte[] value) = enumerator.Current;
+
+                if (value == null)
+                    continue;
+
+                ConversionRequestCoordinationVote deserialized = this.dBreezeSerializer.Deserialize<ConversionRequestCoordinationVote>(value);
+                values.Add(deserialized);
+            }
+
+            return values;
+        }
+
+        public List<ConversionRequestCoordinationVote> GetAll(string requestId)
+        {
+            var values = new List<ConversionRequestCoordinationVote>();
+            IEnumerator<KeyValuePair<byte[], byte[]>> enumerator = this.leveldb.GetEnumerator();
+
+            while (enumerator.MoveNext())
+            {
+                (byte[] key, byte[] value) = enumerator.Current;
+
+                if (value == null)
+                    continue;
+
+                ConversionRequestCoordinationVote deserialized = this.dBreezeSerializer.Deserialize<ConversionRequestCoordinationVote>(value);
+
+                if (deserialized.RequestId != requestId)
+                    continue;
+
+                values.Add(deserialized);
+            }
+
+            return values;
+        }
+
+        public List<ConversionRequestCoordinationVote> GetAll(PubKey pubKey)
+        {
+            var values = new List<ConversionRequestCoordinationVote>();
+            IEnumerator<KeyValuePair<byte[], byte[]>> enumerator = this.leveldb.GetEnumerator();
+
+            while (enumerator.MoveNext())
+            {
+                (byte[] key, byte[] value) = enumerator.Current;
+
+                if (value == null)
+                    continue;
+
+                ConversionRequestCoordinationVote deserialized = this.dBreezeSerializer.Deserialize<ConversionRequestCoordinationVote>(value);
+
+                if (deserialized.PubKey != pubKey)
+                    continue;
+
+                values.Add(deserialized);
+            }
+
+            return values;
+        }
+
+        public List<T> GetAllAsJson<T>()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public void SaveBytes(string key, byte[] bytes, bool overWrite = false)
+        {
+            byte[] keyBytes = Encoding.ASCII.GetBytes(key);
+
+            this.leveldb.Put(keyBytes, bytes);
+        }
+
+        public void SaveValue<T>(string key, T value, bool overWrite = false)
+        {
+            this.SaveBytes(key, this.dBreezeSerializer.Serialize(value));
+        }
+
+        public void SaveValueJson<T>(string key, T value, bool overWrite = false)
+        {
+            string json = Serializer.ToString(value);
+            byte[] jsonBytes = Encoding.ASCII.GetBytes(json);
+
+            this.SaveBytes(key, jsonBytes);
+        }
+
+        public byte[] LoadBytes(string key)
+        {
+            byte[] keyBytes = Encoding.ASCII.GetBytes(key);
+
+            byte[] row = this.leveldb.Get(keyBytes);
+
+            if (row == null)
+                return null;
+
+            return row;
+        }
+
+        public T LoadValue<T>(string key)
+        {
+            byte[] bytes = this.LoadBytes(key);
+
+            if (bytes == null)
+                return default(T);
+
+            T value = this.dBreezeSerializer.Deserialize<T>(bytes);
+            return value;
+        }
+
+        public T LoadValueJson<T>(string key)
+        {
+            byte[] bytes = this.LoadBytes(key);
+
+            if (bytes == null)
+                return default(T);
+
+            string json = Encoding.ASCII.GetString(bytes);
+
+            T value = Serializer.ToObject<T>(json);
+
+            return value;
+        }
+
+        public void Dispose()
+        {
+            this.leveldb.Dispose();
+        }
+
+        public void Delete(string key)
+        {
+            byte[] keyBytes = Encoding.ASCII.GetBytes(key);
+            this.leveldb.Delete(keyBytes);
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Conversion/ConversionRequestVoteRepository.cs
+++ b/src/Stratis.Features.FederatedPeg/Conversion/ConversionRequestVoteRepository.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using NBitcoin;
+
+namespace Stratis.Features.FederatedPeg.Conversion
+{
+    /// <summary>Provides saving and retrieving functionality for objects of <see cref="ConversionRequestCoordinationVote"/> type.</summary>
+    public interface IConversionRequestCoordinationVoteRepository
+    {
+        /// <summary>Saves <see cref="ConversionRequestCoordinationVote"/> to the repository.</summary>
+        void Save(ConversionRequestCoordinationVote vote);
+
+        /// <summary>Retrieves <see cref="ConversionRequestCoordinationVote"/> with specified id and pubkey.</summary>
+        ConversionRequestCoordinationVote Get(string requestId, PubKey pubKey);
+
+        /// <summary>Retrieves list of all <see cref="ConversionRequestCoordinationVote"/> currently saved.</summary>
+        List<ConversionRequestCoordinationVote> GetAll();
+
+        /// <summary>Retrieves list of <see cref="ConversionRequestCoordinationVote"/> for specified request id.</summary>
+        List<ConversionRequestCoordinationVote> GetAll(string requestId);
+
+        /// <summary>
+        /// Deletes a particular conversion request coordination vote.
+        /// </summary>
+        void Delete(string requestId, PubKey pubKey);
+
+        /// <summary>
+        /// Deletes all current unprocessed conversion request coordination votes.
+        /// </summary>
+        /// <returns>The amount of conversion request coordination votes that have been deleted.</returns>
+        int DeleteAll();
+    }
+
+    public class ConversionRequestCoordinationVoteRepository : IConversionRequestCoordinationVoteRepository
+    {
+        private IConversionRequestCoordinationVoteKeyValueStore KeyValueStore { get; }
+
+        private string MakeKey(string requestId, PubKey pubKey)
+        {
+            return $"{requestId}:{pubKey.ToHex()}";
+        }
+
+        public ConversionRequestCoordinationVoteRepository(IConversionRequestCoordinationVoteKeyValueStore conversionRequestKeyValueStore)
+        {
+            this.KeyValueStore = conversionRequestKeyValueStore;
+        }
+
+        /// <inheritdoc />
+        public void Save(ConversionRequestCoordinationVote vote)
+        {
+            this.KeyValueStore.SaveValue(MakeKey(vote.RequestId, vote.PubKey), vote);
+        }
+
+        /// <inheritdoc />
+        public ConversionRequestCoordinationVote Get(string requestId, PubKey pubKey)
+        {
+            return this.KeyValueStore.LoadValue<ConversionRequestCoordinationVote>(MakeKey(requestId, pubKey));
+        }
+
+        /// <inheritdoc />
+        public List<ConversionRequestCoordinationVote> GetAll()
+        {
+            return this.KeyValueStore.GetAll();
+        }
+
+        /// <inheritdoc />
+        public List<ConversionRequestCoordinationVote> GetAll(string requestId)
+        {
+            return this.KeyValueStore.GetAll(requestId);
+        }
+
+        /// <inheritdoc />
+        public int DeleteAll()
+        {
+            List<ConversionRequestCoordinationVote> result = this.KeyValueStore.GetAll();
+
+            foreach (ConversionRequestCoordinationVote vote in result)
+            {
+                this.KeyValueStore.Delete(MakeKey(vote.RequestId, vote.PubKey));
+            }
+
+            return result.Count;
+        }
+
+        /// <inheritdoc />
+        public void Delete(string requestId, PubKey pubKey)
+        {
+            this.KeyValueStore.Delete(MakeKey(requestId, pubKey));
+        }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/Distribution/IRewardDistributionManager.cs
+++ b/src/Stratis.Features.FederatedPeg/Distribution/IRewardDistributionManager.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using NBitcoin;
 using Stratis.Features.FederatedPeg.Wallet;
 
 namespace Stratis.Features.FederatedPeg.Distribution
 {
-    public interface IRewardDistributionManager
+    public interface IRewardDistributionManager : IDisposable
     {
         /// <summary>
         /// For wSTRAX and SRC20 to ERC20 transfers, the multisig needs to have a fee for submitting and confirming the transaction on the external chain, paid out to them.
@@ -17,6 +18,11 @@ namespace Stratis.Features.FederatedPeg.Distribution
         /// Finds the proportion of blocks mined by each miner.
         /// Creates a corresponding list of recipient scriptPubKeys and reward amounts.
         /// </summary>
-        List<Recipient> Distribute(int blockHeight, Money totalReward);
+        List<Recipient> Distribute(int blockHeight, Money totalReward, uint blockTime, uint256 depositId);
+
+        /// <summary>
+        /// Rotates the stored distribution transaction metadata so that the range for the next one will be updated.
+        /// </summary>
+        void SetNewMetadata();
     }
 }

--- a/src/Stratis.Features.FederatedPeg/Distribution/RewardDistributionMetadata.cs
+++ b/src/Stratis.Features.FederatedPeg/Distribution/RewardDistributionMetadata.cs
@@ -1,0 +1,11 @@
+﻿using NBitcoin;
+
+namespace Stratis.Features.FederatedPeg.Distribution
+{
+    public class RewardDistributionMetadata
+    {
+        public uint256 TransactionId { get; set; }
+
+        public ulong MainChainHeaderTimestamp { get; set; }
+    }
+}

--- a/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
+++ b/src/Stratis.Features.FederatedPeg/FederatedPegFeature.cs
@@ -75,6 +75,8 @@ namespace Stratis.Features.FederatedPeg
 
         private readonly MultiSigStateMonitor multiSigStateMonitor;
 
+        private readonly IRewardDistributionManager rewardDistributionManager;
+
         private readonly ISignals signals;
 
         public FederatedPegFeature(
@@ -93,7 +95,8 @@ namespace Stratis.Features.FederatedPeg
             IInputConsolidator inputConsolidator,
             ISignals signals,
             IFederationManager federationManager = null,
-            MultiSigStateMonitor multiSigStateMonitor = null)
+            MultiSigStateMonitor multiSigStateMonitor = null,
+            IRewardDistributionManager rewardDistributionManager = null)
         {
             this.connectionManager = connectionManager;
             this.federatedPegSettings = federatedPegSettings;
@@ -109,6 +112,7 @@ namespace Stratis.Features.FederatedPeg
             this.inputConsolidator = inputConsolidator;
             this.federationManager = federationManager;
             this.multiSigStateMonitor = multiSigStateMonitor;
+            this.rewardDistributionManager = rewardDistributionManager;
             this.signals = signals;
 
             this.logger = LogManager.GetCurrentClassLogger();
@@ -190,6 +194,9 @@ namespace Stratis.Features.FederatedPeg
             this.maturedBlocksSyncManager.Dispose();
 
             this.crossChainTransferStore.Dispose();
+
+            // Only present on the sidechain.
+            this.rewardDistributionManager?.Dispose();
         }
 
         [NoTrace]
@@ -306,6 +313,8 @@ namespace Stratis.Features.FederatedPeg
                         if (!isMainChain)
                         {
                             services.AddSingleton<IConversionRequestCoordinationService, ConversionRequestCoordinationService>();
+                            services.AddSingleton<IConversionRequestCoordinationVoteKeyValueStore, ConversionRequestCoordinationVoteKeyValueStore>();
+                            services.AddSingleton<IConversionRequestCoordinationVoteRepository, ConversionRequestCoordinationVoteRepository>();
                             services.AddSingleton<IConversionRequestFeeService, ConversionRequestFeeService>();
                             services.AddSingleton<IConversionRequestFeeKeyValueStore, ConversionRequestFeeKeyValueStore>();
                             services.AddSingleton<IReplenishmentKeyValueStore, ReplenishmentKeyValueStore>();

--- a/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
+++ b/src/Stratis.Features.FederatedPeg/TargetChain/WithdrawalTransactionBuilder.cs
@@ -89,7 +89,7 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                         // Use the distribution manager to determine the actual list of recipients.
                         this.logger.LogDebug("Generating recipient list for reward distribution.");
                         
-                        multiSigContext.Recipients = this.distributionManager.Distribute(blockHeight, recipient.WithPaymentReducedByFee(FederatedPegSettings.CrossChainTransferFee).Amount); // Reduce the overall amount by the fee first before splitting it up.
+                        multiSigContext.Recipients = this.distributionManager.Distribute(blockHeight, recipient.WithPaymentReducedByFee(FederatedPegSettings.CrossChainTransferFee).Amount, blockTime, depositId); // Reduce the overall amount by the fee first before splitting it up.
                     }
 
                     if (recipient.ScriptPubKey == this.conversionTransactionFeeDistributionScriptPubKey)
@@ -118,7 +118,12 @@ namespace Stratis.Features.FederatedPeg.TargetChain
                 // Build the transaction.
                 Transaction transaction = this.federationWalletTransactionHandler.BuildTransaction(multiSigContext);
 
-                this.logger.LogDebug("transaction = {0}", transaction.ToString(this.network, RawFormat.BlockExplorer));
+                if (transaction != null)
+                {
+                    this.logger.LogDebug("transaction = {0}", transaction.ToString(this.network, RawFormat.BlockExplorer));
+
+                    this.distributionManager.SetNewMetadata();
+                }
 
                 return transaction;
             }

--- a/src/Stratis.Sidechains.Networks/CirrusMain.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusMain.cs
@@ -187,6 +187,7 @@ namespace Stratis.Sidechains.Networks
                 ContractSerializerV2ActivationHeight = 3_386_335, // Monday 13 December 16:00:00 (Estimated)
                 Release1300ActivationHeight = 4_334_400,
                 Release1400ActivationHeight = 5_345_325, // 7 December 2022 (Estimated)
+                Release1500ActivationHeight = 6_000_000, // Placeholder
             };
 
             var buriedDeployments = new BuriedDeploymentsArray

--- a/src/Stratis.Sidechains.Networks/CirrusTest.cs
+++ b/src/Stratis.Sidechains.Networks/CirrusTest.cs
@@ -138,6 +138,7 @@ namespace Stratis.Sidechains.Networks
                 ContractSerializerV2ActivationHeight = 2_842_681,
                 Release1300ActivationHeight = 3_280_032,
                 Release1400ActivationHeight = 4_074_250,
+                Release1500ActivationHeight = 5_000_000, // Placeholder
             };
 
             var buriedDeployments = new BuriedDeploymentsArray


### PR DESCRIPTION
Consists of two parts:

a. Alter the reward distribution epoch to be the time (i.e. blocks) between two prior distributions rather than a fixed window. This removes the fixed number of slots so that rewards get apportioned to every mining participant in the epoch.

b. Introduce a bugfix/improvement for the conversion request coordination service. It was not persisting votes to disk, therefore if a sufficiently large number of multisig nodes were rebooted in a short time frame it was possible for InterFlux transaction vote information to be lost.